### PR TITLE
Make Android silence auto-stop optional

### DIFF
--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -50,8 +50,8 @@ android {
         applicationId = "com.whispermate.aidictation"
         minSdk = 26
         targetSdk = 35
-        versionCode = configValue("VERSION_CODE", "9").toInt()
-        versionName = configValue("VERSION_NAME", "0.0.9")
+        versionCode = configValue("VERSION_CODE", "10").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.10")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/AppPreferences.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/AppPreferences.kt
@@ -44,6 +44,7 @@ class AppPreferences @Inject constructor(
         val MULTILINGUAL_ENABLED = booleanPreferencesKey("multilingual_enabled")
         val POST_PROCESSING_ENABLED = booleanPreferencesKey("post_processing_enabled")
         val ON_DEVICE_TRANSCRIPTION_ENABLED = booleanPreferencesKey("on_device_transcription_enabled")
+        val AUTO_STOP_ON_SILENCE_ENABLED = booleanPreferencesKey("auto_stop_on_silence_enabled")
         val LOCAL_MONTHLY_WORD_COUNT = intPreferencesKey("local_monthly_word_count")
         val LOCAL_WORD_COUNT_RESET_AT = longPreferencesKey("local_word_count_reset_at")
     }
@@ -99,6 +100,16 @@ class AppPreferences @Inject constructor(
     suspend fun setOnDeviceTranscriptionEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[Keys.ON_DEVICE_TRANSCRIPTION_ENABLED] = enabled
+        }
+    }
+
+    val autoStopOnSilenceEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[Keys.AUTO_STOP_ON_SILENCE_ENABLED] ?: false
+    }
+
+    suspend fun setAutoStopOnSilenceEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.AUTO_STOP_ON_SILENCE_ENABLED] = enabled
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
@@ -159,6 +159,7 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
     private var recordingMode: RecordingMode = RecordingMode.Dictation
     private var audioRecorder: AudioRecorder? = null
     private var vadJob: Job? = null
+    private var autoStopOnSilenceEnabled = false
     private var volumeShortcutNoSpeechJob: Job? = null
     private var recordingStartedByVolumeShortcut = false
     private var bubbleAnimationJob: Job? = null
@@ -192,6 +193,12 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+
+        serviceScope.launch {
+            appPreferences.autoStopOnSilenceEnabled.collectLatest { enabled ->
+                autoStopOnSilenceEnabled = enabled
+            }
+        }
 
         prewarmOnDeviceTranscriber()
         refreshOverlayVisibility(null)
@@ -1330,7 +1337,10 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
             return
         }
 
