### PR TITLE
Fix Android release transcription model

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -135,6 +135,17 @@ jobs:
 
       - name: Write local.properties
         run: |
+          normalize_transcription_model() {
+            case "$1" in
+              ""|*"gpt-4o-transcribe"*)
+                printf '%s\n' "groq/whisper-large-v3-turbo"
+                ;;
+              *)
+                printf '%s\n' "$1"
+                ;;
+            esac
+          }
+          TRANSCRIPTION_MODEL="$(normalize_transcription_model "${TRANSCRIPTION_MODEL:-}")"
           cat > local.properties <<EOF
           sdk.dir=$ANDROID_SDK_ROOT
           TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}
@@ -317,6 +328,17 @@ jobs:
 
       - name: Write local.properties
         run: |
+          normalize_transcription_model() {
+            case "$1" in
+              ""|*"gpt-4o-transcribe"*)
+                printf '%s\n' "groq/whisper-large-v3-turbo"
+                ;;
+              *)
+                printf '%s\n' "$1"
+                ;;
+            esac
+          }
+          TRANSCRIPTION_MODEL="$(normalize_transcription_model "${TRANSCRIPTION_MODEL:-}")"
           cat > local.properties <<EOF
           sdk.dir=$ANDROID_SDK_ROOT
           TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -18,7 +18,7 @@ runs, matching the local-developer layout described in
 |---|---|
 | `TRANSCRIPTION_API_KEY` | Writingmate transcription key. Sent as `Authorization: Bearer …`. |
 | `TRANSCRIPTION_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/audio/transcriptions` (matches the Mac app's `.custom` provider). |
-| `TRANSCRIPTION_MODEL` | Optional override. Defaults to `groq/whisper-large-v3-turbo`. |
+| `TRANSCRIPTION_MODEL` | Optional override. Defaults to `groq/whisper-large-v3-turbo`. The workflow normalizes stale `gpt-4o-transcribe` values from secrets to this Android-supported model. |
 | `AIDICTATION_POST_PROCESSING_KEY` | Writingmate post-processing key for suggestions, commands, and cleanup. |
 | `AIDICTATION_POST_PROCESSING_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/chat/completions`. |
 | `AIDICTATION_POST_PROCESSING_MODEL` | Optional override. Defaults to `openai/gpt-oss-20b`. |

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "com.whispermate.aidictation"
         minSdk = 26
         targetSdk = 35
-        versionCode = 4
-        versionName = "0.0.4"
+        versionCode = 5
+        versionName = "0.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/AIDictationAndroid/app/src/main/res/values/strings.xml
+++ b/AIDictationAndroid/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">AIDictation</string>
 
     <!-- Onboarding -->
-    <string name="onboarding_welcome_title">Welcome to AI Dictation</string>
+    <string name="onboarding_welcome_title">Welcome to AIDictation</string>
     <string name="onboarding_welcome_subtitle">Your voice, instantly transcribed</string>
     <string name="onboarding_feature_1">Speak naturally</string>
     <string name="onboarding_feature_2">Fast transcription</string>
@@ -14,7 +14,7 @@
     <string name="onboarding_mic_enable">Enable Microphone</string>
     <string name="onboarding_overlay_title">Enable Overlay Dictation</string>
     <string name="onboarding_overlay_subtitle">Enable Accessibility to show a mic bubble only when text input is focused</string>
-    <string name="onboarding_overlay_step1">Enable WhisperMate in Accessibility settings</string>
+    <string name="onboarding_overlay_step1">Enable AIDictation in Accessibility settings</string>
     <string name="onboarding_overlay_step2">Focus any text field and tap the bubble to dictate</string>
     <string name="onboarding_overlay_step3">Use the test field below to confirm dictation works</string>
     <string name="onboarding_overlay_hint">The overlay stays hidden in password and secure fields.</string>


### PR DESCRIPTION
## Summary
- normalize stale Android release model values containing gpt-4o-transcribe to groq/whisper-large-v3-turbo
- bump Android to 0.0.5 / versionCode 5 for a clean replacement release cut
- carry the visible AIDictation onboarding label cleanup

## Root cause
The Gradle default was correct, but the GitHub Actions release job copied CustomTranscriptionModel from shared SECRETS_PLIST or a stale TRANSCRIPTION_MODEL secret into local.properties, overriding the safe Android model during the signed release build.

## Verification
- Ruby YAML parse for .github/workflows/android-build.yml
- shell normalization check for gpt-4o-transcribe, openai/gpt-4o-transcribe, and groq/whisper-large-v3-turbo
- JAVA_HOME=/usr/local/opt/openjdk ./gradlew testDebugUnitTest assembleRelease bundleRelease