### PR TITLE
fix(android): use whisper-large-v3-turbo for Writingmate transcription

### DIFF
--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -40,11 +40,11 @@ android {
 
         // API keys from local.properties (do not commit). Defaults mirror the Mac
         // app, which ships with Writingmate AI as the default transcription provider
-        // (gpt-4o-transcribe) so a fresh install points at Writingmate unless a custom
-        // endpoint is set in local.properties.
+        // routing to groq/whisper-large-v3-turbo so a fresh install points at
+        // Writingmate unless a custom endpoint is set in local.properties.
         buildConfigField("String", "TRANSCRIPTION_API_KEY", "\"${localProperties.getProperty("TRANSCRIPTION_API_KEY", "")}\"")
         buildConfigField("String", "TRANSCRIPTION_ENDPOINT", "\"${localProperties.getProperty("TRANSCRIPTION_ENDPOINT", "https://writingmate.ai/api/openai/v1/audio/transcriptions")}\"")
-        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${localProperties.getProperty("TRANSCRIPTION_MODEL", "gpt-4o-transcribe")}\"")
+        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${localProperties.getProperty("TRANSCRIPTION_MODEL", "groq/whisper-large-v3-turbo")}\"")
 
         // LLM API for post-processing (Mac app defaults to Groq here).
         buildConfigField("String", "GROQ_API_KEY", "\"${localProperties.getProperty("GROQ_API_KEY", "")}\"")

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
@@ -69,7 +69,7 @@ class ApiConfigManager @Inject constructor(
             private set
 
         fun defaultTranscriptionModel(provider: ApiProvider): String = when (provider) {
-            ApiProvider.WRITINGMATE -> "gpt-4o-transcribe"
+            ApiProvider.WRITINGMATE -> "groq/whisper-large-v3-turbo"
             ApiProvider.OPENAI -> "whisper-1"
             ApiProvider.GROQ -> "whisper-large-v3-turbo"
         }
@@ -122,6 +122,15 @@ class ApiConfigManager @Inject constructor(
 
     init {
         instance = this
+        scope.launch {
+            // Migrate stale saved model: `gpt-4o-transcribe` is not available
+            // through the Writingmate proxy and returns a 500 from the server.
+            context.apiConfigDataStore.edit { prefs ->
+                if (prefs[Keys.TRANSCRIPTION_MODEL] == "gpt-4o-transcribe") {
+                    prefs.remove(Keys.TRANSCRIPTION_MODEL)
+                }
+            }
+        }
         scope.launch {
             context.apiConfigDataStore.data.collect { prefs ->
                 val userPickedProvider = prefs[Keys.TRANSCRIPTION_PROVIDER]

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/remote/ModelListClient.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/remote/ModelListClient.kt
@@ -25,7 +25,7 @@ object ModelListClient {
     // MARK: - Fallback lists
 
     private val transcriptionFallbacks = mapOf(
-        ApiProvider.WRITINGMATE to listOf("gpt-4o-transcribe", "whisper-1"),
+        ApiProvider.WRITINGMATE to listOf("groq/whisper-large-v3-turbo", "whisper-1"),
         ApiProvider.OPENAI to listOf("whisper-1"),
         ApiProvider.GROQ to listOf("whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en")
     )


### PR DESCRIPTION
The Writingmate proxy returns 500 for `gpt-4o-transcribe` ("model does
not exist or you do not have access"). Switch the Writingmate default to
`groq/whisper-large-v3-turbo`, matching the Mac/iOS apps, and migrate
any stale saved value so existing installs recover automatically.