### PR TITLE
Fix Android overlay flicker on keyboard hide; default to Writingmate

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ${{ env.ANDROID_PROJECT_DIR }}
 
     env:
-      # Transcription API (OpenAI / Groq compatible)
+      # Transcription API (OpenAI / Groq / Writingmate compatible)
       TRANSCRIPTION_API_KEY: ${{ secrets.TRANSCRIPTION_API_KEY }}
       TRANSCRIPTION_ENDPOINT: ${{ secrets.TRANSCRIPTION_ENDPOINT }}
       TRANSCRIPTION_MODEL: ${{ secrets.TRANSCRIPTION_MODEL }}
@@ -37,6 +37,9 @@ jobs:
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       GROQ_ENDPOINT: ${{ secrets.GROQ_ENDPOINT }}
       GROQ_MODEL: ${{ secrets.GROQ_MODEL }}
+      # Shared macOS Secrets.plist (base64). If set, the Writingmate key is
+      # extracted from CustomTranscriptionKey so both platforms share one secret.
+      SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
       # Release signing
       KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -64,6 +67,36 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('AIDictationAndroid/**/*.gradle*', 'AIDictationAndroid/gradle/wrapper/gradle-wrapper.properties', 'AIDictationAndroid/gradle/libs.versions.toml') }}
           restore-keys: |
             gradle-${{ runner.os }}-
+
+      - name: Resolve Writingmate creds from SECRETS_PLIST
+        if: env.SECRETS_PLIST != ''
+        shell: bash
+        run: |
+          # The macOS release workflow ships a base64-encoded Secrets.plist that
+          # holds the Writingmate transcription key, endpoint, and model. Reuse
+          # it here so a single repo secret drives both platforms. Only fills
+          # fields that weren't set via dedicated Android secrets.
+          echo "$SECRETS_PLIST" | base64 -d > /tmp/secrets.plist
+          extract() {
+            python3 - "$1" <<'PY'
+          import plistlib, sys
+          with open("/tmp/secrets.plist", "rb") as f:
+              print(plistlib.load(f).get(sys.argv[1], "") or "")
+          PY
+          }
+          wm_key=$(extract CustomTranscriptionKey)
+          wm_endpoint=$(extract CustomTranscriptionEndpoint)
+          wm_model=$(extract CustomTranscriptionModel)
+          if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
+            echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_ENDPOINT" ] && [ -n "$wm_endpoint" ]; then
+            echo "TRANSCRIPTION_ENDPOINT=$wm_endpoint" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_MODEL" ] && [ -n "$wm_model" ]; then
+            echo "TRANSCRIPTION_MODEL=$wm_model" >> "$GITHUB_ENV"
+          fi
+          rm /tmp/secrets.plist
 
       - name: Write local.properties
         run: |
@@ -117,6 +150,7 @@ jobs:
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       GROQ_ENDPOINT: ${{ secrets.GROQ_ENDPOINT }}
       GROQ_MODEL: ${{ secrets.GROQ_MODEL }}
+      SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
       KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
@@ -135,6 +169,7 @@ jobs:
           echo "GROQ_API_KEY:              $(present "$GROQ_API_KEY")"
           echo "GROQ_ENDPOINT:             $(present "$GROQ_ENDPOINT")"
           echo "GROQ_MODEL:                $(present "$GROQ_MODEL")"
+          echo "SECRETS_PLIST:             $(present "$SECRETS_PLIST")"
           echo "ANDROID_KEYSTORE_BASE64:   $(present "$ANDROID_KEYSTORE_BASE64")"
           echo "ANDROID_KEYSTORE_PASSWORD: $(present "$KEYSTORE_PASSWORD")"
           echo "ANDROID_KEY_ALIAS:         $(present "$KEY_ALIAS")"
@@ -163,6 +198,32 @@ jobs:
         if: env.ANDROID_KEYSTORE_BASE64 != ''
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > release.keystore
+
+      - name: Resolve Writingmate creds from SECRETS_PLIST
+        if: env.SECRETS_PLIST != ''
+        shell: bash
+        run: |
+          echo "$SECRETS_PLIST" | base64 -d > /tmp/secrets.plist
+          extract() {
+            python3 - "$1" <<'PY'
+          import plistlib, sys
+          with open("/tmp/secrets.plist", "rb") as f:
+              print(plistlib.load(f).get(sys.argv[1], "") or "")
+          PY
+          }
+          wm_key=$(extract CustomTranscriptionKey)
+          wm_endpoint=$(extract CustomTranscriptionEndpoint)
+          wm_model=$(extract CustomTranscriptionModel)
+          if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
+            echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_ENDPOINT" ] && [ -n "$wm_endpoint" ]; then
+            echo "TRANSCRIPTION_ENDPOINT=$wm_endpoint" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_MODEL" ] && [ -n "$wm_model" ]; then
+            echo "TRANSCRIPTION_MODEL=$wm_model" >> "$GITHUB_ENV"
+          fi
+          rm /tmp/secrets.plist
 
       - name: Write local.properties
         run: |

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -70,8 +70,8 @@ jobs:
           cat > local.properties <<EOF
           sdk.dir=$ANDROID_SDK_ROOT
           TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}
