### PR TITLE
Enable offline Android Parakeet APK releases

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -39,6 +39,8 @@ permissions:
 env:
   JAVA_VERSION: '17'
   ANDROID_PROJECT_DIR: AIDictationAndroid
+  PARAKEET_ASSETS_RELEASE_TAG: android-parakeet-assets-v3
+  PARAKEET_ASSETS_ARCHIVE: AIDictation-Parakeet-Assets-v3.zip
 
 jobs:
   build:
@@ -210,7 +212,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
+
+      - name: Download Parakeet model assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          archive_dir=/tmp/parakeet-assets
+          rm -rf "$archive_dir" parakeetpack/src/main/assets
+          mkdir -p "$archive_dir" parakeetpack/src/main/assets
+          gh release download "$PARAKEET_ASSETS_RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$PARAKEET_ASSETS_ARCHIVE" \
+            --dir "$archive_dir"
+          unzip -q "$archive_dir/$PARAKEET_ASSETS_ARCHIVE" -d parakeetpack/src/main/assets
+          test -s parakeetpack/src/main/assets/encoder-model.int8.onnx
+          test -s parakeetpack/src/main/assets/decoder_joint-model.int8.onnx
+          test -s parakeetpack/src/main/assets/nemo128.onnx
+          test -s parakeetpack/src/main/assets/vocab.txt
+          test -s parakeetpack/src/main/assets/config.json
 
       - name: Resolve release metadata
         id: release_meta
@@ -356,14 +376,15 @@ jobs:
         run: chmod +x gradlew
 
       - name: Assemble release APK
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew assembleRelease -PPARAKEET_RUNTIME=onnx -PPACKAGE_OFFLINE_MODELS=true --stacktrace
 
       - name: Bundle release AAB
-        run: ./gradlew bundleRelease --stacktrace
+        run: ./gradlew bundleRelease -PPARAKEET_RUNTIME=onnx --stacktrace
 
       - name: Collect release assets
         run: |
           tag="${{ steps.release_meta.outputs.tag }}"
+          artifact_version="${tag#android-v}"
           mkdir -p release-artifacts
           apk_path=$(find app/build/outputs/apk/release -maxdepth 1 -name '*.apk' | head -n 1)
           aab_path=$(find app/build/outputs/bundle/release -maxdepth 1 -name '*.aab' | head -n 1)
@@ -371,8 +392,9 @@ jobs:
             echo "Release APK or AAB was not produced" >&2
             exit 1
           fi
-          cp "$apk_path" "release-artifacts/AIDictation-Android-${tag}.apk"
-          cp "$aab_path" "release-artifacts/AIDictation-Android-${tag}.aab"
+          cp "$apk_path" "release-artifacts/AIDictation-Android-${artifact_version}.apk"
+          cp "$aab_path" "release-artifacts/AIDictation-Android-${artifact_version}.aab"
+          (cd release-artifacts && shasum -a 256 * > SHA256SUMS.txt)
           ls -lh release-artifacts
 
       - name: Upload release APK

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -394,7 +394,12 @@ jobs:
           fi
           cp "$apk_path" "release-artifacts/AIDictation-Android-${artifact_version}.apk"
           cp "$aab_path" "release-artifacts/AIDictation-Android-${artifact_version}.aab"
-          (cd release-artifacts && shasum -a 256 * > SHA256SUMS.txt)
+          (
+            cd release-artifacts
+            shasum -a 256 *.apk > "AIDictation-Android-${artifact_version}.apk.sha256"
+            shasum -a 256 *.aab > "AIDictation-Android-${artifact_version}.aab.sha256"
+            shasum -a 256 *.apk *.aab > SHA256SUMS.txt
+          )
           ls -lh release-artifacts
 
       - name: Upload release APK

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -216,8 +216,8 @@ jobs:
         id: release_meta
         shell: bash
         run: |
