### PR TITLE
Implement dictation shortcut and fix foldable cover screen support

### DIFF
--- a/AIDictationAndroid/app/src/main/AndroidManifest.xml
+++ b/AIDictationAndroid/app/src/main/AndroidManifest.xml
@@ -25,7 +25,27 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
+
+        <activity
+            android:name=".ShortcutActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:launchMode="standard"
+            android:theme="@android:style/Theme.NoDisplay" />
+
+        <receiver
+            android:name=".ShortcutReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.whispermate.aidictation.action.TOGGLE_DICTATION" />
+            </intent-filter>
+        </receiver>
 
         <!-- Color Debug Activity -->
         <activity

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/MainActivity.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.whispermate.aidictation
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,15 +8,23 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.whispermate.aidictation.service.OverlayDictationAccessibilityService
 import com.whispermate.aidictation.ui.AIDictationNavHost
 import com.whispermate.aidictation.ui.theme.AIDictationTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private var shouldStartRecording by mutableStateOf(false)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        handleIntent(intent)
         enableEdgeToEdge()
         setContent {
             AIDictationTheme {
@@ -23,9 +32,23 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AIDictationNavHost()
+                    AIDictationNavHost(
+                        shouldStartRecording = shouldStartRecording,
+                        onRecordingStarted = { shouldStartRecording = false }
+                    )
                 }
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent?) {
+        if (intent?.action == OverlayDictationAccessibilityService.ACTION_START_DICTATION) {
+            shouldStartRecording = true
         }
     }
 }

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ShortcutActivity.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ShortcutActivity.kt
@@ -1,0 +1,68 @@
+package com.whispermate.aidictation
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Toast
+import com.whispermate.aidictation.service.OverlayDictationAccessibilityService
+
+/**
+ * A transparent activity that handles the shortcut intent.
+ * It immediately starts the service and finishes to return focus
+ * to the previously active app.
+ */
+class ShortcutActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        try {
+            if (isAccessibilityServiceEnabled()) {
+                val serviceIntent = Intent(this, OverlayDictationAccessibilityService::class.java)
+                serviceIntent.action = OverlayDictationAccessibilityService.ACTION_START_DICTATION
+                startService(serviceIntent)
+            } else {
+                Toast.makeText(this, "Please enable AIDictation accessibility service", Toast.LENGTH_LONG).show()
+                val intent = Intent(this, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+                startActivity(intent)
+            }
+        } finally {
+            finish()
+        }
+    }
+
+
+    override fun onPause() {
+        super.onPause()
+        finish()
+    }
+
+    private fun isAccessibilityServiceEnabled(): Boolean {
+        val enabled = Settings.Secure.getInt(
+            contentResolver,
+            Settings.Secure.ACCESSIBILITY_ENABLED,
+            0
+        ) == 1
+
+        if (!enabled) return false
+
+        val enabledServices = Settings.Secure.getString(
+            contentResolver,
+            Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+        ) ?: return false
+
+        val className = OverlayDictationAccessibilityService::class.java.name
+        val classNameWithoutPackage = className.removePrefix("${packageName}.")
+        val fullServiceId = "$packageName/$className"
+        val shortServiceId = "$packageName/.$classNameWithoutPackage"
+        val shortSimpleServiceId = "$packageName/.${OverlayDictationAccessibilityService::class.java.simpleName}"
+
+        return enabledServices.split(':').any { serviceId ->
+            serviceId.equals(fullServiceId, ignoreCase = true) ||
+                    serviceId.equals(shortServiceId, ignoreCase = true) ||
+                    serviceId.equals(shortSimpleServiceId, ignoreCase = true)
+        }
+    }
+}

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ShortcutReceiver.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ShortcutReceiver.kt
@@ -1,0 +1,17 @@
+package com.whispermate.aidictation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.whispermate.aidictation.service.OverlayDictationAccessibilityService
+
+/**
+ * A receiver that can be triggered directly via Intent to toggle dictation.
+ */
+class ShortcutReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val serviceIntent = Intent(context, OverlayDictationAccessibilityService::class.java)
+        serviceIntent.action = OverlayDictationAccessibilityService.ACTION_START_DICTATION
+        context.startService(serviceIntent)
+    }
+}

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
@@ -1185,6 +1185,11 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             return true
         }
 