-          TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://api.openai.com/v1/audio/transcriptions}
-          TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-whisper-1}
+          TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://writingmate.ai/api/openai/v1/audio/transcriptions}
+          TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-gpt-4o-transcribe}
           GROQ_API_KEY=${GROQ_API_KEY}
           GROQ_ENDPOINT=${GROQ_ENDPOINT:-https://api.groq.com/openai/v1/chat/completions}
           GROQ_MODEL=${GROQ_MODEL:-openai/gpt-oss-20b}
@@ -169,8 +169,8 @@ jobs:
           cat > local.properties <<EOF
           sdk.dir=$ANDROID_SDK_ROOT
           TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}
-          TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://api.openai.com/v1/audio/transcriptions}
-          TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-whisper-1}
+          TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://writingmate.ai/api/openai/v1/audio/transcriptions}
+          TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-gpt-4o-transcribe}
           GROQ_API_KEY=${GROQ_API_KEY}
           GROQ_ENDPOINT=${GROQ_ENDPOINT:-https://api.groq.com/openai/v1/chat/completions}
           GROQ_MODEL=${GROQ_MODEL:-openai/gpt-oss-20b}

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -14,12 +14,13 @@ runs, matching the local-developer layout described in
 
 | Secret | Purpose |
 |---|---|
-| `TRANSCRIPTION_API_KEY` | OpenAI/Groq audio transcription key |
-| `TRANSCRIPTION_ENDPOINT` | Optional override, defaults to OpenAI whisper endpoint |
-| `TRANSCRIPTION_MODEL` | Optional override, defaults to `whisper-1` |
-| `GROQ_API_KEY` | LLM key (word suggestions, cleanup) |
-| `GROQ_ENDPOINT` | Optional override, defaults to Groq chat completions |
-| `GROQ_MODEL` | Optional override, defaults to `openai/gpt-oss-20b` |
+| `TRANSCRIPTION_API_KEY` | Writingmate / OpenAI / Groq transcription key. Sent as `Authorization: Bearer …`. |
+| `TRANSCRIPTION_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/audio/transcriptions` (matches the Mac app's `.custom` provider). |
+| `TRANSCRIPTION_MODEL` | Optional override. Defaults to `gpt-4o-transcribe`. |
+| `GROQ_API_KEY` | LLM key for post-processing (word suggestions, cleanup). |
+| `GROQ_ENDPOINT` | Optional override. Defaults to Groq chat completions. |
+| `GROQ_MODEL` | Optional override. Defaults to `openai/gpt-oss-20b`. |
+| `SECRETS_PLIST` | Optional. Base64-encoded Mac `Secrets.plist` — the same secret used by `release-macos.yml`. When present and `TRANSCRIPTION_API_KEY` is empty, the workflow extracts `CustomTranscriptionKey` / `CustomTranscriptionEndpoint` / `CustomTranscriptionModel` so both platforms ship with the same Writingmate credentials. |
 
 ### Release signing (only needed for the `release` job on `main`)
 
@@ -33,7 +34,13 @@ runs, matching the local-developer layout described in
 ## Adding secrets
 
 ```
+# Either: dedicated Android secret
 gh secret set TRANSCRIPTION_API_KEY --repo writingmate/aidictation
+
+# Or: reuse the Mac Secrets.plist (base64-encoded) — the Writingmate
+# transcription key is pulled from CustomTranscriptionKey automatically.
+base64 -w0 Secrets.plist | gh secret set SECRETS_PLIST --repo writingmate/aidictation
+
 gh secret set GROQ_API_KEY         --repo writingmate/aidictation
 base64 -w0 release.keystore | gh secret set ANDROID_KEYSTORE_BASE64 --repo writingmate/aidictation
 gh secret set ANDROID_KEYSTORE_PASSWORD --repo writingmate/aidictation

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -38,12 +38,15 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        // API keys from local.properties (do not commit)
+        // API keys from local.properties (do not commit). Defaults mirror the Mac
+        // app, which ships with Writingmate AI as the default transcription provider
+        // (gpt-4o-transcribe) so a fresh install points at Writingmate unless a custom
+        // endpoint is set in local.properties.
         buildConfigField("String", "TRANSCRIPTION_API_KEY", "\"${localProperties.getProperty("TRANSCRIPTION_API_KEY", "")}\"")
-        buildConfigField("String", "TRANSCRIPTION_ENDPOINT", "\"${localProperties.getProperty("TRANSCRIPTION_ENDPOINT", "https://api.openai.com/v1/audio/transcriptions")}\"")
-        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${localProperties.getProperty("TRANSCRIPTION_MODEL", "whisper-1")}\"")
+        buildConfigField("String", "TRANSCRIPTION_ENDPOINT", "\"${localProperties.getProperty("TRANSCRIPTION_ENDPOINT", "https://writingmate.ai/api/openai/v1/audio/transcriptions")}\"")
+        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${localProperties.getProperty("TRANSCRIPTION_MODEL", "gpt-4o-transcribe")}\"")
 
-        // LLM API for word suggestions
+        // LLM API for post-processing (Mac app defaults to Groq here).
         buildConfigField("String", "GROQ_API_KEY", "\"${localProperties.getProperty("GROQ_API_KEY", "")}\"")
         buildConfigField("String", "GROQ_ENDPOINT", "\"${localProperties.getProperty("GROQ_ENDPOINT", "https://api.groq.com/openai/v1/chat/completions")}\"")
         buildConfigField("String", "GROQ_MODEL", "\"${localProperties.getProperty("GROQ_MODEL", "openai/gpt-oss-20b")}\"")

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
@@ -22,20 +22,24 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 enum class ApiProvider(val displayName: String) {
+    WRITINGMATE("Writingmate"),
     OPENAI("OpenAI"),
     GROQ("Groq");
 
     fun transcriptionEndpoint(): String = when (this) {
+        WRITINGMATE -> "https://writingmate.ai/api/openai/v1/audio/transcriptions"
         OPENAI -> "https://api.openai.com/v1/audio/transcriptions"
         GROQ -> "https://api.groq.com/openai/v1/audio/transcriptions"
     }
 
     fun llmEndpoint(): String = when (this) {
+        WRITINGMATE -> "https://writingmate.ai/api/openai/v1/chat/completions"
         OPENAI -> "https://api.openai.com/v1/chat/completions"
         GROQ -> "https://api.groq.com/openai/v1/chat/completions"
     }
 
     fun baseUrl(): String = when (this) {
+        WRITINGMATE -> "https://writingmate.ai/api/openai"
         OPENAI -> "https://api.openai.com"
         GROQ -> "https://api.groq.com/openai"
     }
@@ -65,11 +69,13 @@ class ApiConfigManager @Inject constructor(
             private set
 
         fun defaultTranscriptionModel(provider: ApiProvider): String = when (provider) {
+            ApiProvider.WRITINGMATE -> "gpt-4o-transcribe"
             ApiProvider.OPENAI -> "whisper-1"
             ApiProvider.GROQ -> "whisper-large-v3-turbo"
         }
 
         fun defaultPostProcessingModel(provider: ApiProvider): String = when (provider) {
+            ApiProvider.WRITINGMATE -> "gpt-4o-mini"
             ApiProvider.OPENAI -> "gpt-4o-mini"
             ApiProvider.GROQ -> "openai/gpt-oss-20b"
         }
@@ -232,11 +238,24 @@ class ApiConfigManager @Inject constructor(
     // MARK: - Private Methods
 
     private fun defaultTranscriptionProvider(): ApiProvider {
-        return if (BuildConfig.TRANSCRIPTION_ENDPOINT.contains("groq")) ApiProvider.GROQ else ApiProvider.OPENAI
+        val endpoint = BuildConfig.TRANSCRIPTION_ENDPOINT
+        return when {
+            endpoint.contains("writingmate", ignoreCase = true) -> ApiProvider.WRITINGMATE
+            endpoint.contains("groq", ignoreCase = true) -> ApiProvider.GROQ
+            endpoint.contains("openai", ignoreCase = true) -> ApiProvider.OPENAI
+            // Match the Mac app, which ships with Writingmate as the default.
+            else -> ApiProvider.WRITINGMATE
+        }
     }
 
     private fun defaultPostProcessingProvider(): ApiProvider {
-        return if (BuildConfig.GROQ_ENDPOINT.contains("groq")) ApiProvider.GROQ else ApiProvider.OPENAI
+        val endpoint = BuildConfig.GROQ_ENDPOINT
+        return when {
+            endpoint.contains("writingmate", ignoreCase = true) -> ApiProvider.WRITINGMATE
+            endpoint.contains("groq", ignoreCase = true) -> ApiProvider.GROQ
+            endpoint.contains("openai", ignoreCase = true) -> ApiProvider.OPENAI
+            else -> ApiProvider.GROQ
+        }
     }
 
     private fun buildDefaultTranscriptionConfig(): ApiConfig {

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/remote/ModelListClient.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/remote/ModelListClient.kt
@@ -25,11 +25,13 @@ object ModelListClient {
     // MARK: - Fallback lists
 
     private val transcriptionFallbacks = mapOf(
+        ApiProvider.WRITINGMATE to listOf("gpt-4o-transcribe", "whisper-1"),
         ApiProvider.OPENAI to listOf("whisper-1"),
         ApiProvider.GROQ to listOf("whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en")
     )
 
     private val postProcessingFallbacks = mapOf(
+        ApiProvider.WRITINGMATE to listOf("gpt-4o-mini", "gpt-4o", "gpt-4.1-nano", "gpt-4.1-mini", "gpt-4.1"),
         ApiProvider.OPENAI to listOf("gpt-4o-mini", "gpt-4o", "gpt-4.1-nano", "gpt-4.1-mini", "gpt-4.1"),
         ApiProvider.GROQ to listOf(
             "openai/gpt-oss-20b",

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
@@ -61,7 +61,10 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
         private const val MIN_RECORDING_MS = 500L
         private const val BUBBLE_SIZE_DP = 44
         private const val BUBBLE_MARGIN_DP = 8
-        private const val BUBBLE_VISIBILITY_DELAY_MS = 80L
+        // Keyboard-dismissal fires bursts of accessibility events, during which focus can
+        // briefly be unreadable. We must wait long enough for the dismissal animation to
+        // settle before committing to a hide, otherwise the bubble fades out and back in.
+        private const val BUBBLE_VISIBILITY_DELAY_MS = 300L
         private const val BUBBLE_ANIMATION_MS = 140L
         private const val COMMAND_ACTION_HORIZONTAL_MARGIN_DP = 8
         private const val COMMAND_ACTION_GAP_DP = 8
@@ -289,16 +292,12 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
         bubbleShouldBeVisible = true
         val token = ++bubbleVisibilityToken
         if (isBubbleAttached) {
-            // Smoothly fade back in if a hide animation is in flight; don't snap —
-            // snapping from a mid-fade alpha to 1f causes a visible flash (e.g. when
-            // keyboard dismissal fires bursts of accessibility events).
-            if (bubble.alpha < 0.999f) {
-                bubble.animate().cancel()
-                bubble.animate()
-                    .alpha(1f)
-                    .setDuration(BUBBLE_ANIMATION_MS)
-                    .start()
-            }
+            // A pending fade-out got cancelled (e.g. transient focus loss during keyboard
+            // dismissal). Snap back to fully visible instead of running a fade-in during
+            // the fade-out — the debounce keeps the snap imperceptible, whereas a reverse
+            // animation reads as a visible flicker.
+            bubble.animate().cancel()
+            bubble.alpha = 1f
             updateCommandActionsPosition()
             updateBubbleUi()
             return

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/ApiConfigViewModel.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/ApiConfigViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class ApiConfigUiState(
-    val transcriptionProvider: ApiProvider = ApiProvider.OPENAI,
+    val transcriptionProvider: ApiProvider = ApiProvider.WRITINGMATE,
     val transcriptionApiKey: String = "",
     val transcriptionModel: String = "",
     val transcriptionModels: List<String> = emptyList(),


### PR DESCRIPTION
Overlay flicker
- Bump BUBBLE_VISIBILITY_DELAY_MS from 80ms to 300ms. Keyboard dismissal
  fires a burst of accessibility events during which focus is briefly
  unreadable; 80ms wasn't enough for focus to re-stabilize, so the
  hide-fade would start and then get reversed.
- On a cancelled fade-out, snap the bubble to alpha 1f instead of
  running a fade-in during the fade-out. The longer debounce keeps the
  snap imperceptible; the reverse animation was the visible flicker.

Default API endpoint (match Mac app)
- Add ApiProvider.WRITINGMATE (transcription + LLM + baseUrl pointing
  at https://writingmate.ai/api/openai).
- Default transcription model: gpt-4o-transcribe. Post-processing model
  defaults to gpt-4o-mini for Writingmate; Groq-via-Writingmate stays
  Groq as the Mac app does.
- defaultTranscriptionProvider()/defaultPostProcessingProvider() now
  detect writingmate.ai hosts; unconfigured installs default to
  WRITINGMATE for transcription (post-processing still defaults to
  Groq, mirroring the Mac).
- build.gradle.kts + android-build.yml CI defaults point at the
  Writingmate transcription endpoint so fresh builds with no
  local.properties match the Mac.
- ModelListClient fallbacks + ApiConfigViewModel initial state updated
  to include WRITINGMATE.

https://claude.ai/code/session_01WxQVYvcpbTqyMLXM1XASZN