### PR TITLE
Fix Android release auth configuration

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -60,6 +60,13 @@ jobs:
       AIDICTATION_POST_PROCESSING_KEY: ${{ secrets.AIDICTATION_POST_PROCESSING_KEY }}
       AIDICTATION_POST_PROCESSING_ENDPOINT: ${{ secrets.AIDICTATION_POST_PROCESSING_ENDPOINT }}
       AIDICTATION_POST_PROCESSING_MODEL: ${{ secrets.AIDICTATION_POST_PROCESSING_MODEL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      AUTH_WEB_URL: ${{ secrets.AUTH_WEB_URL }}
+      STRIPE_PAYMENT_LINK: ${{ secrets.STRIPE_PAYMENT_LINK }}
+      STRIPE_PAYMENT_LINK_MONTHLY: ${{ secrets.STRIPE_PAYMENT_LINK_MONTHLY }}
+      STRIPE_PAYMENT_LINK_ANNUAL: ${{ secrets.STRIPE_PAYMENT_LINK_ANNUAL }}
+      STRIPE_PAYMENT_LINK_LIFETIME: ${{ secrets.STRIPE_PAYMENT_LINK_LIFETIME }}
       # Shared macOS Secrets.plist (base64). If set, the Writingmate key is
       # extracted from CustomTranscriptionKey so both platforms share one secret.
       SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
@@ -93,14 +100,14 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: Resolve Writingmate creds from SECRETS_PLIST
+      - name: Resolve app config from SECRETS_PLIST
         if: env.SECRETS_PLIST != ''
         shell: bash
         run: |
           # The macOS release workflow ships a base64-encoded Secrets.plist that
-          # holds the Writingmate transcription key, endpoint, and model. Reuse
-          # it here so a single repo secret drives both platforms. Only fills
-          # fields that weren't set via dedicated Android secrets.
+          # holds the shared Writingmate, Supabase, auth, and Stripe config.
+          # Reuse it here so a single repo secret drives both platforms. Only
+          # fills fields that weren't set via dedicated Android secrets.
           echo "$SECRETS_PLIST" | base64 -d > /tmp/secrets.plist
           extract() {
             python3 - "$1" <<'PY'
@@ -115,6 +122,13 @@ jobs:
           pp_key=$(extract AIDictationPostProcessingKey)
           pp_endpoint=$(extract AIDictationPostProcessingEndpoint)
           pp_model=$(extract AIDictationPostProcessingModel)
+          supabase_url=$(extract SUPABASE_URL)
+          supabase_anon_key=$(extract SUPABASE_ANON_KEY)
+          auth_web_url=$(extract AUTH_WEB_URL)
+          stripe_link=$(extract STRIPE_PAYMENT_LINK)
+          stripe_monthly=$(extract STRIPE_PAYMENT_LINK_MONTHLY)
+          stripe_annual=$(extract STRIPE_PAYMENT_LINK_ANNUAL)
+          stripe_lifetime=$(extract STRIPE_PAYMENT_LINK_LIFETIME)
           if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
             echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
           fi
@@ -132,6 +146,27 @@ jobs:
           fi
           if [ -z "$AIDICTATION_POST_PROCESSING_MODEL" ] && [ -n "$pp_model" ]; then
             echo "AIDICTATION_POST_PROCESSING_MODEL=$pp_model" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_URL" ] && [ -n "$supabase_url" ]; then
+            echo "SUPABASE_URL=$supabase_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_ANON_KEY" ] && [ -n "$supabase_anon_key" ]; then
+            echo "SUPABASE_ANON_KEY=$supabase_anon_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AUTH_WEB_URL" ] && [ -n "$auth_web_url" ]; then
+            echo "AUTH_WEB_URL=$auth_web_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK" ] && [ -n "$stripe_link" ]; then
+            echo "STRIPE_PAYMENT_LINK=$stripe_link" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_MONTHLY" ] && [ -n "$stripe_monthly" ]; then
+            echo "STRIPE_PAYMENT_LINK_MONTHLY=$stripe_monthly" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_ANNUAL" ] && [ -n "$stripe_annual" ]; then
+            echo "STRIPE_PAYMENT_LINK_ANNUAL=$stripe_annual" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_LIFETIME" ] && [ -n "$stripe_lifetime" ]; then
+            echo "STRIPE_PAYMENT_LINK_LIFETIME=$stripe_lifetime" >> "$GITHUB_ENV"
           fi
           rm /tmp/secrets.plist
 
