### PR TITLE
Make Android Parakeet download on demand

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -376,10 +376,10 @@ jobs:
         run: chmod +x gradlew
 
       - name: Assemble release APK
-        run: ./gradlew assembleRelease -PPARAKEET_RUNTIME=onnx -PPACKAGE_OFFLINE_MODELS=true --stacktrace
+        run: ./gradlew assembleRelease --stacktrace
 
       - name: Bundle release AAB
-        run: ./gradlew bundleRelease -PPARAKEET_RUNTIME=onnx --stacktrace
+        run: ./gradlew bundleRelease --stacktrace
 
       - name: Collect release assets
         run: |

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -9,9 +9,10 @@ assets to a GitHub Release named `android-v<versionName>`.
 The GitHub release job does not rely on Git LFS bandwidth for Parakeet
 weights. It checks out source with LFS disabled, downloads
 `AIDictation-Parakeet-Assets-v3.zip` from the
-`android-parakeet-assets-v3` GitHub Release, builds the sideload APK with
-`PACKAGE_OFFLINE_MODELS=true`, and builds the Play AAB with the
-`parakeet_v3_pack` asset pack.
+`android-parakeet-assets-v3` GitHub Release for the Play asset pack, builds
+a small sideload APK that downloads Parakeet only when the user enables
+on-device transcription, and builds the Play AAB with the `parakeet_v3_pack`
+asset pack.
 
 `.github/workflows/android-play-dev.yml` is a manual dev-release workflow
 that publishes the signed release AAB to a Google Play testing track