-          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
-          version_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p' app/build.gradle.kts | head -n 1)
+          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p; s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          version_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p; s/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*configValue\("VERSION_CODE", "([0-9]+)".*/\1/p' app/build.gradle.kts | head -n 1)
           if [ -z "$version_name" ] || [ -z "$version_code" ]; then
             echo "Could not read Android versionName/versionCode from app/build.gradle.kts" >&2
             exit 1

--- a/.github/workflows/android-play-dev.yml
+++ b/.github/workflows/android-play-dev.yml
@@ -1,0 +1,226 @@
+name: Android Play Dev Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Google Play track for the dev release.'
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+      parakeet_runtime:
+        description: 'Local transcription runtime baked into BuildConfig.'
+        required: true
+        default: onnx
+        type: choice
+        options:
+          - onnx
+          - cloud
+      release_name:
+        description: 'Optional Play release name override.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-play-dev-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '17'
+  ANDROID_PROJECT_DIR: AIDictationAndroid
+
+jobs:
+  publish:
+    name: Publish signed AAB to Play
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.ANDROID_PROJECT_DIR }}
+
+    env:
+      PLAY_TRACK: ${{ github.event.inputs.track || 'internal' }}
+      PLAY_RELEASE_NAME: ${{ github.event.inputs.release_name || '' }}
+      PARAKEET_RUNTIME: ${{ github.event.inputs.parakeet_runtime || 'onnx' }}
+
+      # Google Play API credentials. Prefer the base64 secret for copy/paste
+      # safety; raw ANDROID_PUBLISHER_CREDENTIALS is also supported.
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+      ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.ANDROID_PUBLISHER_CREDENTIALS }}
+
+      # Writingmate transcription API
+      TRANSCRIPTION_API_KEY: ${{ secrets.TRANSCRIPTION_API_KEY }}
+      TRANSCRIPTION_ENDPOINT: ${{ secrets.TRANSCRIPTION_ENDPOINT }}
+      TRANSCRIPTION_MODEL: ${{ secrets.TRANSCRIPTION_MODEL }}
+
+      # Writingmate LLM API
+      AIDICTATION_POST_PROCESSING_KEY: ${{ secrets.AIDICTATION_POST_PROCESSING_KEY }}
+      AIDICTATION_POST_PROCESSING_ENDPOINT: ${{ secrets.AIDICTATION_POST_PROCESSING_ENDPOINT }}
+      AIDICTATION_POST_PROCESSING_MODEL: ${{ secrets.AIDICTATION_POST_PROCESSING_MODEL }}
+      SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
+
+      # Release signing
+      KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('AIDictationAndroid/**/*.gradle*', 'AIDictationAndroid/gradle/wrapper/gradle-wrapper.properties', 'AIDictationAndroid/gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Decode release keystore
+        run: |
+          if [ -z "${ANDROID_KEYSTORE_BASE64}" ]; then
+            echo "ANDROID_KEYSTORE_BASE64 is required to publish to Play." >&2
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > release.keystore
+
+      - name: Decode Google Play credentials
+        run: |
+          credentials_path="$RUNNER_TEMP/google-play-service-account.json"
+          if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64}" ]; then
+            echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64 -d > "$credentials_path"
+          elif [ -n "${ANDROID_PUBLISHER_CREDENTIALS}" ]; then
+            printf '%s' "$ANDROID_PUBLISHER_CREDENTIALS" > "$credentials_path"
+          else
+            echo "Set GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 or ANDROID_PUBLISHER_CREDENTIALS." >&2
+            exit 1
+          fi
+          python3 -m json.tool "$credentials_path" >/dev/null
+          echo "PLAY_SERVICE_ACCOUNT_CREDENTIALS=$credentials_path" >> "$GITHUB_ENV"
+
+      - name: Resolve Writingmate creds from SECRETS_PLIST
+        if: env.SECRETS_PLIST != ''
+        shell: bash
+        run: |
+          echo "$SECRETS_PLIST" | base64 -d > /tmp/secrets.plist
+          extract() {
+            python3 - "$1" <<'PY'
+          import plistlib, sys
+          with open("/tmp/secrets.plist", "rb") as f:
+              print(plistlib.load(f).get(sys.argv[1], "") or "")
+          PY
+          }
+          wm_key=$(extract CustomTranscriptionKey)
+          wm_endpoint=$(extract CustomTranscriptionEndpoint)
+          wm_model=$(extract CustomTranscriptionModel)
+          pp_key=$(extract AIDictationPostProcessingKey)
+          pp_endpoint=$(extract AIDictationPostProcessingEndpoint)
+          pp_model=$(extract AIDictationPostProcessingModel)
+          if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
+            echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_ENDPOINT" ] && [ -n "$wm_endpoint" ]; then
+            echo "TRANSCRIPTION_ENDPOINT=$wm_endpoint" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$TRANSCRIPTION_MODEL" ] && [ -n "$wm_model" ]; then
+            echo "TRANSCRIPTION_MODEL=$wm_model" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AIDICTATION_POST_PROCESSING_KEY" ] && [ -n "$pp_key" ]; then
+            echo "AIDICTATION_POST_PROCESSING_KEY=$pp_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AIDICTATION_POST_PROCESSING_ENDPOINT" ] && [ -n "$pp_endpoint" ]; then
+            echo "AIDICTATION_POST_PROCESSING_ENDPOINT=$pp_endpoint" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AIDICTATION_POST_PROCESSING_MODEL" ] && [ -n "$pp_model" ]; then
+            echo "AIDICTATION_POST_PROCESSING_MODEL=$pp_model" >> "$GITHUB_ENV"
+          fi
+          rm /tmp/secrets.plist
+
+      - name: Resolve dev version
+        run: |
+          base_version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          if [ -z "$base_version_name" ]; then
+            base_version_name="0.0.5"
+          fi
+          echo "VERSION_CODE=$((1000 + GITHUB_RUN_NUMBER))" >> "$GITHUB_ENV"
+          echo "VERSION_NAME=${base_version_name}-dev.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Write local.properties
+        run: |
+          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
+            PARAKEET_RUNTIME=""
+          fi
+          normalize_transcription_model() {
+            case "$1" in
+              ""|*"gpt-4o-transcribe"*)
+                printf '%s\n' "groq/whisper-large-v3-turbo"
+                ;;
+              *)
+                printf '%s\n' "$1"
+                ;;
+            esac
+          }
+          TRANSCRIPTION_MODEL="$(normalize_transcription_model "${TRANSCRIPTION_MODEL:-}")"
+          cat > local.properties <<EOF
+          sdk.dir=$ANDROID_SDK_ROOT
+          VERSION_CODE=${VERSION_CODE}
+          VERSION_NAME=${VERSION_NAME}
+          TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}
+          TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://writingmate.ai/api/openai/v1/audio/transcriptions}
+          TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-groq/whisper-large-v3-turbo}
+          PARAKEET_RUNTIME=${PARAKEET_RUNTIME}
+          AIDICTATION_POST_PROCESSING_KEY=${AIDICTATION_POST_PROCESSING_KEY}
+          AIDICTATION_POST_PROCESSING_ENDPOINT=${AIDICTATION_POST_PROCESSING_ENDPOINT:-https://writingmate.ai/api/openai/v1/chat/completions}
+          AIDICTATION_POST_PROCESSING_MODEL=${AIDICTATION_POST_PROCESSING_MODEL:-openai/gpt-oss-20b}
+          KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
+          KEY_ALIAS=${KEY_ALIAS:-release}
+          KEY_PASSWORD=${KEY_PASSWORD}
+          EOF
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Validate release bundle
+        run: |
+          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
+            PARAKEET_RUNTIME=""
+          fi
+          ./gradlew :app:bundleRelease -PPARAKEET_RUNTIME="${PARAKEET_RUNTIME}" --stacktrace
+
+      - name: Publish to Google Play
+        run: |
+          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
+            PARAKEET_RUNTIME=""
+          fi
+          args=(
+            :app:publishReleaseBundle
+            -PPLAY_TRACK="${PLAY_TRACK}"
+            -PPLAY_SERVICE_ACCOUNT_CREDENTIALS="${PLAY_SERVICE_ACCOUNT_CREDENTIALS}"
+            -PPARAKEET_RUNTIME="${PARAKEET_RUNTIME}"
+            --stacktrace
+          )
+          if [ -n "${PLAY_RELEASE_NAME}" ]; then
+            args+=(-PPLAY_RELEASE_NAME="${PLAY_RELEASE_NAME}")
+          fi
+          ./gradlew "${args[@]}"

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -6,6 +6,13 @@ Android source tree. A push to `main`, an `android-v*` tag, or a manual
 workflow dispatch also runs the signed release job and publishes APK/AAB
 assets to a GitHub Release named `android-v<versionName>`.
 
+`.github/workflows/android-play-dev.yml` is a manual dev-release workflow
+that publishes the signed release AAB to a Google Play testing track
+(`internal` by default). It is intended for Play Store tester installs,
+including the on-demand `parakeet_v3_pack` asset pack. The workflow assigns
+dev builds `versionCode = 1000 + GITHUB_RUN_NUMBER` so repeated internal
+uploads do not collide with the checked-in production version.
+
 ## Required repository secrets
 
 These are written into `local.properties` on the runner before Gradle
@@ -19,6 +26,8 @@ runs, matching the local-developer layout described in
 | `TRANSCRIPTION_API_KEY` | Writingmate transcription key. Sent as `Authorization: Bearer …`. |
 | `TRANSCRIPTION_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/audio/transcriptions` (matches the Mac app's `.custom` provider). |
 | `TRANSCRIPTION_MODEL` | Optional override. Defaults to `groq/whisper-large-v3-turbo`. The workflow normalizes stale `gpt-4o-transcribe` values from secrets to this Android-supported model. |
+| `PARAKEET_RUNTIME` | Local prototype runtime. Leave empty for cloud releases; use `litert` only for builds that include converted Parakeet `.tflite` files in `parakeetpack`. |
+| `PACKAGE_OFFLINE_MODELS` | Optional sideload APK mode. Set to `true` with `PARAKEET_RUNTIME=onnx` to embed Parakeet weights directly in the APK. Play releases should leave this `false` and use the on-demand asset pack. |
 | `AIDICTATION_POST_PROCESSING_KEY` | Writingmate post-processing key for suggestions, commands, and cleanup. |
 | `AIDICTATION_POST_PROCESSING_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/chat/completions`. |
 | `AIDICTATION_POST_PROCESSING_MODEL` | Optional override. Defaults to `openai/gpt-oss-20b`. |
@@ -32,6 +41,18 @@ runs, matching the local-developer layout described in
 | `ANDROID_KEYSTORE_PASSWORD` | Maps to `KEYSTORE_PASSWORD` in `local.properties` |
 | `ANDROID_KEY_ALIAS` | Maps to `KEY_ALIAS` in `local.properties` (default `release`) |
 | `ANDROID_KEY_PASSWORD` | Maps to `KEY_PASSWORD` in `local.properties` |
+
+### Google Play dev releases
+
+| Secret | Purpose |
+|---|---|
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64` | Preferred. Base64-encoded Google Play service account JSON. |
+| `ANDROID_PUBLISHER_CREDENTIALS` | Optional fallback. Raw Google Play service account JSON used by Gradle Play Publisher. |
+
+Before the workflow can publish, create the app once in Play Console and
+upload the first signed AAB manually if the package has never been uploaded.
+Then enable the Android Publisher API, link the Play Console account to the
+Google Cloud project, and grant the service account release access to this app.
 
 ## Adding secrets
 
@@ -48,4 +69,6 @@ base64 -w0 release.keystore | gh secret set ANDROID_KEYSTORE_BASE64 --repo writi
 gh secret set ANDROID_KEYSTORE_PASSWORD --repo writingmate/aidictation
 gh secret set ANDROID_KEY_ALIAS         --repo writingmate/aidictation
 gh secret set ANDROID_KEY_PASSWORD      --repo writingmate/aidictation
+
+base64 -w0 google-play-service-account.json | gh secret set GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 --repo writingmate/aidictation
 ```

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -6,6 +6,13 @@ Android source tree. A push to `main`, an `android-v*` tag, or a manual
 workflow dispatch also runs the signed release job and publishes APK/AAB
 assets to a GitHub Release named `android-v<versionName>`.
 
+The GitHub release job does not rely on Git LFS bandwidth for Parakeet
+weights. It checks out source with LFS disabled, downloads
+`AIDictation-Parakeet-Assets-v3.zip` from the
+`android-parakeet-assets-v3` GitHub Release, builds the sideload APK with
+`PACKAGE_OFFLINE_MODELS=true`, and builds the Play AAB with the
+`parakeet_v3_pack` asset pack.
+
 `.github/workflows/android-play-dev.yml` is a manual dev-release workflow
 that publishes the signed release AAB to a Google Play testing track
 (`internal` by default). It is intended for Play Store tester installs,

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.gradle.play.publisher)
 }
 
 // Load local.properties