+        if (currentText.isEmpty()) {
+            val rawLen = node.text?.length ?: 0
+            if (rawLen > 0) setNodeSelection(node, 0, rawLen)
+        }
+
         return pasteFallback(node, replacement, safeStart, safeEnd)
     }
 
@@ -1268,9 +1273,19 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
         if (rawText.isEmpty()) return NormalizedText("", 0)
         if (node.isShowingHintText) return NormalizedText("", rawText.length)
 
+        // if both selection endpoints are -1, the field has no cursor position,
+        // which means it's likely showing placeholder text. Apps like Telegram don't set
+        // isShowingHintText=true or hintText when displaying their placeholder.
+        if (node.textSelectionStart == -1 && node.textSelectionEnd == -1) {
+            return NormalizedText("", rawText.length)
+        }
+
         val hint = node.hintText?.toString()?.trim().orEmpty()
         if (hint.isNotEmpty()) {
-            if (rawText.equals(hint, ignoreCase = true)) {
+            val hintNfc = java.text.Normalizer.normalize(hint, java.text.Normalizer.Form.NFC)
+            val rawNfc = java.text.Normalizer.normalize(rawText.trim(), java.text.Normalizer.Form.NFC)
+
+            if (rawNfc.equals(hintNfc, ignoreCase = true)) {
                 return NormalizedText("", rawText.length)
             }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
@@ -2,13 +2,17 @@ package com.whispermate.aidictation.service
 
 import android.Manifest
 import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.PixelFormat
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.TypedValue
@@ -48,6 +52,7 @@ import kotlinx.coroutines.launch
 class OverlayDictationAccessibilityService : AccessibilityService() {
 
     companion object {
+        const val ACTION_START_DICTATION = "com.whispermate.aidictation.action.START_DICTATION"
         private const val TAG = "OverlayDictationSvc"
         private const val BUBBLE_PREFS = "overlay_bubble"
         private const val BUBBLE_X_KEY = "bubble_x"
@@ -148,7 +153,20 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
         super.onServiceConnected()
         appPreferences = AppPreferences(applicationContext, Moshi.Builder().build())
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+        
         refreshOverlayVisibility(null)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_START_DICTATION) {
+            // We add a delay to ensure that the ShortcutActivity (if any) has 
+            // finished and focus has returned to the previously active app.
+            serviceScope.launch {
+                delay(300)
+                onBubbleTapped()
+            }
+        }
+        return START_STICKY
     }
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
@@ -202,9 +220,9 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
     }
 
     private fun shouldShowBubble(source: AccessibilityNodeInfo?): Boolean {
-        if (!isInputMethodVisible()) return false
+        // We check for eligibility even if keyboard is hidden, 
+        // especially for cover screen shortcuts on foldables.
         val focusedNode = resolveFocusedEditableNode(source) ?: return false
-        focusedNode.recycle()
         return true
     }
 
@@ -215,18 +233,29 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
     }
 
     private fun resolveFocusedEditableNode(source: AccessibilityNodeInfo?): AccessibilityNodeInfo? {
-        if (source != null && source.isFocused && isEligibleEditableNode(source)) {
-            return AccessibilityNodeInfo.obtain(source)
+        if (source != null && isEligibleEditableNode(source)) {
+            return source
         }
 
         val sourceFocused = source?.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
         if (sourceFocused != null && isEligibleEditableNode(sourceFocused)) {
-            return AccessibilityNodeInfo.obtain(sourceFocused)
+            return sourceFocused
+        }
+
+        // Search across all windows. On foldables (Flip/Fold), the target app 
+        // might be in a different window type when closed/on cover screen.
+        val windows = windows
+        for (window in windows) {
+            val root = window.root ?: continue
+            val focused = root.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
+            if (focused != null && isEligibleEditableNode(focused)) {
+                return focused
+            }
         }
 
         val focused = rootInActiveWindow?.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
         if (focused != null && isEligibleEditableNode(focused)) {
-            return AccessibilityNodeInfo.obtain(focused)
+            return focused
         }
 
         return null
@@ -234,13 +263,12 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
 
     private fun isEligibleEditableNode(node: AccessibilityNodeInfo): Boolean {
         if (!node.isEditable) return false
-        if (!node.isVisibleToUser) return false
-        if (!node.isFocused) return false
+        // isVisibleToUser and isFocused can be unreliable on foldable cover screens 
+        // or when an overlay/routine is starting up.
         if (!node.isEnabled) return false
         if (node.isPassword) return false
         return true
     }
-
     private fun showBubble() {
         ensureBubbleCreated()
         val bubble = bubbleView ?: return
@@ -487,7 +515,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
         }
 
         val snapshot = captureEditableTextSnapshot(node)
-        node.recycle()
 
         val hasSelection = snapshot.selectionEnd > snapshot.selectionStart && snapshot.text.isNotBlank()
         if (hasSelection) {
@@ -754,7 +781,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
                 contextBefore = contextBefore
             )
         } finally {
-            node.recycle()
         }
     }
 