@@ -156,6 +191,13 @@ jobs:
           AIDICTATION_POST_PROCESSING_KEY=${AIDICTATION_POST_PROCESSING_KEY}
           AIDICTATION_POST_PROCESSING_ENDPOINT=${AIDICTATION_POST_PROCESSING_ENDPOINT:-https://writingmate.ai/api/openai/v1/chat/completions}
           AIDICTATION_POST_PROCESSING_MODEL=${AIDICTATION_POST_PROCESSING_MODEL:-openai/gpt-oss-20b}
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          AUTH_WEB_URL=${AUTH_WEB_URL:-https://voicesinmyhead.co/auth}
+          STRIPE_PAYMENT_LINK=${STRIPE_PAYMENT_LINK}
+          STRIPE_PAYMENT_LINK_MONTHLY=${STRIPE_PAYMENT_LINK_MONTHLY}
+          STRIPE_PAYMENT_LINK_ANNUAL=${STRIPE_PAYMENT_LINK_ANNUAL}
+          STRIPE_PAYMENT_LINK_LIFETIME=${STRIPE_PAYMENT_LINK_LIFETIME}
           KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
           KEY_ALIAS=${KEY_ALIAS:-release}
           KEY_PASSWORD=${KEY_PASSWORD}
@@ -198,6 +240,13 @@ jobs:
       AIDICTATION_POST_PROCESSING_KEY: ${{ secrets.AIDICTATION_POST_PROCESSING_KEY }}
       AIDICTATION_POST_PROCESSING_ENDPOINT: ${{ secrets.AIDICTATION_POST_PROCESSING_ENDPOINT }}
       AIDICTATION_POST_PROCESSING_MODEL: ${{ secrets.AIDICTATION_POST_PROCESSING_MODEL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      AUTH_WEB_URL: ${{ secrets.AUTH_WEB_URL }}
+      STRIPE_PAYMENT_LINK: ${{ secrets.STRIPE_PAYMENT_LINK }}
+      STRIPE_PAYMENT_LINK_MONTHLY: ${{ secrets.STRIPE_PAYMENT_LINK_MONTHLY }}
+      STRIPE_PAYMENT_LINK_ANNUAL: ${{ secrets.STRIPE_PAYMENT_LINK_ANNUAL }}
+      STRIPE_PAYMENT_LINK_LIFETIME: ${{ secrets.STRIPE_PAYMENT_LINK_LIFETIME }}
       SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
       KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -278,6 +327,13 @@ jobs:
           echo "AIDICTATION_POST_PROCESSING_KEY:      $(present "$AIDICTATION_POST_PROCESSING_KEY")"
           echo "AIDICTATION_POST_PROCESSING_ENDPOINT: $(present "$AIDICTATION_POST_PROCESSING_ENDPOINT")"
           echo "AIDICTATION_POST_PROCESSING_MODEL:    $(present "$AIDICTATION_POST_PROCESSING_MODEL")"
+          echo "SUPABASE_URL:            $(present "$SUPABASE_URL")"
+          echo "SUPABASE_ANON_KEY:       $(present "$SUPABASE_ANON_KEY")"
+          echo "AUTH_WEB_URL:            $(present "$AUTH_WEB_URL")"
+          echo "STRIPE_PAYMENT_LINK:     $(present "$STRIPE_PAYMENT_LINK")"
+          echo "STRIPE_PAYMENT_LINK_MONTHLY:  $(present "$STRIPE_PAYMENT_LINK_MONTHLY")"
+          echo "STRIPE_PAYMENT_LINK_ANNUAL:   $(present "$STRIPE_PAYMENT_LINK_ANNUAL")"
+          echo "STRIPE_PAYMENT_LINK_LIFETIME: $(present "$STRIPE_PAYMENT_LINK_LIFETIME")"
           echo "SECRETS_PLIST:             $(present "$SECRETS_PLIST")"
           echo "ANDROID_KEYSTORE_BASE64:   $(present "$ANDROID_KEYSTORE_BASE64")"
           echo "ANDROID_KEYSTORE_PASSWORD: $(present "$KEYSTORE_PASSWORD")"
@@ -308,7 +364,7 @@ jobs:
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > release.keystore
 
-      - name: Resolve Writingmate creds from SECRETS_PLIST
+      - name: Resolve app config from SECRETS_PLIST
         if: env.SECRETS_PLIST != ''
         shell: bash
         run: |
@@ -326,6 +382,13 @@ jobs:
           pp_key=$(extract AIDictationPostProcessingKey)
           pp_endpoint=$(extract AIDictationPostProcessingEndpoint)
           pp_model=$(extract AIDictationPostProcessingModel)
+          supabase_url=$(extract SUPABASE_URL)
+          supabase_anon_key=$(extract SUPABASE_ANON_KEY)
+          auth_web_url=$(extract AUTH_WEB_URL)
+          stripe_link=$(extract STRIPE_PAYMENT_LINK)
+          stripe_monthly=$(extract STRIPE_PAYMENT_LINK_MONTHLY)
+          stripe_annual=$(extract STRIPE_PAYMENT_LINK_ANNUAL)
+          stripe_lifetime=$(extract STRIPE_PAYMENT_LINK_LIFETIME)
           if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
             echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
           fi
@@ -343,6 +406,27 @@ jobs:
           fi
           if [ -z "$AIDICTATION_POST_PROCESSING_MODEL" ] && [ -n "$pp_model" ]; then
             echo "AIDICTATION_POST_PROCESSING_MODEL=$pp_model" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_URL" ] && [ -n "$supabase_url" ]; then
+            echo "SUPABASE_URL=$supabase_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_ANON_KEY" ] && [ -n "$supabase_anon_key" ]; then
+            echo "SUPABASE_ANON_KEY=$supabase_anon_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AUTH_WEB_URL" ] && [ -n "$auth_web_url" ]; then
+            echo "AUTH_WEB_URL=$auth_web_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK" ] && [ -n "$stripe_link" ]; then
+            echo "STRIPE_PAYMENT_LINK=$stripe_link" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_MONTHLY" ] && [ -n "$stripe_monthly" ]; then
+            echo "STRIPE_PAYMENT_LINK_MONTHLY=$stripe_monthly" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_ANNUAL" ] && [ -n "$stripe_annual" ]; then
+            echo "STRIPE_PAYMENT_LINK_ANNUAL=$stripe_annual" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_LIFETIME" ] && [ -n "$stripe_lifetime" ]; then
+            echo "STRIPE_PAYMENT_LINK_LIFETIME=$stripe_lifetime" >> "$GITHUB_ENV"
           fi
           rm /tmp/secrets.plist
 
@@ -367,6 +451,13 @@ jobs:
           AIDICTATION_POST_PROCESSING_KEY=${AIDICTATION_POST_PROCESSING_KEY}
           AIDICTATION_POST_PROCESSING_ENDPOINT=${AIDICTATION_POST_PROCESSING_ENDPOINT:-https://writingmate.ai/api/openai/v1/chat/completions}
           AIDICTATION_POST_PROCESSING_MODEL=${AIDICTATION_POST_PROCESSING_MODEL:-openai/gpt-oss-20b}
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          AUTH_WEB_URL=${AUTH_WEB_URL:-https://voicesinmyhead.co/auth}
+          STRIPE_PAYMENT_LINK=${STRIPE_PAYMENT_LINK}
+          STRIPE_PAYMENT_LINK_MONTHLY=${STRIPE_PAYMENT_LINK_MONTHLY}
+          STRIPE_PAYMENT_LINK_ANNUAL=${STRIPE_PAYMENT_LINK_ANNUAL}
+          STRIPE_PAYMENT_LINK_LIFETIME=${STRIPE_PAYMENT_LINK_LIFETIME}
           KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
           KEY_ALIAS=${KEY_ALIAS:-release}
           KEY_PASSWORD=${KEY_PASSWORD}

--- a/.github/workflows/android-play-dev.yml
+++ b/.github/workflows/android-play-dev.yml
@@ -64,6 +64,13 @@ jobs:
       AIDICTATION_POST_PROCESSING_KEY: ${{ secrets.AIDICTATION_POST_PROCESSING_KEY }}
       AIDICTATION_POST_PROCESSING_ENDPOINT: ${{ secrets.AIDICTATION_POST_PROCESSING_ENDPOINT }}
       AIDICTATION_POST_PROCESSING_MODEL: ${{ secrets.AIDICTATION_POST_PROCESSING_MODEL }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      AUTH_WEB_URL: ${{ secrets.AUTH_WEB_URL }}
+      STRIPE_PAYMENT_LINK: ${{ secrets.STRIPE_PAYMENT_LINK }}
+      STRIPE_PAYMENT_LINK_MONTHLY: ${{ secrets.STRIPE_PAYMENT_LINK_MONTHLY }}
+      STRIPE_PAYMENT_LINK_ANNUAL: ${{ secrets.STRIPE_PAYMENT_LINK_ANNUAL }}
+      STRIPE_PAYMENT_LINK_LIFETIME: ${{ secrets.STRIPE_PAYMENT_LINK_LIFETIME }}
       SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
 
       # Release signing
@@ -119,7 +126,7 @@ jobs:
           python3 -m json.tool "$credentials_path" >/dev/null
           echo "PLAY_SERVICE_ACCOUNT_CREDENTIALS=$credentials_path" >> "$GITHUB_ENV"
 
-      - name: Resolve Writingmate creds from SECRETS_PLIST
+      - name: Resolve app config from SECRETS_PLIST
         if: env.SECRETS_PLIST != ''
         shell: bash
         run: |
@@ -137,6 +144,13 @@ jobs:
           pp_key=$(extract AIDictationPostProcessingKey)
           pp_endpoint=$(extract AIDictationPostProcessingEndpoint)
           pp_model=$(extract AIDictationPostProcessingModel)
+          supabase_url=$(extract SUPABASE_URL)
+          supabase_anon_key=$(extract SUPABASE_ANON_KEY)
+          auth_web_url=$(extract AUTH_WEB_URL)
+          stripe_link=$(extract STRIPE_PAYMENT_LINK)
+          stripe_monthly=$(extract STRIPE_PAYMENT_LINK_MONTHLY)
+          stripe_annual=$(extract STRIPE_PAYMENT_LINK_ANNUAL)
+          stripe_lifetime=$(extract STRIPE_PAYMENT_LINK_LIFETIME)
           if [ -z "$TRANSCRIPTION_API_KEY" ] && [ -n "$wm_key" ]; then
             echo "TRANSCRIPTION_API_KEY=$wm_key" >> "$GITHUB_ENV"
           fi
@@ -154,6 +168,27 @@ jobs:
           fi
           if [ -z "$AIDICTATION_POST_PROCESSING_MODEL" ] && [ -n "$pp_model" ]; then
             echo "AIDICTATION_POST_PROCESSING_MODEL=$pp_model" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_URL" ] && [ -n "$supabase_url" ]; then
+            echo "SUPABASE_URL=$supabase_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$SUPABASE_ANON_KEY" ] && [ -n "$supabase_anon_key" ]; then
+            echo "SUPABASE_ANON_KEY=$supabase_anon_key" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$AUTH_WEB_URL" ] && [ -n "$auth_web_url" ]; then
+            echo "AUTH_WEB_URL=$auth_web_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK" ] && [ -n "$stripe_link" ]; then
+            echo "STRIPE_PAYMENT_LINK=$stripe_link" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_MONTHLY" ] && [ -n "$stripe_monthly" ]; then
+            echo "STRIPE_PAYMENT_LINK_MONTHLY=$stripe_monthly" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_ANNUAL" ] && [ -n "$stripe_annual" ]; then
+            echo "STRIPE_PAYMENT_LINK_ANNUAL=$stripe_annual" >> "$GITHUB_ENV"
+          fi
+          if [ -z "$STRIPE_PAYMENT_LINK_LIFETIME" ] && [ -n "$stripe_lifetime" ]; then
+            echo "STRIPE_PAYMENT_LINK_LIFETIME=$stripe_lifetime" >> "$GITHUB_ENV"
           fi
           rm /tmp/secrets.plist
 
@@ -193,6 +228,13 @@ jobs:
           AIDICTATION_POST_PROCESSING_KEY=${AIDICTATION_POST_PROCESSING_KEY}
           AIDICTATION_POST_PROCESSING_ENDPOINT=${AIDICTATION_POST_PROCESSING_ENDPOINT:-https://writingmate.ai/api/openai/v1/chat/completions}
           AIDICTATION_POST_PROCESSING_MODEL=${AIDICTATION_POST_PROCESSING_MODEL:-openai/gpt-oss-20b}
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          AUTH_WEB_URL=${AUTH_WEB_URL:-https://voicesinmyhead.co/auth}
+          STRIPE_PAYMENT_LINK=${STRIPE_PAYMENT_LINK}
+          STRIPE_PAYMENT_LINK_MONTHLY=${STRIPE_PAYMENT_LINK_MONTHLY}
+          STRIPE_PAYMENT_LINK_ANNUAL=${STRIPE_PAYMENT_LINK_ANNUAL}
+          STRIPE_PAYMENT_LINK_LIFETIME=${STRIPE_PAYMENT_LINK_LIFETIME}
           KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
           KEY_ALIAS=${KEY_ALIAS:-release}
           KEY_PASSWORD=${KEY_PASSWORD}

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -41,7 +41,14 @@ runs, matching the local-developer layout described in
 | `AIDICTATION_POST_PROCESSING_KEY` | Writingmate post-processing key for suggestions, commands, and cleanup. |
 | `AIDICTATION_POST_PROCESSING_ENDPOINT` | Optional override. Defaults to `https://writingmate.ai/api/openai/v1/chat/completions`. |
 | `AIDICTATION_POST_PROCESSING_MODEL` | Optional override. Defaults to `openai/gpt-oss-20b`. |
-| `SECRETS_PLIST` | Optional. Base64-encoded Mac `Secrets.plist` — the same secret used by `release-macos.yml`. When present, the workflow extracts `CustomTranscription*` and `AIDictationPostProcessing*` so both platforms ship with the same Writingmate credentials. |
+| `SUPABASE_URL` | Optional dedicated Android override for Supabase auth/profile requests. |
+| `SUPABASE_ANON_KEY` | Optional dedicated Android override for the Supabase anon key. |
+| `AUTH_WEB_URL` | Optional dedicated Android override for the hosted auth page. Defaults to `https://voicesinmyhead.co/auth`. |
+| `STRIPE_PAYMENT_LINK` | Optional default Stripe checkout link. |
+| `STRIPE_PAYMENT_LINK_MONTHLY` | Optional monthly checkout link. |
+| `STRIPE_PAYMENT_LINK_ANNUAL` | Optional annual checkout link. |
+| `STRIPE_PAYMENT_LINK_LIFETIME` | Optional lifetime checkout link. |
+| `SECRETS_PLIST` | Optional. Base64-encoded Mac `Secrets.plist` — the same secret used by `release-macos.yml`. When present, the workflow extracts `CustomTranscription*`, `AIDictationPostProcessing*`, `SUPABASE_*`, `AUTH_WEB_URL`, and `STRIPE_PAYMENT_LINK*` so both platforms ship with the same Writingmate auth and billing configuration. |
 
 ### Release signing (only needed for the `release` job on `main`)
 
@@ -70,11 +77,15 @@ Google Cloud project, and grant the service account release access to this app.
 # Either: dedicated Android secret
 gh secret set TRANSCRIPTION_API_KEY --repo writingmate/aidictation
 
-# Or: reuse the Mac Secrets.plist (base64-encoded) — Writingmate
-# transcription and post-processing keys are pulled automatically.
+# Or: reuse the Mac Secrets.plist (base64-encoded) — Writingmate,
+# Supabase auth, and Stripe values are pulled automatically.
 base64 -w0 Secrets.plist | gh secret set SECRETS_PLIST --repo writingmate/aidictation
 
 gh secret set AIDICTATION_POST_PROCESSING_KEY --repo writingmate/aidictation
+gh secret set SUPABASE_URL --repo writingmate/aidictation
+gh secret set SUPABASE_ANON_KEY --repo writingmate/aidictation
+gh secret set AUTH_WEB_URL --repo writingmate/aidictation
+gh secret set STRIPE_PAYMENT_LINK_MONTHLY --repo writingmate/aidictation
 base64 -w0 release.keystore | gh secret set ANDROID_KEYSTORE_BASE64 --repo writingmate/aidictation
 gh secret set ANDROID_KEYSTORE_PASSWORD --repo writingmate/aidictation
 gh secret set ANDROID_KEY_ALIAS         --repo writingmate/aidictation

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -50,8 +50,8 @@ android {
         applicationId = "com.whispermate.aidictation"
         minSdk = 26
         targetSdk = 35
-        versionCode = configValue("VERSION_CODE", "7").toInt()
-        versionName = configValue("VERSION_NAME", "0.0.7")
+        versionCode = configValue("VERSION_CODE", "8").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.8")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -69,20 +69,20 @@ android {
 
         // Writingmate post-processing, matching the macOS app's
         // AIDictationPostProcessing* secrets.
-        buildConfigField("String", "AIDICTATION_POST_PROCESSING_KEY", "\"${localProperties.getProperty("AIDICTATION_POST_PROCESSING_KEY", "")}\"")
-        buildConfigField("String", "AIDICTATION_POST_PROCESSING_ENDPOINT", "\"${localProperties.getProperty("AIDICTATION_POST_PROCESSING_ENDPOINT", "https://writingmate.ai/api/openai/v1/chat/completions")}\"")
-        buildConfigField("String", "AIDICTATION_POST_PROCESSING_MODEL", "\"${localProperties.getProperty("AIDICTATION_POST_PROCESSING_MODEL", "openai/gpt-oss-20b")}\"")
+        buildConfigField("String", "AIDICTATION_POST_PROCESSING_KEY", "\"${configValue("AIDICTATION_POST_PROCESSING_KEY", "")}\"")
+        buildConfigField("String", "AIDICTATION_POST_PROCESSING_ENDPOINT", "\"${configValue("AIDICTATION_POST_PROCESSING_ENDPOINT", "https://writingmate.ai/api/openai/v1/chat/completions")}\"")
+        buildConfigField("String", "AIDICTATION_POST_PROCESSING_MODEL", "\"${configValue("AIDICTATION_POST_PROCESSING_MODEL", "openai/gpt-oss-20b")}\"")
 
         // Auth, usage, and purchase links. Android uses the same web auth and
         // Stripe checkout flow as the macOS app; empty values leave those entry
         // points disabled in local builds.
-        buildConfigField("String", "SUPABASE_URL", "\"${localProperties.getProperty("SUPABASE_URL", "")}\"")
-        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${localProperties.getProperty("SUPABASE_ANON_KEY", "")}\"")
-        buildConfigField("String", "AUTH_WEB_URL", "\"${localProperties.getProperty("AUTH_WEB_URL", "https://voicesinmyhead.co/auth")}\"")
-        buildConfigField("String", "STRIPE_PAYMENT_LINK", "\"${localProperties.getProperty("STRIPE_PAYMENT_LINK", "")}\"")
-        buildConfigField("String", "STRIPE_PAYMENT_LINK_MONTHLY", "\"${localProperties.getProperty("STRIPE_PAYMENT_LINK_MONTHLY", localProperties.getProperty("STRIPE_PAYMENT_LINK", ""))}\"")
-        buildConfigField("String", "STRIPE_PAYMENT_LINK_ANNUAL", "\"${localProperties.getProperty("STRIPE_PAYMENT_LINK_ANNUAL", "")}\"")
-        buildConfigField("String", "STRIPE_PAYMENT_LINK_LIFETIME", "\"${localProperties.getProperty("STRIPE_PAYMENT_LINK_LIFETIME", "")}\"")
+        buildConfigField("String", "SUPABASE_URL", "\"${configValue("SUPABASE_URL", "")}\"")
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${configValue("SUPABASE_ANON_KEY", "")}\"")
+        buildConfigField("String", "AUTH_WEB_URL", "\"${configValue("AUTH_WEB_URL", "https://voicesinmyhead.co/auth")}\"")
+        buildConfigField("String", "STRIPE_PAYMENT_LINK", "\"${configValue("STRIPE_PAYMENT_LINK", "")}\"")
+        buildConfigField("String", "STRIPE_PAYMENT_LINK_MONTHLY", "\"${configValue("STRIPE_PAYMENT_LINK_MONTHLY", configValue("STRIPE_PAYMENT_LINK", ""))}\"")
+        buildConfigField("String", "STRIPE_PAYMENT_LINK_ANNUAL", "\"${configValue("STRIPE_PAYMENT_LINK_ANNUAL", "")}\"")
+        buildConfigField("String", "STRIPE_PAYMENT_LINK_LIFETIME", "\"${configValue("STRIPE_PAYMENT_LINK_LIFETIME", "")}\"")
     }
 
     buildTypes {

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -5,8 +5,8 @@
 sdk.dir=/path/to/Android/Sdk
 
 # Optional local version overrides. CI uses these for Play dev releases.
-VERSION_CODE=7
-VERSION_NAME=0.0.7
+VERSION_CODE=8
+VERSION_NAME=0.0.8
 
 # Writingmate transcription configuration
 TRANSCRIPTION_API_KEY=your_writingmate_transcription_key_here


### PR DESCRIPTION
## Summary
- carry macOS Secrets.plist auth and Stripe config into Android GitHub Release and Play dev builds
- let Gradle read auth/post-processing config from env or Gradle properties, not only local.properties
- bump Android release to 0.0.8 so the fixed artifact publishes under a fresh tag

## Verification
- ruby YAML parse for Android workflows
- ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest with auth supplied via env
- generated BuildConfig contains version 0.0.8 and nonblank auth fields
- ./gradlew :app:lintDebug

## Note
Refreshed the repo SECRETS_PLIST from the working macOS Secrets.plist so Android CI can extract SUPABASE_URL, SUPABASE_ANON_KEY, AUTH_WEB_URL, and Stripe links.