@@ -15,6 +16,14 @@ val localProperties = Properties().apply {
         load(localPropertiesFile.inputStream())
     }
 }
+
+fun configValue(name: String, defaultValue: String = ""): String {
+    return providers.gradleProperty(name).orNull
+        ?: providers.environmentVariable(name).orNull
+        ?: localProperties.getProperty(name, defaultValue)
+}
+
+val packageOfflineModels = configValue("PACKAGE_OFFLINE_MODELS", "false").toBooleanStrictOrNull() ?: false
 
 android {
     namespace = "com.whispermate.aidictation"
@@ -33,8 +42,8 @@ android {
         applicationId = "com.whispermate.aidictation"
         minSdk = 26
         targetSdk = 35
-        versionCode = 5
-        versionName = "0.0.5"
+        versionCode = configValue("VERSION_CODE", "5").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.5")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -42,9 +51,11 @@ android {
         // app, which ships with Writingmate AI as the default transcription provider
         // routing Groq Whisper through the Writingmate proxy unless a custom
         // endpoint is set in local.properties.
-        buildConfigField("String", "TRANSCRIPTION_API_KEY", "\"${localProperties.getProperty("TRANSCRIPTION_API_KEY", "")}\"")
-        buildConfigField("String", "TRANSCRIPTION_ENDPOINT", "\"${localProperties.getProperty("TRANSCRIPTION_ENDPOINT", "https://writingmate.ai/api/openai/v1/audio/transcriptions")}\"")
-        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${localProperties.getProperty("TRANSCRIPTION_MODEL", "groq/whisper-large-v3-turbo")}\"")
+        buildConfigField("String", "TRANSCRIPTION_API_KEY", "\"${configValue("TRANSCRIPTION_API_KEY", "")}\"")
+        buildConfigField("String", "TRANSCRIPTION_ENDPOINT", "\"${configValue("TRANSCRIPTION_ENDPOINT", "https://writingmate.ai/api/openai/v1/audio/transcriptions")}\"")
+        buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${configValue("TRANSCRIPTION_MODEL", "groq/whisper-large-v3-turbo")}\"")
+        buildConfigField("String", "PARAKEET_RUNTIME", "\"${configValue("PARAKEET_RUNTIME", "")}\"")
+        buildConfigField("boolean", "PACKAGE_OFFLINE_MODELS", packageOfflineModels.toString())
 
         // Writingmate post-processing, matching the macOS app's
         // AIDictationPostProcessing* secrets.
@@ -86,8 +97,31 @@ android {
         buildConfig = true
     }
 
-    // Play-delivered on-device model pack for Parakeet.
-    assetPacks.add(":parakeetpack")
+    androidResources {
+        noCompress += listOf("onnx", "tflite", "txt", "json")
+    }
+
+    if (packageOfflineModels) {
+        sourceSets.getByName("main").assets.srcDir(rootProject.file("parakeetpack/src/main/assets"))
+    } else {
+        // Play-delivered on-device model pack for Parakeet.
+        assetPacks.add(":parakeetpack")
+    }
+}
+
+play {
+    val credentialsPath = configValue("PLAY_SERVICE_ACCOUNT_CREDENTIALS", "")
+    val releaseNameOverride = configValue("PLAY_RELEASE_NAME", "")
+    if (credentialsPath.isNotBlank()) {
+        serviceAccountCredentials.set(file(credentialsPath))
+    }
+    track.set(configValue("PLAY_TRACK", "internal"))
+    defaultToAppBundles.set(true)
+    releaseName.set(
+        releaseNameOverride.ifBlank {
+            "AIDictation Android ${android.defaultConfig.versionName} (${android.defaultConfig.versionCode})"
+        }
+    )
 }
 
 dependencies {
@@ -137,6 +171,7 @@ dependencies {
     // ONNX Runtime for Silero VAD
     implementation(libs.onnx.runtime)
     implementation(libs.play.asset.delivery)
+    implementation(libs.litert)
 
     // Debug
     debugImplementation(libs.androidx.ui.tooling)

--- a/AIDictationAndroid/app/proguard-rules.pro
+++ b/AIDictationAndroid/app/proguard-rules.pro
@@ -22,6 +22,10 @@
 -keep class ai.onnxruntime.** { *; }
 -keepclassmembers class ai.onnxruntime.** { *; }
 
+# LiteRT JNI looks up exception/status classes by their original names.
+-keep class com.google.ai.edge.litert.** { *; }
+-keepclassmembers class com.google.ai.edge.litert.** { *; }
+
 # Tink (via androidx.security.crypto) references errorprone annotations at
 # compile time; they're not shipped at runtime, so tell R8 to ignore them.
 -dontwarn com.google.errorprone.annotations.**

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/AIDictationApp.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/AIDictationApp.kt
@@ -1,11 +1,38 @@
 package com.whispermate.aidictation
 
 import android.app.Application
+import android.util.Log
+import com.whispermate.aidictation.data.local.ParakeetModelAssets
 import com.whispermate.aidictation.data.preferences.ApiConfigManager
 import dagger.hilt.android.HiltAndroidApp
+import java.io.File
 import javax.inject.Inject
 
 @HiltAndroidApp
 class AIDictationApp : Application() {
     @Inject lateinit var apiConfigManager: ApiConfigManager
+
+    override fun onCreate() {
+        super.onCreate()
+        removeStaleInternalParakeetCache()
+    }
+
+    private fun removeStaleInternalParakeetCache() {
+        val externalDir = File(getExternalFilesDir(null) ?: return, "parakeet")
+        val hasExternalModel = listOf(
+            ParakeetModelAssets.REQUIRED_ONNX_FILES,
+            ParakeetModelAssets.REQUIRED_LITERT_FILES
+        ).any { requiredFiles ->
+            requiredFiles.all { name ->
+                File(externalDir, name).let { it.isFile && it.length() > 0L }
+            }
+        }
+        if (!hasExternalModel) return
+
+        val internalDir = File(filesDir, "parakeet")
+        if (!internalDir.exists()) return
+
+        Log.d("AIDictationApp", "Removing stale internal Parakeet cache at ${internalDir.absolutePath}")
+        internalDir.deleteRecursively()
+    }
 }

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetLiteRtModel.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetLiteRtModel.kt
@@ -1,0 +1,221 @@
+package com.whispermate.aidictation.data.local
+
+import android.util.Log
+import com.google.ai.edge.litert.Accelerator
+import com.google.ai.edge.litert.CompiledModel
+import com.google.ai.edge.litert.Environment
+import com.google.ai.edge.litert.TensorBuffer
+import java.io.File
+
+internal class ParakeetLiteRtModel private constructor(
+    private val environment: Environment,
+    private val decoder: CompiledModel,
+    private val joint: CompiledModel,
+    directory: File
+) : AutoCloseable {
+    private val vocab = loadVocabulary(File(directory, "vocab.txt"))
+    private val blankIndex = vocab.indexOf(BLANK_TOKEN).takeIf { it >= 0 }
+        ?: error("Parakeet vocabulary is missing $BLANK_TOKEN")
+    private val vocabSize = vocab.size
+
+    fun transcribeEncoded(values: FloatArray, length: Int, timeSteps: Int): String {
+        val encoded = EncodedAudio(values, length, timeSteps)
+        val tokenIds = decode(encoded)
+        return decodeTokens(tokenIds)
+    }
+
+    private fun decode(encoded: EncodedAudio): List<Int> {
+        val tokens = mutableListOf<Int>()
+        var state1 = FloatArray(DECODER_STATE_LAYERS * DECODER_STATE_SIZE)
+        var state2 = FloatArray(DECODER_STATE_LAYERS * DECODER_STATE_SIZE)
+        var timeIndex = 0
+        var emittedTokens = 0
+
+        while (timeIndex < encoded.length) {
+            val frame = encoded.frameAt(timeIndex)
+            val stepResult = runDecoder(frame, tokens.lastOrNull() ?: blankIndex, state1, state2)
+            val token = argmax(stepResult.tokenLogits, 0, vocabSize.coerceAtMost(stepResult.tokenLogits.size))
+
+            if (token != blankIndex) {
+                tokens.add(token)
+                state1 = stepResult.state1
+                state2 = stepResult.state2
+                emittedTokens += 1
+            }
+
+            when {
+                stepResult.duration > 0 -> {
+                    timeIndex += stepResult.duration
+                    emittedTokens = 0
+                }
+                token == blankIndex || emittedTokens == MAX_TOKENS_PER_STEP -> {
+                    timeIndex += 1
+                    emittedTokens = 0
+                }
+            }
+        }
+
+        return tokens
+    }
+
+    private fun runDecoder(
+        encoderFrame: FloatArray,
+        previousToken: Int,
+        state1: FloatArray,
+        state2: FloatArray
+    ): DecoderStep {
+        lateinit var decoderOutput: FloatArray
+        lateinit var outputState1: FloatArray
+        lateinit var outputState2: FloatArray
+
+        decoder.runWithInputs { inputs ->
+            inputs.requireSize(3, "decoder inputs")
+            inputs[0].writeLong(longArrayOf(previousToken.toLong()))
+            inputs[1].writeFloat(state1)
+            inputs[2].writeFloat(state2)
+        }.useAndRead {
+            it.requireSize(3, "decoder outputs")
+            decoderOutput = it[0].readFloat()
+            outputState1 = it[1].readFloat()
+            outputState2 = it[2].readFloat()
+        }
+
+        val outputs = joint.runWithInputs { inputs ->
+            inputs.requireSize(2, "joint inputs")
+            inputs[0].writeFloat(encoderFrame)
+            inputs[1].writeFloat(decoderOutput)
+        }
+        return outputs.useAndRead {
+            it.requireSize(2, "joint outputs")
+            val tokenLogits = it[0].readFloat()
+            val durationLogits = it[1].readFloat()
+            DecoderStep(
+                tokenLogits = tokenLogits,
+                duration = argmax(durationLogits, 0, durationLogits.size),
+                state1 = outputState1,
+                state2 = outputState2
+            )
+        }
+    }
+
+    private fun decodeTokens(tokenIds: List<Int>): String {
+        val joined = tokenIds.asSequence()
+            .mapNotNull { id -> vocab.getOrNull(id) }
+            .filterNot { token -> token == BLANK_TOKEN || token.startsWith("<|") }
+            .joinToString("")
+            .replace('\u2581', ' ')
+        return joined
+            .replace(Regex("^\\s+"), "")
+            .replace(Regex("\\s+([,.;:!?%])"), "$1")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+    }
+
+    private fun EncodedAudio.frameAt(timeIndex: Int): FloatArray {
+        return FloatArray(ENCODER_SIZE) { dimension ->
+            values[(dimension * timeSteps) + timeIndex]
+        }
+    }
+
+    override fun close() {
+        joint.close()
+        decoder.close()
+        environment.close()
+    }
+
+    companion object {
+        private const val BLANK_TOKEN = "<blk>"
+        private const val MAX_TOKENS_PER_STEP = 10
+        private const val DECODER_STATE_LAYERS = 2
+        private const val DECODER_STATE_SIZE = 640
+        private const val ENCODER_SIZE = 1024
+        private const val TAG = "ParakeetLiteRtModel"
+
+        fun load(directory: File): ParakeetLiteRtModel {
+            val environment = Environment.create()
+            val options = CompiledModel.Options(Accelerator.CPU)
+            Log.d(TAG, "Opening Parakeet LiteRT decoder_model_float32.tflite")
+            val decoder = CompiledModel.create(
+                File(directory, "decoder_model_float32.tflite").absolutePath,
+                options,
+                environment
+            )
+            Log.d(TAG, "Opening Parakeet LiteRT joint_model_float32.tflite")
+            val joint = CompiledModel.create(
+                File(directory, "joint_model_float32.tflite").absolutePath,
+                options,
+                environment
+            )
+            return ParakeetLiteRtModel(
+                environment = environment,
+                decoder = decoder,
+                joint = joint,
+                directory = directory
+            )
+        }
+
+        private fun loadVocabulary(file: File): List<String> {
+            val tokensById = mutableMapOf<Int, String>()
+            file.forEachLine(Charsets.UTF_8) { line ->
+                val separator = line.lastIndexOf(' ')
+                if (separator <= 0) return@forEachLine
+                val token = line.substring(0, separator)
+                val id = line.substring(separator + 1).toIntOrNull() ?: return@forEachLine
+                tokensById[id] = token
+            }
+            return List((tokensById.keys.maxOrNull() ?: -1) + 1) { id -> tokensById[id].orEmpty() }
+        }
+
+        private fun argmax(values: FloatArray, fromInclusive: Int, toExclusive: Int): Int {
+            var bestIndex = fromInclusive
+            var bestValue = Float.NEGATIVE_INFINITY
+            for (index in fromInclusive until toExclusive) {
+                val value = values[index]
+                if (value > bestValue) {
+                    bestValue = value
+                    bestIndex = index
+                }
+            }
+            return bestIndex
+        }
+    }
+
+    private data class EncodedAudio(
+        val values: FloatArray,
+        val length: Int,
+        val timeSteps: Int
+    )
+
+    private data class DecoderStep(
+        val tokenLogits: FloatArray,
+        val duration: Int,
+        val state1: FloatArray,
+        val state2: FloatArray
+    )
+}
+
+private fun CompiledModel.runWithInputs(fillInputs: (List<TensorBuffer>) -> Unit): List<TensorBuffer> {
+    val inputs = createInputBuffers()
+    return try {
+        fillInputs(inputs)
+        run(inputs)
+    } finally {
+        inputs.closeAll()
+    }
+}
+
+private inline fun <T> List<TensorBuffer>.useAndRead(block: (List<TensorBuffer>) -> T): T {
+    return try {
+        block(this)
+    } finally {
+        closeAll()
+    }
+}
+
+private fun List<TensorBuffer>.closeAll() {
+    forEach { buffer -> buffer.close() }
+}
+
+private fun List<TensorBuffer>.requireSize(minSize: Int, label: String) {
+    require(size >= minSize) { "Parakeet LiteRT $label expected at least $minSize buffers, got $size" }
+}

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetModelAssets.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetModelAssets.kt
@@ -2,6 +2,7 @@ package com.whispermate.aidictation.data.local
 
 import android.content.Context
 import android.util.Log
+import com.whispermate.aidictation.BuildConfig
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.assetpacks.AssetPackManager
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
@@ -24,10 +25,18 @@ class ParakeetModelAssets @Inject constructor(
         private const val TAG = "ParakeetModelAssets"
         private const val PACK_NAME = "parakeet_v3_pack"
 
-        val REQUIRED_FILES = listOf(
+        val REQUIRED_ONNX_FILES = listOf(
             "nemo128.onnx",
             "encoder-model.int8.onnx",
             "decoder_joint-model.int8.onnx",
+            "vocab.txt"
+        )
+
+        val REQUIRED_LITERT_FILES = listOf(
+            "nemo128.onnx",
+            "encoder-model.int8.onnx",
+            "decoder_model_float32.tflite",
+            "joint_model_float32.tflite",
             "vocab.txt"
         )
     }
@@ -36,26 +45,46 @@ class ParakeetModelAssets @Inject constructor(
         AssetPackManagerFactory.getInstance(context)
     }
 
-    suspend fun requireModelDirectory(): File {
-        findExistingModelDirectory()?.let { return it }
+    suspend fun requireModelDirectory(runtime: ParakeetRuntime = ParakeetRuntime.ONNX): File {
+        findExternalModelDirectory(runtime)?.let {
+            removeStaleInternalModelDirectory()
+            return it
+        }
+
+        if (BuildConfig.PACKAGE_OFFLINE_MODELS) {
+            runCatching { installBundledModelDirectory(runtime) }
+                .onSuccess { return it }
+                .onFailure { Log.w(TAG, "Unable to install bundled Parakeet model", it) }
+        }
+
+        findInternalModelDirectory(runtime)?.let { return it }
+
+        findAssetPackModelDirectory(runtime)?.let { return it }
 
         runCatching { requestAssetPack() }
             .onFailure { Log.w(TAG, "Unable to fetch Parakeet asset pack", it) }
 
-        return findExistingModelDirectory()
+        findAssetPackModelDirectory(runtime)?.let { return it }
+
+        return findInternalModelDirectory(runtime)
             ?: throw IllegalStateException(
-                "Parakeet model files are not installed. Install the $PACK_NAME asset pack or push files to ${externalModelDir().absolutePath}."
+                "Parakeet ${runtime.displayName} model files are not installed. Install the $PACK_NAME asset pack, build with PACKAGE_OFFLINE_MODELS=true, or push files to ${externalModelDir().absolutePath}."
             )
     }
 
-    private fun findExistingModelDirectory(): File? {
-        val localDirs = listOf(externalModelDir(), internalModelDir())
-        localDirs.firstOrNull { hasRequiredFiles(it) }?.let { return it }
+    private fun findInternalModelDirectory(runtime: ParakeetRuntime): File? {
+        return internalModelDir().takeIf { hasRequiredFiles(it, runtime) }
+    }
 
-        val packDir = runCatching { assetPackManager.getPackLocation(PACK_NAME)?.assetsPath() }
+    private fun findExternalModelDirectory(runtime: ParakeetRuntime): File? {
+        return externalModelDir().takeIf { hasRequiredFiles(it, runtime) }
+    }
+
+    private fun findAssetPackModelDirectory(runtime: ParakeetRuntime): File? {
+        return runCatching { assetPackManager.getPackLocation(PACK_NAME)?.assetsPath() }
             .getOrNull()
             ?.let(::File)
-        return packDir?.takeIf { hasRequiredFiles(it) }
+            ?.takeIf { hasRequiredFiles(it, runtime) }
     }
 
     private fun externalModelDir(): File {
@@ -64,8 +93,59 @@ class ParakeetModelAssets @Inject constructor(
 
     private fun internalModelDir(): File = File(context.filesDir, "parakeet")
 
-    private fun hasRequiredFiles(directory: File): Boolean {
-        return directory.isDirectory && REQUIRED_FILES.all { File(directory, it).isFile }
+    private fun hasRequiredFiles(directory: File, runtime: ParakeetRuntime): Boolean {
+        return directory.isDirectory && requiredFiles(runtime).all {
+            File(directory, it).let { file -> file.isFile && file.length() > 0L }
+        }
+    }
+
+    private fun requiredFiles(runtime: ParakeetRuntime): List<String> {
+        return when (runtime) {
+            ParakeetRuntime.ONNX -> REQUIRED_ONNX_FILES
+            ParakeetRuntime.LITERT -> REQUIRED_LITERT_FILES
+        }
+    }
+
+    private fun removeStaleInternalModelDirectory() {
+        val internalDir = internalModelDir()
+        if (!internalDir.exists()) return
+        Log.d(TAG, "Removing stale internal Parakeet model cache at ${internalDir.absolutePath}")
+        internalDir.deleteRecursively()
+    }
+
+    private fun installBundledModelDirectory(runtime: ParakeetRuntime): File {
+        val destination = internalModelDir()
+        val files = requiredFiles(runtime)
+        if (bundledAssetsMatch(destination, files)) return destination
+
+        Log.d(TAG, "Installing bundled Parakeet ${runtime.displayName} model to ${destination.absolutePath}")
+        destination.deleteRecursively()
+        destination.mkdirs()
+
+        for (fileName in files) {
+            context.assets.open(fileName).use { input ->
+                File(destination, fileName).outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+
+        return destination.takeIf { hasRequiredFiles(it, runtime) }
+            ?: throw IllegalStateException("Bundled Parakeet ${runtime.displayName} model copy failed.")
+    }
+
+    private fun bundledAssetsMatch(directory: File, files: List<String>): Boolean {
+        if (!directory.isDirectory) return false
+        return files.all { fileName ->
+            val destination = File(directory, fileName)
+            destination.isFile && destination.length() > 0L && destination.length() == bundledAssetLength(fileName)
+        }
+    }
+
+    private fun bundledAssetLength(fileName: String): Long {
+        return context.assets.openFd(fileName).use { descriptor ->
+            descriptor.length
+        }
     }
 
     private suspend fun requestAssetPack() {

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetRuntime.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetRuntime.kt
@@ -1,0 +1,20 @@
+package com.whispermate.aidictation.data.local
+
+enum class ParakeetRuntime(val configValue: String, val displayName: String) {
+    ONNX("onnx", "ONNX"),
+    LITERT("litert", "LiteRT");
+
+    companion object {
+        fun fromConfig(value: String?): ParakeetRuntime {
+            return if (value.equals(LITERT.configValue, ignoreCase = true)) {
+                LITERT
+            } else {
+                ONNX
+            }
+        }
+
+        fun isLocalRuntime(value: String?): Boolean {
+            return entries.any { runtime -> value.equals(runtime.configValue, ignoreCase = true) }
+        }
+    }
+}

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetTranscriber.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetTranscriber.kt
@@ -4,6 +4,7 @@ import ai.onnxruntime.OnnxTensor
 import ai.onnxruntime.OrtEnvironment
 import ai.onnxruntime.OrtSession
 import android.util.Log
+import com.whispermate.aidictation.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -25,6 +26,7 @@ class ParakeetTranscriber @Inject constructor(
         private const val BLANK_TOKEN = "<blk>"
         private const val MAX_TOKENS_PER_STEP = 10
         private const val SAMPLE_RATE = 16_000
+        private const val MAX_CHUNK_SECONDS = 30
         private const val DECODER_STATE_LAYERS = 2
         private const val DECODER_STATE_SIZE = 640
         private const val ENCODER_SIZE = 1024
@@ -33,65 +35,110 @@ class ParakeetTranscriber @Inject constructor(
     private val mutex = Mutex()
     private val audioDecoder = AndroidAudioDecoder()
     private val ortEnvironment: OrtEnvironment = OrtEnvironment.getEnvironment()
-    private var model: LoadedParakeetModel? = null
+    private var onnxModel: LoadedParakeetModel? = null
+    private var onnxEncoderModel: LoadedParakeetModel? = null
+    private var liteRtModel: ParakeetLiteRtModel? = null
 
     suspend fun transcribe(audioFile: File): Result<String> = withContext(Dispatchers.Default) {
         runCatching {
             mutex.withLock {
-                val loadedModel = model ?: loadModel().also { model = it }
+                val runtime = ParakeetRuntime.fromConfig(BuildConfig.PARAKEET_RUNTIME)
                 val samples = audioDecoder.decodeToMono16k(audioFile)
                 if (samples.isEmpty()) return@withLock ""
 
-                Log.d(TAG, "Running Parakeet on ${samples.size} samples at ${SAMPLE_RATE}Hz")
-                val features = loadedModel.runPreprocessor(samples)
-                val encoded = loadedModel.runEncoder(features)
-                val tokenIds = loadedModel.decode(encoded)
-                val text = loadedModel.decodeTokens(tokenIds)
+                Log.d(TAG, "Running Parakeet ${runtime.displayName} on ${samples.size} samples at ${SAMPLE_RATE}Hz")
+                val text = when (runtime) {
+                    ParakeetRuntime.ONNX -> {
+                        val loadedModel = onnxModel ?: loadOnnxModel().also { onnxModel = it }
+                        val encoded = loadedModel.encodeSamples(samples)
+                        val tokenIds = loadedModel.decode(encoded)
+                        loadedModel.decodeTokens(tokenIds)
+                    }
+                    ParakeetRuntime.LITERT -> {
+                        val encoderModel = onnxEncoderModel
+                            ?: loadOnnxModel(loadDecoder = false, runtime = ParakeetRuntime.LITERT).also { onnxEncoderModel = it }
+                        val loadedModel = liteRtModel ?: loadLiteRtModel().also { liteRtModel = it }
+                        encoderModel.decodeWithLiteRt(samples, loadedModel)
+                    }
+                }
                 Log.d(TAG, "LOCAL_TRANSCRIPTION_OK ${text.take(100)}")
                 text
             }
         }
     }
 
-    private suspend fun loadModel(): LoadedParakeetModel {
-        val directory = modelAssets.requireModelDirectory()
+    private suspend fun loadOnnxModel(
+        loadDecoder: Boolean = true,
+        runtime: ParakeetRuntime = ParakeetRuntime.ONNX
+    ): LoadedParakeetModel {
+        val directory = modelAssets.requireModelDirectory(runtime)
         Log.d(TAG, "Loading Parakeet model from ${directory.absolutePath}")
         return LoadedParakeetModel(
             environment = ortEnvironment,
-            directory = directory
+            directory = directory,
+            loadDecoder = loadDecoder
         )
+    }
+
+    private suspend fun loadLiteRtModel(): ParakeetLiteRtModel {
+        val directory = modelAssets.requireModelDirectory(ParakeetRuntime.LITERT)
+        Log.d(TAG, "Loading Parakeet LiteRT model from ${directory.absolutePath}")
+        return ParakeetLiteRtModel.load(directory)
     }
 
     private class LoadedParakeetModel(
         private val environment: OrtEnvironment,
-        directory: File
+        directory: File,
+        loadDecoder: Boolean
     ) {
         private val sessionOptions = OrtSession.SessionOptions().apply {
-            setOptimizationLevel(OrtSession.SessionOptions.OptLevel.ALL_OPT)
+            setOptimizationLevel(OrtSession.SessionOptions.OptLevel.NO_OPT)
             setIntraOpNumThreads(Runtime.getRuntime().availableProcessors().coerceAtMost(4))
         }
-        private val preprocessor = environment.createSession(
-            File(directory, "nemo128.onnx").absolutePath,
-            sessionOptions
-        )
-        private val encoder = environment.createSession(
-            File(directory, "encoder-model.int8.onnx").absolutePath,
-            sessionOptions
-        )
-        private val decoderJoint = environment.createSession(
-            File(directory, "decoder_joint-model.int8.onnx").absolutePath,
-            sessionOptions
-        )
+        private val preprocessor = createSession(directory, "nemo128.onnx")
+        private val encoder = createSession(directory, "encoder-model.int8.onnx")
+        private val decoderJoint = if (loadDecoder) createSession(directory, "decoder_joint-model.int8.onnx") else null
         private val vocab = loadVocabulary(File(directory, "vocab.txt"))
         private val blankIndex = vocab.indexOf(BLANK_TOKEN).takeIf { it >= 0 }
             ?: error("Parakeet vocabulary is missing $BLANK_TOKEN")
         private val vocabSize = vocab.size
 
-        fun runPreprocessor(samples: FloatArray): Features {
+        fun encodeSamples(samples: FloatArray): EncodedAudio {
+            val chunks = mutableListOf<EncodedAudio>()
+            var offset = 0
+
+            while (offset < samples.size) {
+                val chunkSize = min(SAMPLE_RATE * MAX_CHUNK_SECONDS, samples.size - offset)
+                val chunk = FloatArray(chunkSize)
+                samples.copyInto(chunk, startIndex = offset, endIndex = offset + chunkSize)
+
+                val features = runPreprocessor(chunk, chunkSize)
+                chunks.add(runEncoder(features))
+                offset += chunkSize
+            }
+
+            return concatenateEncodedAudio(chunks)
+        }
+
+        fun decodeWithLiteRt(samples: FloatArray, liteRtModel: ParakeetLiteRtModel): String {
+            val encoded = encodeSamples(samples)
+            return liteRtModel.transcribeEncoded(encoded.values, encoded.length, encoded.timeSteps)
+        }
+
+        private fun createSession(directory: File, fileName: String): OrtSession {
+            val file = File(directory, fileName)
+            val startMs = System.currentTimeMillis()
+            Log.d(TAG, "Opening Parakeet ONNX session $fileName (${file.length()} bytes)")
+            return environment.createSession(file.absolutePath, sessionOptions).also {
+                Log.d(TAG, "Opened Parakeet ONNX session $fileName in ${System.currentTimeMillis() - startMs}ms")
+            }
+        }
+
+        private fun runPreprocessor(samples: FloatArray, validSampleCount: Int): Features {
             val waveformShape = longArrayOf(1, samples.size.toLong())
             val lengthShape = longArrayOf(1)
             OnnxTensor.createTensor(environment, FloatBuffer.wrap(samples), waveformShape).use { waveformTensor ->
-                OnnxTensor.createTensor(environment, LongBuffer.wrap(longArrayOf(samples.size.toLong())), lengthShape)
+                OnnxTensor.createTensor(environment, LongBuffer.wrap(longArrayOf(validSampleCount.toLong())), lengthShape)
                     .use { lengthTensor ->
                         preprocessor.run(
                             mapOf(
@@ -103,7 +150,7 @@ class ParakeetTranscriber @Inject constructor(
                             val features = featuresTensor.floatBuffer.toFloatArray()
                             val featuresLengthTensor = results[1] as OnnxTensor
                             val featuresLength = featuresLengthTensor.longBuffer.get(0)
-                            return Features(features, featuresLength)
+                            return Features(features, featuresLength, features.size / 128)
                         }
                     }
             }
@@ -113,7 +160,7 @@ class ParakeetTranscriber @Inject constructor(
             OnnxTensor.createTensor(
                 environment,
                 FloatBuffer.wrap(features.values),
-                longArrayOf(1, 128, features.length)
+                longArrayOf(1, 128, features.timeSteps.toLong())
             ).use { audioSignalTensor ->
                 OnnxTensor.createTensor(environment, LongBuffer.wrap(longArrayOf(features.length)), longArrayOf(1))
                     .use { lengthTensor ->
@@ -132,6 +179,26 @@ class ParakeetTranscriber @Inject constructor(
                         }
                     }
             }
+        }
+
+        private fun concatenateEncodedAudio(chunks: List<EncodedAudio>): EncodedAudio {
+            val totalLength = chunks.sumOf { it.length }
+            if (totalLength == 0) return EncodedAudio(FloatArray(0), 0, 0)
+
+            val values = FloatArray(ENCODER_SIZE * totalLength)
+            var targetTime = 0
+
+            for (chunk in chunks) {
+                for (timeIndex in 0 until chunk.length) {
+                    for (dimension in 0 until ENCODER_SIZE) {
+                        values[(dimension * totalLength) + targetTime + timeIndex] =
+                            chunk.values[(dimension * chunk.timeSteps) + timeIndex]
+                    }
+                }
+                targetTime += chunk.length
+            }
+
+            return EncodedAudio(values, totalLength, totalLength)
         }
 
         fun decode(encoded: EncodedAudio): List<Int> {
@@ -171,7 +238,7 @@ class ParakeetTranscriber @Inject constructor(
         fun decodeTokens(tokenIds: List<Int>): String {
             val joined = tokenIds.asSequence()
                 .mapNotNull { id -> vocab.getOrNull(id) }
-                .filterNot { token -> token == BLANK_TOKEN || token.startsWith("<|") }
+                .filterNot { token -> token == BLANK_TOKEN || (token.startsWith("<") && token.endsWith(">")) }
                 .joinToString("")
                 .replace('\u2581', ' ')
             return joined
@@ -187,13 +254,17 @@ class ParakeetTranscriber @Inject constructor(
             state1: FloatArray,
             state2: FloatArray
         ): DecoderStep {
+            lateinit var decoderOutput: FloatArray
+            lateinit var outputState1: FloatArray
+            lateinit var outputState2: FloatArray
+
             OnnxTensor.createTensor(
                 environment,
                 FloatBuffer.wrap(encoderFrame),
                 longArrayOf(1, ENCODER_SIZE.toLong(), 1)
             ).use { encoderTensor ->
                 OnnxTensor.createTensor(environment, IntBuffer.wrap(intArrayOf(previousToken)), longArrayOf(1, 1))
-                    .use { targetsTensor ->
+                    .use { targetTensor ->
                         OnnxTensor.createTensor(environment, IntBuffer.wrap(intArrayOf(1)), longArrayOf(1))
                             .use { targetLengthTensor ->
                                 OnnxTensor.createTensor(
@@ -206,27 +277,26 @@ class ParakeetTranscriber @Inject constructor(
                                         FloatBuffer.wrap(state2),
                                         longArrayOf(DECODER_STATE_LAYERS.toLong(), 1, DECODER_STATE_SIZE.toLong())
                                     ).use { state2Tensor ->
-                                        decoderJoint.run(
+                                        requireNotNull(decoderJoint) { "Parakeet ONNX decoder-joint model was not loaded" }.run(
                                             mapOf(
                                                 "encoder_outputs" to encoderTensor,
-                                                "targets" to targetsTensor,
+                                                "targets" to targetTensor,
                                                 "target_length" to targetLengthTensor,
                                                 "input_states_1" to state1Tensor,
                                                 "input_states_2" to state2Tensor
                                             )
                                         ).use { results ->
-                                            val outputTensor = results[0] as OnnxTensor
-                                            val logits = outputTensor.floatBuffer.toFloatArray()
-                                            val outputState1 = (results[2] as OnnxTensor).floatBuffer.toFloatArray()
-                                            val outputState2 = (results[3] as OnnxTensor).floatBuffer.toFloatArray()
-                                            val duration = argmax(logits, vocabSize, logits.size) - vocabSize
-                                            return DecoderStep(logits, duration, outputState1, outputState2)
+                                            decoderOutput = (results.get("outputs").get() as OnnxTensor).floatBuffer.toFloatArray()
+                                            outputState1 = (results.get("output_states_1").get() as OnnxTensor).floatBuffer.toFloatArray()
+                                            outputState2 = (results.get("output_states_2").get() as OnnxTensor).floatBuffer.toFloatArray()
                                         }
                                     }
                                 }
                             }
                     }
-            }
+                }
+            val duration = argmax(decoderOutput, vocabSize, decoderOutput.size) - vocabSize
+            return DecoderStep(decoderOutput, duration, outputState1, outputState2)
         }
 
         private fun EncodedAudio.frameAt(timeIndex: Int): FloatArray {
@@ -268,7 +338,8 @@ class ParakeetTranscriber @Inject constructor(
 
         private data class Features(
             val values: FloatArray,
-            val length: Long
+            val length: Long,
+            val timeSteps: Int
         )
 
         private data class EncodedAudio(

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
@@ -1,6 +1,7 @@
 package com.whispermate.aidictation.data.preferences
 
 import com.whispermate.aidictation.BuildConfig
+import com.whispermate.aidictation.data.local.ParakeetRuntime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,7 +44,10 @@ class ApiConfigManager @Inject constructor() {
             private set
 
         fun defaultTranscriptionModel(provider: ApiProvider): String = when (provider) {
-            ApiProvider.PARAKEET -> "parakeet-tdt-0.6b"
+            ApiProvider.PARAKEET -> when (ParakeetRuntime.fromConfig(BuildConfig.PARAKEET_RUNTIME)) {
+                ParakeetRuntime.ONNX -> "parakeet-tdt-0.6b-v3"
+                ParakeetRuntime.LITERT -> "parakeet-tdt-0.6b-v3-litert"
+            }
             ApiProvider.WRITINGMATE -> "groq/whisper-large-v3-turbo"
             ApiProvider.OPENAI -> "whisper-1"
             ApiProvider.GROQ -> "whisper-large-v3-turbo"
@@ -64,6 +68,10 @@ class ApiConfigManager @Inject constructor() {
     fun getPostProcessingConfig(): ApiConfig = postProcessingConfig
 
     private fun defaultTranscriptionProvider(): ApiProvider {
+        if (ParakeetRuntime.isLocalRuntime(BuildConfig.PARAKEET_RUNTIME)) {
+            return ApiProvider.PARAKEET
+        }
+
         val endpoint = BuildConfig.TRANSCRIPTION_ENDPOINT
         return when {
             endpoint.contains("writingmate", ignoreCase = true) -> ApiProvider.WRITINGMATE
@@ -85,11 +93,20 @@ class ApiConfigManager @Inject constructor() {
 
     private fun buildDefaultTranscriptionConfig(): ApiConfig {
         val provider = defaultTranscriptionProvider()
+        val isLocalParakeet = provider == ApiProvider.PARAKEET
         return ApiConfig(
             provider = provider,
             apiKey = BuildConfig.TRANSCRIPTION_API_KEY,
-            model = BuildConfig.TRANSCRIPTION_MODEL.ifEmpty { defaultTranscriptionModel(provider) },
-            endpoint = BuildConfig.TRANSCRIPTION_ENDPOINT.ifEmpty { provider.transcriptionEndpoint() }
+            model = if (isLocalParakeet) {
+                defaultTranscriptionModel(provider)
+            } else {
+                BuildConfig.TRANSCRIPTION_MODEL.ifEmpty { defaultTranscriptionModel(provider) }
+            },
+            endpoint = if (isLocalParakeet) {
+                provider.transcriptionEndpoint()
+            } else {
+                BuildConfig.TRANSCRIPTION_ENDPOINT.ifEmpty { provider.transcriptionEndpoint() }
+            }
         )
     }
 

--- a/AIDictationAndroid/app/src/main/play/release-notes/en-US/internal.txt
+++ b/AIDictationAndroid/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,0 +1,1 @@
+Internal development build for AIDictation Android testers.

--- a/AIDictationAndroid/build.gradle.kts
+++ b/AIDictationAndroid/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.gradle.play.publisher) apply false
 }

--- a/AIDictationAndroid/gradle/libs.versions.toml
+++ b/AIDictationAndroid/gradle/libs.versions.toml
@@ -17,8 +17,10 @@ ksp = "2.0.21-1.0.27"
 coroutines = "1.9.0"
 coil = "2.7.0"
 securityCrypto = "1.1.0-alpha06"
-onnxRuntime = "1.16.3"
+onnxRuntime = "1.25.1"
 playAssetDelivery = "2.3.0"
+litert = "2.0.3"
+gradlePlayPublisher = "3.13.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -68,6 +70,7 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 # ONNX Runtime for Silero VAD
 onnx-runtime = { group = "com.microsoft.onnxruntime", name = "onnxruntime-android", version.ref = "onnxRuntime" }
 play-asset-delivery = { group = "com.google.android.play", name = "asset-delivery", version.ref = "playAssetDelivery" }
+litert = { group = "com.google.ai.edge.litert", name = "litert", version.ref = "litert" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -76,3 +79,4 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 android-ai-pack = { id = "com.android.ai-pack", version.ref = "agp" }
+gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -4,10 +4,22 @@
 # Android SDK location
 sdk.dir=/path/to/Android/Sdk
 
+# Optional local version overrides. CI uses these for Play dev releases.
+VERSION_CODE=5
+VERSION_NAME=0.0.5
+
 # Writingmate transcription configuration
 TRANSCRIPTION_API_KEY=your_writingmate_transcription_key_here
 TRANSCRIPTION_ENDPOINT=https://writingmate.ai/api/openai/v1/audio/transcriptions
 TRANSCRIPTION_MODEL=groq/whisper-large-v3-turbo
+
+# Optional local Parakeet runtime. Leave empty for cloud transcription.
+# Use `litert` only with converted `.tflite` files in parakeetpack.
+PARAKEET_RUNTIME=
+
+# Optional sideload APK mode. When true, the APK embeds Parakeet weights and
+# copies them from APK assets to app storage on first local transcription.
+PACKAGE_OFFLINE_MODELS=false
 
 # Writingmate post-processing configuration
 # Matches AIDictationPostProcessing* in the macOS Secrets.plist.
@@ -24,3 +36,8 @@ STRIPE_PAYMENT_LINK=https://buy.stripe.com/your_default_checkout_link
 STRIPE_PAYMENT_LINK_MONTHLY=https://buy.stripe.com/your_monthly_checkout_link
 STRIPE_PAYMENT_LINK_ANNUAL=https://buy.stripe.com/your_annual_checkout_link
 STRIPE_PAYMENT_LINK_LIFETIME=https://buy.stripe.com/your_lifetime_checkout_link
+
+# Optional Google Play publishing configuration for local Gradle Play Publisher runs.
+# CI normally writes PLAY_SERVICE_ACCOUNT_CREDENTIALS from a GitHub secret.
+PLAY_TRACK=internal
+PLAY_SERVICE_ACCOUNT_CREDENTIALS=/path/to/google-play-service-account.json

--- a/AIDictationAndroid/parakeetpack/src/main/assets/README_PARAKEET_ASSETS.txt
+++ b/AIDictationAndroid/parakeetpack/src/main/assets/README_PARAKEET_ASSETS.txt
@@ -1,12 +1,26 @@
 Place the local Parakeet payload for Android in this asset pack.
 
-Current upstream bundle wired by the app:
+Current ONNX bundle wired by the default local runtime:
 - encoder-model.int8.onnx
 - decoder_joint-model.int8.onnx
 - nemo128.onnx
 - vocab.txt
 
 These files can be sourced from:
-- https://huggingface.co/istupakov/parakeet-tdt-0.6b-v2-onnx
+- https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
 
-Without those files, the app will request the pack and then fall back to remote transcription.
+Keep Android ONNX files saved with IR version 8. The bundled Android
+ONNX Runtime rejects newer IR metadata before model execution.
+
+LiteRT builds currently use a hybrid runtime: ONNX for preprocessor/encoder,
+LiteRT for decoder/joint:
+- nemo128.onnx
+- encoder-model.int8.onnx
+- decoder_model_float32.tflite
+- joint_model_float32.tflite
+- vocab.txt
+
+Build a local LiteRT APK with:
+./gradlew :app:assembleDebug -PPARAKEET_RUNTIME=litert -PTRANSCRIPTION_ENDPOINT= -PTRANSCRIPTION_MODEL=parakeet-tdt-0.6b-v3-litert
+
+Without the runtime-specific model files, local Parakeet transcription fails fast with a missing-model error.


### PR DESCRIPTION
## Summary

- Add `PACKAGE_OFFLINE_MODELS=true` sideload APK mode that embeds Parakeet v3 ONNX weights in APK assets.
- Copy bundled model assets into app storage on first local transcription, while preserving the Play Asset Delivery path for normal Play builds.
- Add GitHub/Play dev release wiring and version overrides for internal Android release flows.

## Release

Published GitHub release: https://github.com/writingmate/aidictation/releases/tag/android-v0.0.5-offline-parakeet-v3

## Verification

- `./gradlew :app:assembleRelease -PPARAKEET_RUNTIME=onnx -PPACKAGE_OFFLINE_MODELS=true`
- `./gradlew :app:testDebugUnitTest --stacktrace`
- `./gradlew :app:lintRelease --stacktrace`
- `apksigner verify --print-certs AIDictation-Android-0.0.5-offline-parakeet-v3.apk`
- Extracted the ONNX assets from the release APK and transcribed a Russian sample exactly.

## Not tested

- On-device install/runtime because `adb devices` showed no connected devices during this pass.