@@ -767,7 +793,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             if (end <= start) return false
             return replaceRange(node, snapshot.text, start, end, replacement)
         } finally {
-            node.recycle()
         }
     }
 
@@ -797,7 +822,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
 
             return false
         } finally {
-            node.recycle()
         }
     }
 
@@ -837,7 +861,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             Toast.makeText(this, "Focus a text field first", Toast.LENGTH_SHORT).show()
             return
         }
-        focusedNode.recycle()
 
         if (mode == RecordingMode.RewriteInstruction && pendingRewriteTarget == null) {
             activeCommandAction = null
@@ -958,7 +981,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             updateBubbleUi()
             return
         }
-        focusedNode.recycle()
 
         recordingState = RecordingState.Processing
         updateBubbleUi()
@@ -989,7 +1011,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
     private suspend fun processRecording(audioFile: java.io.File) {
         val node = resolveFocusedEditableNode(null)
         val snapshot = node?.let { captureEditableTextSnapshot(it) } ?: EditableTextSnapshot("", 0, 0)
-        node?.recycle()
 
         val contextText = snapshot.text.take(snapshot.selectionStart).takeLast(200)
         val contextRules = appPreferences.getInstructionsForApp(lastFocusedPackage)
@@ -1125,7 +1146,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
 
             return insertDictationText(transformedText)
         } finally {
-            node.recycle()
         }
     }
 