@@ -33,8 +34,10 @@ runs, matching the local-developer layout described in
 | `TRANSCRIPTION_API_KEY` | Writingmate transcription key. Sent as `Authorization: Bearer …`. |
 | `TRANSCRIPTION_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/audio/transcriptions` (matches the Mac app's `.custom` provider). |
 | `TRANSCRIPTION_MODEL` | Optional override. Defaults to `groq/whisper-large-v3-turbo`. The workflow normalizes stale `gpt-4o-transcribe` values from secrets to this Android-supported model. |
-| `PARAKEET_RUNTIME` | Local prototype runtime. Leave empty for cloud releases; use `litert` only for builds that include converted Parakeet `.tflite` files in `parakeetpack`. |
-| `PACKAGE_OFFLINE_MODELS` | Optional sideload APK mode. Set to `true` with `PARAKEET_RUNTIME=onnx` to embed Parakeet weights directly in the APK. Play releases should leave this `false` and use the on-demand asset pack. |
+| `PARAKEET_RUNTIME` | Local prototype runtime. Leave empty for cloud releases; the app's Settings switch enables ONNX Parakeet at runtime after downloading weights. |
+| `PACKAGE_OFFLINE_MODELS` | Local-debug sideload mode. Release APKs leave this `false` and download Parakeet from inside the app only when requested. |
+| `PARAKEET_ON_DEMAND_MODEL_URL` | Optional override for the in-app Parakeet archive download URL. Defaults to the `android-parakeet-assets-v3` GitHub Release asset. |
+| `PARAKEET_ON_DEMAND_MODEL_SHA256` | Optional override for the in-app Parakeet archive checksum. |
 | `AIDICTATION_POST_PROCESSING_KEY` | Writingmate post-processing key for suggestions, commands, and cleanup. |
 | `AIDICTATION_POST_PROCESSING_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/chat/completions`. |
 | `AIDICTATION_POST_PROCESSING_MODEL` | Optional override. Defaults to `openai/gpt-oss-20b`. |

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -24,6 +24,14 @@ fun configValue(name: String, defaultValue: String = ""): String {
 }
 
 val packageOfflineModels = configValue("PACKAGE_OFFLINE_MODELS", "false").toBooleanStrictOrNull() ?: false
+val parakeetOnDemandModelUrl = configValue(
+    "PARAKEET_ON_DEMAND_MODEL_URL",
+    "https://github.com/writingmate/aidictation/releases/download/android-parakeet-assets-v3/AIDictation-Parakeet-Assets-v3.zip"
+)
+val parakeetOnDemandModelSha256 = configValue(
+    "PARAKEET_ON_DEMAND_MODEL_SHA256",
+    "b0ba6367c660c9fb5b9cc711ae35dc4bb96b8ebee199a58a7e8b680acc169824"
+)
 
 android {
     namespace = "com.whispermate.aidictation"
@@ -56,6 +64,8 @@ android {
         buildConfigField("String", "TRANSCRIPTION_MODEL", "\"${configValue("TRANSCRIPTION_MODEL", "groq/whisper-large-v3-turbo")}\"")
         buildConfigField("String", "PARAKEET_RUNTIME", "\"${configValue("PARAKEET_RUNTIME", "")}\"")
         buildConfigField("boolean", "PACKAGE_OFFLINE_MODELS", packageOfflineModels.toString())
+        buildConfigField("String", "PARAKEET_ON_DEMAND_MODEL_URL", "\"$parakeetOnDemandModelUrl\"")
+        buildConfigField("String", "PARAKEET_ON_DEMAND_MODEL_SHA256", "\"$parakeetOnDemandModelSha256\"")
 
         // Writingmate post-processing, matching the macOS app's
         // AIDictationPostProcessing* secrets.

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetModelAssets.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/local/ParakeetModelAssets.kt
@@ -9,9 +9,18 @@ import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.google.android.play.core.assetpacks.AssetPackStateUpdateListener
 import com.google.android.play.core.assetpacks.model.AssetPackStatus
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
 import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.zip.ZipInputStream
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -46,6 +55,19 @@ class ParakeetModelAssets @Inject constructor(
     }
 
     suspend fun requireModelDirectory(runtime: ParakeetRuntime = ParakeetRuntime.ONNX): File {
+        return ensureModelDirectory(runtime)
+    }
+
+    fun isModelInstalled(runtime: ParakeetRuntime = ParakeetRuntime.ONNX): Boolean {
+        return findExternalModelDirectory(runtime) != null ||
+            findInternalModelDirectory(runtime) != null ||
+            findAssetPackModelDirectory(runtime) != null
+    }
+
+    suspend fun ensureModelDirectory(
+        runtime: ParakeetRuntime = ParakeetRuntime.ONNX,
+        onProgress: (Float) -> Unit = {}
+    ): File {
         findExternalModelDirectory(runtime)?.let {
             removeStaleInternalModelDirectory()
             return it
@@ -61,6 +83,10 @@ class ParakeetModelAssets @Inject constructor(
 
         findAssetPackModelDirectory(runtime)?.let { return it }
 
+        runCatching { installOnDemandModelDirectory(runtime, onProgress) }
+            .onSuccess { return it }
+            .onFailure { Log.w(TAG, "Unable to download Parakeet model archive", it) }
+
         runCatching { requestAssetPack() }
             .onFailure { Log.w(TAG, "Unable to fetch Parakeet asset pack", it) }
 
@@ -68,7 +94,7 @@ class ParakeetModelAssets @Inject constructor(
 
         return findInternalModelDirectory(runtime)
             ?: throw IllegalStateException(
-                "Parakeet ${runtime.displayName} model files are not installed. Install the $PACK_NAME asset pack, build with PACKAGE_OFFLINE_MODELS=true, or push files to ${externalModelDir().absolutePath}."
+                "Parakeet ${runtime.displayName} model files are not installed. Download the on-device model, install the $PACK_NAME asset pack, or push files to ${externalModelDir().absolutePath}."
             )
     }
 
@@ -145,6 +171,132 @@ class ParakeetModelAssets @Inject constructor(
     private fun bundledAssetLength(fileName: String): Long {
         return context.assets.openFd(fileName).use { descriptor ->
             descriptor.length
+        }
+    }
+
+    private suspend fun installOnDemandModelDirectory(
+        runtime: ParakeetRuntime,
+        onProgress: (Float) -> Unit
+    ): File = withContext(Dispatchers.IO) {
+        val archiveUrl = BuildConfig.PARAKEET_ON_DEMAND_MODEL_URL
+        if (archiveUrl.isBlank()) {
+            throw IllegalStateException("Parakeet model download URL is not configured")
+        }
+
+        val archive = File(context.cacheDir, "parakeet-model-${runtime.configValue}.zip")
+        val tempDir = File(context.filesDir, "parakeet-${runtime.configValue}.tmp")
+        val destination = internalModelDir()
+
+        try {
+            onProgress(0f)
+            downloadArchive(archiveUrl, archive, onProgress)
+            verifyArchiveChecksum(archive)
+
+            tempDir.deleteRecursively()
+            tempDir.mkdirs()
+            unzipArchive(archive, tempDir)
+
+            if (!hasRequiredFiles(tempDir, runtime)) {
+                throw IllegalStateException("Downloaded Parakeet archive did not contain the required ${runtime.displayName} files")
+            }
+
+            destination.deleteRecursively()
+            if (!tempDir.renameTo(destination)) {
+                destination.mkdirs()
+                tempDir.copyRecursively(destination, overwrite = true)
+                tempDir.deleteRecursively()
+            }
+
+            destination.takeIf { hasRequiredFiles(it, runtime) }
+                ?: throw IllegalStateException("Downloaded Parakeet ${runtime.displayName} model install failed")
+        } finally {
+            archive.delete()
+            tempDir.deleteRecursively()
+        }
+    }
+
+    private fun downloadArchive(
+        archiveUrl: String,
+        destination: File,
+        onProgress: (Float) -> Unit
+    ) {
+        destination.parentFile?.mkdirs()
+        val connection = (URL(archiveUrl).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 30_000
+            readTimeout = 60_000
+            instanceFollowRedirects = true
+        }
+
+        try {
+            connection.connect()
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                throw IllegalStateException("Parakeet model download failed with HTTP $responseCode")
+            }
+
+            val totalBytes = connection.contentLengthLong.takeIf { it > 0L } ?: -1L
+            var copiedBytes = 0L
+            BufferedInputStream(connection.inputStream).use { input ->
+                BufferedOutputStream(destination.outputStream()).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        copiedBytes += read
+                        if (totalBytes > 0L) {
+                            onProgress((copiedBytes.toFloat() / totalBytes).coerceIn(0f, 1f))
+                        }
+                    }
+                }
+            }
+            onProgress(1f)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun verifyArchiveChecksum(archive: File) {
+        val expected = BuildConfig.PARAKEET_ON_DEMAND_MODEL_SHA256.trim().lowercase(Locale.US)
+        if (expected.isBlank()) return
+
+        val digest = MessageDigest.getInstance("SHA-256")
+        archive.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        val actual = digest.digest().joinToString("") { "%02x".format(it.toInt() and 0xff) }
+        if (actual != expected) {
+            throw IllegalStateException("Parakeet model checksum mismatch")
+        }
+    }
+
+    private fun unzipArchive(archive: File, destination: File) {
+        val destinationRoot = destination.canonicalFile
+        ZipInputStream(BufferedInputStream(archive.inputStream())).use { zip ->
+            while (true) {
+                val entry = zip.nextEntry ?: break
+                val output = File(destinationRoot, entry.name).canonicalFile
+                if (output.path != destinationRoot.path &&
+                    !output.path.startsWith(destinationRoot.path + File.separator)
+                ) {
+                    throw IllegalStateException("Parakeet model archive contains an unsafe path: ${entry.name}")
+                }
+
+                if (entry.isDirectory) {
+                    output.mkdirs()
+                } else {
+                    output.parentFile?.mkdirs()
+                    output.outputStream().use { fileOutput ->
+                        zip.copyTo(fileOutput)
+                    }
+                }
+                zip.closeEntry()
+            }
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/AppPreferences.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/AppPreferences.kt
@@ -43,6 +43,7 @@ class AppPreferences @Inject constructor(
         val SELECTED_LANGUAGES = stringPreferencesKey("selected_languages")
         val MULTILINGUAL_ENABLED = booleanPreferencesKey("multilingual_enabled")
         val POST_PROCESSING_ENABLED = booleanPreferencesKey("post_processing_enabled")
+        val ON_DEVICE_TRANSCRIPTION_ENABLED = booleanPreferencesKey("on_device_transcription_enabled")
         val LOCAL_MONTHLY_WORD_COUNT = intPreferencesKey("local_monthly_word_count")
         val LOCAL_WORD_COUNT_RESET_AT = longPreferencesKey("local_word_count_reset_at")
     }
@@ -88,6 +89,16 @@ class AppPreferences @Inject constructor(
     suspend fun setPostProcessingEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[Keys.POST_PROCESSING_ENABLED] = enabled
+        }
+    }
+
+    val onDeviceTranscriptionEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[Keys.ON_DEVICE_TRANSCRIPTION_ENABLED] ?: false
+    }
+
+    suspend fun setOnDeviceTranscriptionEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.ON_DEVICE_TRANSCRIPTION_ENABLED] = enabled
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/repository/TranscriptionRepository.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/repository/TranscriptionRepository.kt
@@ -25,10 +25,11 @@ class TranscriptionRepository @Inject constructor(
         val languages = appPreferences.selectedLanguages.first()
         val multilingual = appPreferences.multilingualEnabled.first()
         val postProcess = appPreferences.postProcessingEnabled.first()
+        val onDeviceTranscription = appPreferences.onDeviceTranscriptionEnabled.first()
         val transcriptionConfig = ApiConfigManager.instance?.getTranscriptionConfig()
         val provider = transcriptionConfig?.provider ?: ApiProvider.WRITINGMATE
 
-        if (provider == ApiProvider.PARAKEET) {
+        if (onDeviceTranscription || provider == ApiProvider.PARAKEET) {
             val raw = parakeetTranscriber.transcribe(audioFile)
                 .getOrElse { return Result.failure(it) }
             return if (postProcess) {
@@ -104,11 +105,18 @@ class TranscriptionRepository @Inject constructor(
     }
 
     suspend fun applyPostProcessing(text: String): String {
+        if (appPreferences.onDeviceTranscriptionEnabled.first()) {
+            return applyLocalTextExpansions(text)
+        }
+
         val provider = ApiConfigManager.instance?.getTranscriptionConfig()?.provider ?: ApiProvider.WRITINGMATE
         if (provider == ApiProvider.WRITINGMATE) return text
 
-        var result = text
+        return applyLocalTextExpansions(text)
+    }
 
+    private suspend fun applyLocalTextExpansions(text: String): String {
+        var result = text
         val dictionary = appPreferences.dictionaryEntries.first()
             .filter { it.isEnabled && it.replacement != null }
             .sortedByDescending { it.trigger.length }

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
@@ -79,6 +79,8 @@ fun MainScreen(
     val error by viewModel.error.collectAsState()
     val multilingualEnabled by viewModel.multilingualEnabled.collectAsState()
     val postProcessingEnabled by viewModel.postProcessingEnabled.collectAsState()
+    val onDeviceTranscriptionEnabled by viewModel.onDeviceTranscriptionEnabled.collectAsState()
+    val onDeviceModelState by viewModel.onDeviceModelState.collectAsState()
     val usageStatus by viewModel.usageStatus.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -228,6 +230,9 @@ fun MainScreen(
                 onMultilingualToggled = { viewModel.setMultilingualEnabled(it) },
                 postProcessingEnabled = postProcessingEnabled,
                 onPostProcessingToggled = { viewModel.setPostProcessingEnabled(it) },
+                onDeviceTranscriptionEnabled = onDeviceTranscriptionEnabled,
+                onDeviceModelState = onDeviceModelState,
+                onOnDeviceTranscriptionToggled = { viewModel.setOnDeviceTranscriptionEnabled(it) },
                 usageStatus = usageStatus,
                 onSignIn = { viewModel.openLogin() },
                 onSignOut = { viewModel.signOut() },

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
@@ -2,6 +2,8 @@ package com.whispermate.aidictation.ui.screens.main
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.whispermate.aidictation.data.local.ParakeetModelAssets
+import com.whispermate.aidictation.data.local.ParakeetRuntime
 import com.whispermate.aidictation.data.preferences.AppPreferences
 import com.whispermate.aidictation.data.repository.RecordingRepository
 import com.whispermate.aidictation.data.repository.SubscriptionRepository
@@ -15,8 +17,11 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 
@@ -26,10 +31,17 @@ enum class RecordingState {
     Processing
 }
 
+data class OnDeviceModelUiState(
+    val isInstalled: Boolean = false,
+    val isDownloading: Boolean = false,
+    val downloadProgress: Float? = null
+)
+
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val recordingRepository: RecordingRepository,
     private val transcriptionRepository: TranscriptionRepository,
+    private val parakeetModelAssets: ParakeetModelAssets,
     private val subscriptionRepository: SubscriptionRepository,
     private val appPreferences: AppPreferences
 ) : ViewModel() {
@@ -43,7 +55,17 @@ class MainViewModel @Inject constructor(
     val postProcessingEnabled: StateFlow<Boolean> = appPreferences.postProcessingEnabled
         .stateIn(viewModelScope, SharingStarted.Lazily, true)
 
+    val onDeviceTranscriptionEnabled: StateFlow<Boolean> = appPreferences.onDeviceTranscriptionEnabled
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
     val usageStatus = subscriptionRepository.usageStatus
+
+    private val _onDeviceModelState = MutableStateFlow(OnDeviceModelUiState())
+    val onDeviceModelState: StateFlow<OnDeviceModelUiState> = _onDeviceModelState.asStateFlow()
+
+    init {
+        refreshOnDeviceModelState()
+    }
 
     fun setMultilingualEnabled(enabled: Boolean) {
         viewModelScope.launch {
@@ -54,6 +76,59 @@ class MainViewModel @Inject constructor(
     fun setPostProcessingEnabled(enabled: Boolean) {
         viewModelScope.launch {
             appPreferences.setPostProcessingEnabled(enabled)
+        }
+    }
+
+    fun setOnDeviceTranscriptionEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            if (!enabled) {
+                appPreferences.setOnDeviceTranscriptionEnabled(false)
+                refreshOnDeviceModelState()
+                return@launch
+            }
+
+            if (_onDeviceModelState.value.isDownloading) return@launch
+
+            try {
+                _onDeviceModelState.value = _onDeviceModelState.value.copy(
+                    isDownloading = true,
+                    downloadProgress = 0f
+                )
+                withContext(Dispatchers.IO) {
+                    parakeetModelAssets.ensureModelDirectory(ParakeetRuntime.ONNX) { progress ->
+                        _onDeviceModelState.value = _onDeviceModelState.value.copy(
+                            isDownloading = true,
+                            downloadProgress = progress
+                        )
+                    }
+                }
+                appPreferences.setOnDeviceTranscriptionEnabled(true)
+                _onDeviceModelState.value = OnDeviceModelUiState(isInstalled = true)
+            } catch (error: Throwable) {
+                appPreferences.setOnDeviceTranscriptionEnabled(false)
+                _onDeviceModelState.value = OnDeviceModelUiState(
+                    isInstalled = withContext(Dispatchers.IO) {
+                        parakeetModelAssets.isModelInstalled(ParakeetRuntime.ONNX)
+                    }
+                )
+                _error.value = error.message ?: "On-device model download failed"
+            }
+        }
+    }
+
+    private fun refreshOnDeviceModelState() {
+        viewModelScope.launch {
+            val isInstalled = withContext(Dispatchers.IO) {
+                parakeetModelAssets.isModelInstalled(ParakeetRuntime.ONNX)
+            }
+            _onDeviceModelState.value = _onDeviceModelState.value.copy(
+                isInstalled = isInstalled,
+                isDownloading = false,
+                downloadProgress = null
+            )
+            if (!isInstalled && appPreferences.onDeviceTranscriptionEnabled.first()) {
+                appPreferences.setOnDeviceTranscriptionEnabled(false)
+            }
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/SettingsScreen.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/SettingsScreen.kt
@@ -64,6 +64,7 @@ import com.whispermate.aidictation.R
 import com.whispermate.aidictation.domain.model.Recording
 import com.whispermate.aidictation.domain.model.UsageStatus
 import com.whispermate.aidictation.service.OverlayDictationAccessibilityService
+import com.whispermate.aidictation.ui.screens.main.OnDeviceModelUiState
 
 @Composable
 fun SettingsScreen(
@@ -75,6 +76,9 @@ fun SettingsScreen(
     onMultilingualToggled: (Boolean) -> Unit = {},
     postProcessingEnabled: Boolean = true,
     onPostProcessingToggled: (Boolean) -> Unit = {},
+    onDeviceTranscriptionEnabled: Boolean = false,
+    onDeviceModelState: OnDeviceModelUiState = OnDeviceModelUiState(),
+    onOnDeviceTranscriptionToggled: (Boolean) -> Unit = {},
     usageStatus: UsageStatus,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
@@ -237,6 +241,14 @@ fun SettingsScreen(
                 containerColor = MaterialTheme.colorScheme.surface
             )
         ) {
+            OnDeviceTranscriptionItem(
+                enabled = onDeviceTranscriptionEnabled,
+                state = onDeviceModelState,
+                onToggle = onOnDeviceTranscriptionToggled
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
             SettingsItem(
                 icon = Icons.Default.Translate,
                 title = stringResource(R.string.settings_multilingual_mode),
@@ -471,6 +483,85 @@ private fun UsageSummary(usageStatus: UsageStatus) {
             LinearProgressIndicator(
                 progress = { usageStatus.percentage.coerceIn(0f, 1f) },
                 modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun OnDeviceTranscriptionItem(
+    enabled: Boolean,
+    state: OnDeviceModelUiState,
+    onToggle: (Boolean) -> Unit
+) {
+    val progress = state.downloadProgress?.coerceIn(0f, 1f)
+    val status = when {
+        state.isDownloading && progress != null -> {
+            stringResource(R.string.settings_on_device_downloading, (progress * 100).toInt())
+        }
+        state.isDownloading -> stringResource(R.string.settings_on_device_downloading_unknown)
+        enabled -> stringResource(R.string.settings_on_device_local)
+        state.isInstalled -> stringResource(R.string.settings_on_device_ready)
+        else -> stringResource(R.string.settings_on_device_cloud)
+    }
+
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (!state.isDownloading) {
+                        Modifier.clickable { onToggle(!enabled) }
+                    } else {
+                        Modifier
+                    }
+                )
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Mic,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = stringResource(R.string.settings_on_device_transcription),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = status,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Switch(
+                checked = enabled || state.isDownloading,
+                enabled = !state.isDownloading,
+                onCheckedChange = onToggle
+            )
+        }
+
+        if (state.isDownloading) {
+            LinearProgressIndicator(
+                progress = { progress ?: 0f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 56.dp, end = 16.dp, bottom = 16.dp)
             )
         }
     }

--- a/AIDictationAndroid/app/src/main/res/values/strings.xml
+++ b/AIDictationAndroid/app/src/main/res/values/strings.xml
@@ -67,6 +67,12 @@
     <string name="account_anonymous_hint">Sign in only when you need more words or want to purchase.</string>
     <string name="account_authenticated_hint">Your word usage and purchases are linked to this account.</string>
     <string name="settings_transcription">Transcription</string>
+    <string name="settings_on_device_transcription">On-device transcription</string>
+    <string name="settings_on_device_cloud">Cloud</string>
+    <string name="settings_on_device_ready">Ready</string>
+    <string name="settings_on_device_local">Local</string>
+    <string name="settings_on_device_downloading">Downloading %1$d%%</string>
+    <string name="settings_on_device_downloading_unknown">Downloading</string>
     <string name="settings_post_processing_settings">Post-processing Settings</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -17,9 +17,11 @@ TRANSCRIPTION_MODEL=groq/whisper-large-v3-turbo
 # Use `litert` only with converted `.tflite` files in parakeetpack.
 PARAKEET_RUNTIME=
 
-# Optional sideload APK mode. When true, the APK embeds Parakeet weights and
-# copies them from APK assets to app storage on first local transcription.
+# Optional sideload APK mode for local debugging only. Release APKs keep this
+# false and download Parakeet weights on demand from inside the app.
 PACKAGE_OFFLINE_MODELS=false
+PARAKEET_ON_DEMAND_MODEL_URL=https://github.com/writingmate/aidictation/releases/download/android-parakeet-assets-v3/AIDictation-Parakeet-Assets-v3.zip
+PARAKEET_ON_DEMAND_MODEL_SHA256=b0ba6367c660c9fb5b9cc711ae35dc4bb96b8ebee199a58a7e8b680acc169824
 
 # Writingmate post-processing configuration
 # Matches AIDictationPostProcessing* in the macOS Secrets.plist.


### PR DESCRIPTION
## Summary
- keeps Android release APKs on Writingmate cloud transcription by default
- adds a Settings switch for on-device Parakeet that downloads the checked model archive only when enabled
- changes the release workflow so APKs are small while Play AABs can still include the on-demand Parakeet asset pack

## Verification
- `./gradlew :app:compileDebugKotlin --stacktrace`
- `./gradlew :app:testDebugUnitTest --stacktrace`
- `./gradlew :app:lintDebug --stacktrace`
- `./gradlew :app:assembleDebug --stacktrace`
- inspected `app-debug.apk`; no Parakeet ONNX/vocab assets are packaged

## Not tested
- live 640 MB in-app model download on physical device