-        val recorder = AudioRecorder(this, enableVAD = true)
+        val recorder = AudioRecorder(
+            context = this,
+            autoStopOnSilenceEnabled = autoStopOnSilenceEnabled
+        )
         val file = recorder.start()
         if (file == null) {
             if (mode == RecordingMode.RewriteInstruction) {
@@ -1365,6 +1375,7 @@ class OverlayDictationAccessibilityService : AccessibilityService() {
 
     private fun scheduleVolumeShortcutNoSpeechTimeout(recorder: AudioRecorder) {
         if (!recordingStartedByVolumeShortcut) return
+        if (!autoStopOnSilenceEnabled) return
 
         volumeShortcutNoSpeechJob = serviceScope.launch {
             delay(VOLUME_SHORTCUT_NO_SPEECH_TIMEOUT_MS)

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -80,17 +81,25 @@ fun MainScreen(
     val multilingualEnabled by viewModel.multilingualEnabled.collectAsState()
     val postProcessingEnabled by viewModel.postProcessingEnabled.collectAsState()
     val onDeviceTranscriptionEnabled by viewModel.onDeviceTranscriptionEnabled.collectAsState()
+    val autoStopOnSilenceEnabled by viewModel.autoStopOnSilenceEnabled.collectAsState()
     val onDeviceModelState by viewModel.onDeviceModelState.collectAsState()
     val usageStatus by viewModel.usageStatus.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentRecordingState by rememberUpdatedState(recordingState)
+    val currentAutoStopOnSilenceEnabled by rememberUpdatedState(autoStopOnSilenceEnabled)
 
     // Audio recorder state
     var audioRecorder by remember { mutableStateOf<AudioRecorder?>(null) }
     val audioLevel = audioRecorder?.audioLevel?.collectAsState()?.value ?: 0f
     val frequencyBands = audioRecorder?.frequencyBands?.collectAsState()?.value
     val shouldAutoStop = audioRecorder?.shouldAutoStop?.collectAsState()?.value ?: false
+
+    fun createAudioRecorder() = AudioRecorder(
+        context = context,
+        autoStopOnSilenceEnabled = currentAutoStopOnSilenceEnabled
+    )
 
     // Show error in snackbar
     LaunchedEffect(error) {
@@ -103,8 +112,8 @@ fun MainScreen(
     // Handle external start recording trigger
     LaunchedEffect(Unit) {
         viewModel.startRecordingTrigger.collect {
-            if (recordingState == RecordingState.Idle) {
-                val recorder = AudioRecorder(context)
+            if (currentRecordingState == RecordingState.Idle) {
+                val recorder = createAudioRecorder()
                 audioRecorder = recorder
                 val file = recorder.start()
                 if (file != null) {
@@ -119,7 +128,7 @@ fun MainScreen(
     // Handle initial start recording from navigation
     LaunchedEffect(shouldStartRecording) {
         if (shouldStartRecording && recordingState == RecordingState.Idle) {
-            val recorder = AudioRecorder(context)
+            val recorder = createAudioRecorder()
             audioRecorder = recorder
             val file = recorder.start()
             if (file != null) {
@@ -152,7 +161,7 @@ fun MainScreen(
     fun toggleRecording() {
         when (recordingState) {
             RecordingState.Idle -> {
-                val recorder = AudioRecorder(context)
+                val recorder = createAudioRecorder()
                 audioRecorder = recorder
                 val file = recorder.start()
                 if (file != null) {
@@ -233,6 +242,8 @@ fun MainScreen(
                 onDeviceTranscriptionEnabled = onDeviceTranscriptionEnabled,
                 onDeviceModelState = onDeviceModelState,
                 onOnDeviceTranscriptionToggled = { viewModel.setOnDeviceTranscriptionEnabled(it) },
+                autoStopOnSilenceEnabled = autoStopOnSilenceEnabled,
+                onAutoStopOnSilenceToggled = { viewModel.setAutoStopOnSilenceEnabled(it) },
                 usageStatus = usageStatus,
                 onSignIn = { viewModel.openLogin() },
                 onSignOut = { viewModel.signOut() },

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/main/MainViewModel.kt
@@ -65,6 +65,9 @@ class MainViewModel @Inject constructor(
     val onDeviceTranscriptionEnabled: StateFlow<Boolean> = appPreferences.onDeviceTranscriptionEnabled
         .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
+    val autoStopOnSilenceEnabled: StateFlow<Boolean> = appPreferences.autoStopOnSilenceEnabled
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
+
     val usageStatus = subscriptionRepository.usageStatus
 
     private val _onDeviceModelState = MutableStateFlow(OnDeviceModelUiState())
@@ -83,6 +86,12 @@ class MainViewModel @Inject constructor(
     fun setPostProcessingEnabled(enabled: Boolean) {
         viewModelScope.launch {
             appPreferences.setPostProcessingEnabled(enabled)
+        }
+    }
+
+    fun setAutoStopOnSilenceEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            appPreferences.setAutoStopOnSilenceEnabled(enabled)
         }
     }
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/SettingsScreen.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/ui/screens/settings/SettingsScreen.kt
@@ -79,6 +79,8 @@ fun SettingsScreen(
     onDeviceTranscriptionEnabled: Boolean = false,
     onDeviceModelState: OnDeviceModelUiState = OnDeviceModelUiState(),
     onOnDeviceTranscriptionToggled: (Boolean) -> Unit = {},
+    autoStopOnSilenceEnabled: Boolean = false,
+    onAutoStopOnSilenceToggled: (Boolean) -> Unit = {},
     usageStatus: UsageStatus,
     onSignIn: () -> Unit,
     onSignOut: () -> Unit,
@@ -245,6 +247,19 @@ fun SettingsScreen(
                 enabled = onDeviceTranscriptionEnabled,
                 state = onDeviceModelState,
                 onToggle = onOnDeviceTranscriptionToggled
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
+            SettingsItem(
+                icon = Icons.Default.Mic,
+                title = stringResource(R.string.settings_auto_stop_on_silence),
+                trailingContent = {
+                    Switch(
+                        checked = autoStopOnSilenceEnabled,
+                        onCheckedChange = onAutoStopOnSilenceToggled
+                    )
+                }
             )
 
             HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/util/AudioRecorder.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/util/AudioRecorder.kt
@@ -20,7 +20,7 @@ import kotlin.math.pow
 
 class AudioRecorder(
     private val context: Context,
-    private val enableVAD: Boolean = true
+    private val autoStopOnSilenceEnabled: Boolean = false
 ) {
     companion object {
         private const val TAG = "AudioRecorder"
@@ -48,7 +48,7 @@ class AudioRecorder(
     private var speechDetected = false
     private var speechActive = false
     private var silenceStartTime: Long = 0
-    private val silenceDurationMs = 1500L // 1.5 seconds of silence to auto-stop
+    private val silenceDurationMs = 1500L
     private var noiseFloor: Float = BASE_NOISE_FLOOR
     private var speechStartThreshold: Float = MIN_START_THRESHOLD
     private var speechStopThreshold: Float = MIN_STOP_THRESHOLD
@@ -162,7 +162,7 @@ class AudioRecorder(
                             if (belowStop) {
                                 if (silenceStartTime == 0L) {
                                     silenceStartTime = now
-                                } else if (enableVAD && now - silenceStartTime > silenceDurationMs) {
+                                } else if (autoStopOnSilenceEnabled && now - silenceStartTime > silenceDurationMs) {
                                     _shouldAutoStop.value = true
                                 }
                             } else {

--- a/AIDictationAndroid/app/src/main/res/values/strings.xml
+++ b/AIDictationAndroid/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="settings_on_device_local">Local</string>
     <string name="settings_on_device_downloading">Downloading %1$d%%</string>
     <string name="settings_on_device_downloading_unknown">Downloading</string>
+    <string name="settings_auto_stop_on_silence">Auto-stop on silence</string>
     <string name="settings_post_processing_settings">Post-processing Settings</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -5,8 +5,8 @@
 sdk.dir=/path/to/Android/Sdk
 
 # Optional local version overrides. CI uses these for Play dev releases.
-VERSION_CODE=9
-VERSION_NAME=0.0.9
+VERSION_CODE=10
+VERSION_NAME=0.0.10
 
 # Writingmate transcription configuration
 TRANSCRIPTION_API_KEY=your_writingmate_transcription_key_here


### PR DESCRIPTION
## Summary
- default Android recordings to manual stop instead of stopping after silence
- add a Settings toggle for Auto-stop on silence
- apply the setting to the main mic flow, overlay dictation, and Volume Down no-speech timeout
- bump Android to 0.0.10 / versionCode 10

## Verification
- git diff --check
- :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug
- signed CI APK installed successfully on Pixel 10 Pro over 0.0.9