@@ -1140,7 +1160,6 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             val insertText = withLeadingSpaceIfNeeded(current, selStart, text)
             return replaceRange(node, current, selStart, selEnd, insertText)
         } finally {
-            node.recycle()
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/Navigation.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/Navigation.kt
@@ -2,6 +2,7 @@ package com.whispermate.aidictation.ui
 
 import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -28,12 +29,22 @@ sealed class Screen(val route: String) {
 
 @Composable
 fun AIDictationNavHost(
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    shouldStartRecording: Boolean = false,
+    onRecordingStarted: () -> Unit = {}
 ) {
     val onboardingViewModel: OnboardingViewModel = hiltViewModel()
     val hasCompletedOnboarding by onboardingViewModel.hasCompletedOnboarding.collectAsState()
 
     val startDestination = if (hasCompletedOnboarding) Screen.Main.route else Screen.Onboarding.route
+
+    LaunchedEffect(shouldStartRecording) {
+        if (shouldStartRecording && hasCompletedOnboarding) {
+            navController.navigate(Screen.Main.route) {
+                popUpTo(Screen.Main.route) { inclusive = true }
+            }
+        }
+    }
 
     NavHost(
         navController = navController,
@@ -61,7 +72,9 @@ fun AIDictationNavHost(
                 onNavigateToRecordingDetail = { recordingId ->
                     Log.d("Navigation", "Navigating to recording detail: $recordingId")
                     navController.navigate(Screen.RecordingDetail.createRoute(recordingId))
-                }
+                },
+                shouldStartRecording = shouldStartRecording,
+                onRecordingStarted = onRecordingStarted
             )
         }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
@@ -65,6 +65,8 @@ import kotlinx.coroutines.launch
 fun MainScreen(
     onNavigateToTranscriptionSettings: () -> Unit,
     onNavigateToRecordingDetail: (String) -> Unit,
+    shouldStartRecording: Boolean = false,
+    onRecordingStarted: () -> Unit = {},
     viewModel: MainViewModel = hiltViewModel()
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
@@ -86,6 +88,37 @@ fun MainScreen(
         error?.let {
             snackbarHostState.showSnackbar(it)
             viewModel.clearError()
+        }
+    }
+
+    // Handle external start recording trigger
+    LaunchedEffect(Unit) {
+        viewModel.startRecordingTrigger.collect {
+            if (recordingState == RecordingState.Idle) {
+                val recorder = AudioRecorder(context)
+                audioRecorder = recorder
+                val file = recorder.start()
+                if (file != null) {
+                    viewModel.startRecording()
+                } else {
+                    audioRecorder = null
+                }
+            }
+        }
+    }
+
+    // Handle initial start recording from navigation
+    LaunchedEffect(shouldStartRecording) {
+        if (shouldStartRecording && recordingState == RecordingState.Idle) {
+            val recorder = AudioRecorder(context)
+            audioRecorder = recorder
+            val file = recorder.start()
+            if (file != null) {
+                viewModel.startRecording()
+            } else {
+                audioRecorder = null
+            }
+            onRecordingStarted()
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
@@ -6,9 +6,12 @@ import com.whispermate.aidictation.data.repository.RecordingRepository
 import com.whispermate.aidictation.data.repository.TranscriptionRepository
 import com.whispermate.aidictation.domain.model.Recording
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -34,6 +37,10 @@ class MainViewModel @Inject constructor(
     private val _recordingState = MutableStateFlow(RecordingState.Idle)
     val recordingState: StateFlow<RecordingState> = _recordingState.asStateFlow()
 
+    // Trigger for starting recording from outside (e.g. shortcut)
+    private val _startRecordingTrigger = MutableSharedFlow<Unit>(replay = 0)
+    val startRecordingTrigger: SharedFlow<Unit> = _startRecordingTrigger.asSharedFlow()
+
     // Selected recording for detail view
     private val _selectedRecording = MutableStateFlow<Recording?>(null)
     val selectedRecording: StateFlow<Recording?> = _selectedRecording.asStateFlow()
@@ -44,6 +51,12 @@ class MainViewModel @Inject constructor(
 
     fun startRecording() {
         _recordingState.value = RecordingState.Recording
+    }
+
+    fun triggerStartRecording() {
+        viewModelScope.launch {
+            _startRecordingTrigger.emit(Unit)
+        }
     }
 
     fun stopRecording(audioFile: File?, durationMs: Long) {

--- a/AIDictationAndroid/app/src/main/res/values/strings.xml
+++ b/AIDictationAndroid/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="tab_settings">Settings</string>
     <string name="no_recordings">No recordings yet</string>
     <string name="record">Record</string>
+    <string name="shortcut_start_dictation">Start Dictation</string>
 
     <!-- Recording -->
     <string name="recording">Recording…</string>

--- a/AIDictationAndroid/app/src/main/res/values/themes.xml
+++ b/AIDictationAndroid/app/src/main/res/values/themes.xml
@@ -5,4 +5,15 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
     </style>
+
+    <style name="Theme.ShortcutHandler" parent="android:Theme.Translucent.NoTitleBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowNoDisplay">false</item>
+    </style>
 </resources>

--- a/AIDictationAndroid/app/src/main/res/xml/shortcuts.xml
+++ b/AIDictationAndroid/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="start_dictation"
+        android:enabled="true"
+        android:icon="@drawable/ic_mic_toolbar"
+        android:shortcutShortLabel="@string/shortcut_start_dictation"
+        android:shortcutLongLabel="@string/shortcut_start_dictation">
+        <intent
+            android:action="com.whispermate.aidictation.action.START_DICTATION"
+            android:targetPackage="com.whispermate.aidictation"
+            android:targetClass="com.whispermate.aidictation.ShortcutActivity" />
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
- Add ShortcutActivity and ShortcutReceiver to handle dictation toggle without focus loss
- Implement onStartCommand in OverlayDictationAccessibilityService for direct service triggering
- Broaden node resolution logic to support Samsung Galaxy Flip cover screens when device is closed
- Remove deprecated AccessibilityNodeInfo recycle() and obtain() calls
- Ensure shortcut trigger doesn't disrupt the active app's focus or bring the home screen