### PR TITLE
Stop bundling Groq API keys

### DIFF
--- a/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
+++ b/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
@@ -12,11 +12,9 @@ public enum SecretsLoader {
 
     public static func transcriptionKey(for provider: TranscriptionProvider) -> String? {
         switch provider {
-        case .groq:
-            return secretsDictionary?["GroqTranscriptionKey"] as? String
         case .custom:
             return secretsDictionary?["CustomTranscriptionKey"] as? String
-        case .openai:
+        case .groq, .openai:
             return nil
         }
     }
@@ -31,9 +29,7 @@ public enum SecretsLoader {
 
     public static func llmKey(for provider: LLMProvider) -> String? {
         switch provider {
-        case .groq:
-            return secretsDictionary?["GroqLLMKey"] as? String
-        case .openai, .anthropic, .custom:
+        case .groq, .openai, .anthropic, .custom:
             return nil
         }
     }

--- a/Whishpermate/Whispermate/Secrets.template.plist
+++ b/Whishpermate/Whispermate/Secrets.template.plist
@@ -2,9 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>GroqTranscriptionKey</key>
-    <string>YOUR_GROQ_TRANSCRIPTION_KEY_HERE</string>
-    <key>GroqLLMKey</key>
+    <key>CustomTranscriptionKey</key>
     <string></string>
+    <key>CustomTranscriptionEndpoint</key>
+    <string>https://writingmate.ai/api/openai/v1/audio/transcriptions</string>
+    <key>CustomTranscriptionModel</key>
+    <string>gpt-4o-transcribe</string>
+    <key>SUPABASE_URL</key>
+    <string></string>
+    <key>SUPABASE_ANON_KEY</key>
+    <string></string>
+    <key>STRIPE_PAYMENT_LINK_MONTHLY</key>
+    <string></string>
+    <key>AUTH_WEB_URL</key>
+    <string>https://voicesinmyhead.co/auth</string>
 </dict>
 </plist>

--- a/Whishpermate/Whispermate/Services/SecretsLoader.swift
+++ b/Whishpermate/Whispermate/Services/SecretsLoader.swift
@@ -14,11 +14,9 @@ enum SecretsLoader {
         switch provider {
         case .parakeet:
             return nil // On-device, no API key needed
-        case .groq:
-            return secretsDictionary?["GroqTranscriptionKey"] as? String
         case .custom:
             return secretsDictionary?["CustomTranscriptionKey"] as? String
-        case .openai:
+        case .groq, .openai:
             return nil
         }
     }
@@ -41,9 +39,7 @@ enum SecretsLoader {
 
     static func llmKey(for provider: LLMProvider) -> String? {
         switch provider {
-        case .groq:
-            return secretsDictionary?["GroqLLMKey"] as? String
-        case .lfm25, .openai, .anthropic, .custom:
+        case .groq, .lfm25, .openai, .anthropic, .custom:
             return nil
         }
     }


### PR DESCRIPTION
Groq paths were never set up for end users — command mode is being reworked, and no UI exposes Groq selection. The shipped Secrets.plist embedded live Groq keys that anyone could extract from the DMG, so strip GroqLLMKey/GroqTranscriptionKey from the plist and route the .groq cases in SecretsLoader to nil so a stale plist can't re-leak.

Refresh Secrets.template.plist to match the actual schema.