### PR TITLE
Release Android from main tags only

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -4,34 +4,14 @@ on:
   push:
     branches:
       - main
-      - 'claude/**'
-      - 'codex/**'
     tags:
       - 'android-v[0-9]*.[0-9]*.[0-9]*'
-    paths:
-      - 'AIDictationAndroid/**'
-      - '.github/workflows/android-build.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'AIDictationAndroid/**'
       - '.github/workflows/android-build.yml'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'GitHub Release tag. Defaults to android-v<versionName>.'
-        required: false
-        type: string
-      draft:
-        description: 'Create the GitHub Release as a draft.'
-        required: false
-        default: false
-        type: boolean
-      prerelease:
-        description: 'Mark the GitHub Release as a prerelease.'
-        required: false
-        default: false
-        type: boolean
+      - '.github/workflows/android-play-release.yml'
 
 permissions:
   contents: write
@@ -226,7 +206,7 @@ jobs:
   release:
     name: Release (signed)
     needs: build
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/android-v')))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/android-v')
     runs-on: ubuntu-latest
 
     defaults:
@@ -252,9 +232,6 @@ jobs:
       KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
       ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      RELEASE_DRAFT: ${{ github.event.inputs.draft || 'false' }}
-      RELEASE_PRERELEASE: ${{ github.event.inputs.prerelease || 'false' }}
-      RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag || '' }}
 
     steps:
       - name: Checkout
@@ -262,6 +239,48 @@ jobs:
         with:
           fetch-depth: 0
           lfs: false
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        run: |
+          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p; s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          version_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p; s/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*configValue\("VERSION_CODE", "([0-9]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          if [ -z "$version_name" ] || [ -z "$version_code" ]; then
+            echo "Could not read Android versionName/versionCode from app/build.gradle.kts" >&2
+            exit 1
+          fi
+
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Android releases must be created by pushing an android-v<versionName> tag." >&2
+            exit 1
+          fi
+
+          tag="${GITHUB_REF_NAME}"
+          expected_tag="android-v${version_name}"
+          if [ "$tag" != "$expected_tag" ]; then
+            echo "Tag $tag does not match Android versionName $version_name; expected $expected_tag." >&2
+            exit 1
+          fi
+          tag_sha=$(git rev-list -n 1 "$tag")
+
+          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=$tag_sha" >> "$GITHUB_OUTPUT"
+          echo "title=AIDictation Android ${version_name} (${version_code})" >> "$GITHUB_OUTPUT"
+
+      - name: Guard main release tag
+        env:
+          RELEASE_TAG: ${{ steps.release_meta.outputs.tag }}
+          RELEASE_TAG_SHA: ${{ steps.release_meta.outputs.tag_sha }}
+        run: |
+          git fetch origin main --prune
+          if ! git merge-base --is-ancestor "$RELEASE_TAG_SHA" origin/main; then
+            echo "Release tag $RELEASE_TAG points to $RELEASE_TAG_SHA, which is not on origin/main." >&2
+            echo "Merge to main first, then tag the main commit." >&2
+            exit 1
+          fi
 
       - name: Download Parakeet model assets
         env:
@@ -280,43 +299,6 @@ jobs:
           test -s parakeetpack/src/main/assets/nemo128.onnx
           test -s parakeetpack/src/main/assets/vocab.txt
           test -s parakeetpack/src/main/assets/config.json
-
-      - name: Resolve release metadata
-        id: release_meta
-        shell: bash
-        run: |
-          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p; s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
-          version_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p; s/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*configValue\("VERSION_CODE", "([0-9]+)".*/\1/p' app/build.gradle.kts | head -n 1)
-          if [ -z "$version_name" ] || [ -z "$version_code" ]; then
-            echo "Could not read Android versionName/versionCode from app/build.gradle.kts" >&2
-            exit 1
-          fi
-
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            tag="${GITHUB_REF_NAME}"
-          elif [ -n "$RELEASE_TAG_INPUT" ]; then
-            tag="$RELEASE_TAG_INPUT"
-          else
-            tag="android-v${version_name}"
-          fi
-
-          echo "version_name=$version_name" >> "$GITHUB_OUTPUT"
-          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "title=AIDictation Android ${version_name} (${version_code})" >> "$GITHUB_OUTPUT"
-
-      - name: Guard main release tag
-        env:
-          RELEASE_TAG: ${{ steps.release_meta.outputs.tag }}
-        run: |
-          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
-            tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-            if [ "$tag_sha" != "$GITHUB_SHA" ] && [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
-              echo "Release tag $RELEASE_TAG already points to $tag_sha, not this main merge $GITHUB_SHA." >&2
-              echo "Bump Android versionName/versionCode before merging to main." >&2
-              exit 1
-            fi
-          fi
 
       - name: Report secret presence
         run: |
@@ -511,23 +493,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release_meta.outputs.tag }}
+          RELEASE_TAG_SHA: ${{ steps.release_meta.outputs.tag_sha }}
           RELEASE_TITLE: ${{ steps.release_meta.outputs.title }}
         run: |
-          flags=(--repo "$GITHUB_REPOSITORY")
-          if [ "$RELEASE_DRAFT" = "true" ]; then
-            flags+=(--draft)
-          fi
-          if [ "$RELEASE_PRERELEASE" = "true" ]; then
-            flags+=(--prerelease)
-          fi
-
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" release-artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
             gh release edit "$RELEASE_TAG" --title "$RELEASE_TITLE" --repo "$GITHUB_REPOSITORY"
           else
             gh release create "$RELEASE_TAG" release-artifacts/* \
-              --target "$GITHUB_SHA" \
+              --target "$RELEASE_TAG_SHA" \
               --title "$RELEASE_TITLE" \
               --generate-notes \
-              "${flags[@]}"
+              --repo "$GITHUB_REPOSITORY"
           fi

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -1,35 +1,15 @@
-name: Android Play Dev Release
+name: Android Play Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      track:
-        description: 'Google Play track for the dev release.'
-        required: true
-        default: internal
-        type: choice
-        options:
-          - internal
-          - alpha
-          - beta
-      parakeet_runtime:
-        description: 'Local transcription runtime baked into BuildConfig.'
-        required: true
-        default: onnx
-        type: choice
-        options:
-          - onnx
-          - cloud
-      release_name:
-        description: 'Optional Play release name override.'
-        required: false
-        type: string
+  push:
+    tags:
+      - 'android-v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: read
 
 concurrency:
-  group: android-play-dev-${{ github.ref }}
+  group: android-play-release-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -48,9 +28,9 @@ jobs:
         working-directory: ${{ env.ANDROID_PROJECT_DIR }}
 
     env:
-      PLAY_TRACK: ${{ github.event.inputs.track || 'internal' }}
-      PLAY_RELEASE_NAME: ${{ github.event.inputs.release_name || '' }}
-      PARAKEET_RUNTIME: ${{ github.event.inputs.parakeet_runtime || 'onnx' }}
+      PLAY_TRACK: internal
+      PLAY_RELEASE_NAME: ''
+      PARAKEET_RUNTIME: onnx
 
       # Google Play API credentials. Prefer the base64 secret for copy/paste
       # safety; raw ANDROID_PUBLISHER_CREDENTIALS is also supported.
@@ -85,7 +65,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           lfs: false
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Play releases must be created by pushing an android-v<versionName> tag." >&2
+            exit 1
+          fi
+
+          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p; s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          version_code=$(sed -nE 's/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p; s/^[[:space:]]*versionCode[[:space:]]*=[[:space:]]*configValue\("VERSION_CODE", "([0-9]+)".*/\1/p' app/build.gradle.kts | head -n 1)
+          if [ -z "$version_name" ] || [ -z "$version_code" ]; then
+            echo "Could not read Android versionName/versionCode from app/build.gradle.kts" >&2
+            exit 1
+          fi
+
+          expected_tag="android-v${version_name}"
+          if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match Android versionName $version_name; expected $expected_tag." >&2
+            exit 1
+          fi
+
+          tag_sha=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          git fetch origin main --prune
+          if ! git merge-base --is-ancestor "$tag_sha" origin/main; then
+            echo "Release tag $GITHUB_REF_NAME points to $tag_sha, which is not on origin/main." >&2
+            echo "Merge to main first, then tag the main commit." >&2
+            exit 1
+          fi
+
+          echo "VERSION_CODE=$version_code" >> "$GITHUB_ENV"
+          echo "VERSION_NAME=$version_name" >> "$GITHUB_ENV"
+          echo "PLAY_RELEASE_NAME=AIDictation Android ${version_name} (${version_code})" >> "$GITHUB_ENV"
 
       - name: Download Parakeet model assets
         env:
@@ -102,6 +117,8 @@ jobs:
           test -s parakeetpack/src/main/assets/encoder-model.int8.onnx
           test -s parakeetpack/src/main/assets/decoder_joint-model.int8.onnx
           test -s parakeetpack/src/main/assets/nemo128.onnx
+          test -s parakeetpack/src/main/assets/vocab.txt
+          test -s parakeetpack/src/main/assets/config.json
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
@@ -210,20 +227,8 @@ jobs:
           fi
           rm /tmp/secrets.plist
 
-      - name: Resolve dev version
-        run: |
-          base_version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\\("VERSION_NAME", "([^"]+)".*/\1/p' app/build.gradle.kts | head -n 1)
-          if [ -z "$base_version_name" ]; then
-            base_version_name="0.0.5"
-          fi
-          echo "VERSION_CODE=$((1000 + GITHUB_RUN_NUMBER))" >> "$GITHUB_ENV"
-          echo "VERSION_NAME=${base_version_name}-dev.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
-
       - name: Write local.properties
         run: |
-          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
-            PARAKEET_RUNTIME=""
-          fi
           normalize_transcription_model() {
             case "$1" in
               ""|*"gpt-4o-transcribe"*)
@@ -263,16 +268,10 @@ jobs:
 
       - name: Validate release bundle
         run: |
-          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
-            PARAKEET_RUNTIME=""
-          fi
           ./gradlew :app:bundleRelease -PPARAKEET_RUNTIME="${PARAKEET_RUNTIME}" --stacktrace
 
       - name: Publish to Google Play
         run: |
-          if [ "${PARAKEET_RUNTIME}" = "cloud" ]; then
-            PARAKEET_RUNTIME=""
-          fi
           args=(
             :app:publishReleaseBundle
             -PPLAY_TRACK="${PLAY_TRACK}"

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -1,10 +1,10 @@
 # Android CI
 
 The `.github/workflows/android-build.yml` pipeline builds the
-`AIDictationAndroid` Gradle project on every push/PR that touches the
-Android source tree. A push to `main`, an `android-v*` tag, or a manual
-workflow dispatch also runs the signed release job and publishes APK/AAB
-assets to a GitHub Release named `android-v<versionName>`.
+`AIDictationAndroid` Gradle project on pushes to `main`, Android release
+tags, and PRs into `main` that touch the Android source tree or Android
+release workflows. Only an `android-v<versionName>` tag runs the signed
+release job and publishes APK/AAB assets to a GitHub Release.
 
 The GitHub release job does not rely on Git LFS bandwidth for Parakeet
 weights. It checks out source with LFS disabled, downloads
@@ -14,12 +14,14 @@ a small sideload APK that downloads Parakeet only when the user enables
 on-device transcription, and builds the Play AAB with the `parakeet_v3_pack`
 asset pack.
 
-`.github/workflows/android-play-dev.yml` is a manual dev-release workflow
-that publishes the signed release AAB to a Google Play testing track
-(`internal` by default). It is intended for Play Store tester installs,
-including the on-demand `parakeet_v3_pack` asset pack. The workflow assigns
-dev builds `versionCode = 1000 + GITHUB_RUN_NUMBER` so repeated internal
-uploads do not collide with the checked-in production version.
+`.github/workflows/android-play-release.yml` publishes the signed release
+AAB to the Google Play `internal` track from the same `android-v<versionName>`
+tag. It uses the checked-in `versionName` and `versionCode`, and rejects tags
+that do not point at a commit reachable from `origin/main`.
+
+Google Play version codes are monotonic across every track. Because an earlier
+internal upload used version code `1007`, Android release version codes must be
+greater than `1007`.
 
 ## Required repository secrets
 
@@ -50,7 +52,7 @@ runs, matching the local-developer layout described in
 | `STRIPE_PAYMENT_LINK_LIFETIME` | Optional lifetime checkout link. |
 | `SECRETS_PLIST` | Optional. Base64-encoded Mac `Secrets.plist` — the same secret used by `release-macos.yml`. When present, the workflow extracts `CustomTranscription*`, `AIDictationPostProcessing*`, `SUPABASE_*`, `AUTH_WEB_URL`, and `STRIPE_PAYMENT_LINK*` so both platforms ship with the same Writingmate auth and billing configuration. |
 
-### Release signing (only needed for the `release` job on `main`)
+### Release signing (only needed for tagged Android releases)
 
 | Secret | Purpose |
 |---|---|
@@ -59,7 +61,7 @@ runs, matching the local-developer layout described in
 | `ANDROID_KEY_ALIAS` | Maps to `KEY_ALIAS` in `local.properties` (default `release`) |
 | `ANDROID_KEY_PASSWORD` | Maps to `KEY_PASSWORD` in `local.properties` |
 
-### Google Play dev releases
+### Google Play releases
 
 | Secret | Purpose |
 |---|---|

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -50,8 +50,8 @@ android {
         applicationId = "com.whispermate.aidictation"
         minSdk = 26
         targetSdk = 35
-        versionCode = configValue("VERSION_CODE", "10").toInt()
-        versionName = configValue("VERSION_NAME", "0.0.10")
+        versionCode = configValue("VERSION_CODE", "1008").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.11")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -4,9 +4,9 @@
 # Android SDK location
 sdk.dir=/path/to/Android/Sdk
 
-# Optional local version overrides. CI uses these for Play dev releases.
-VERSION_CODE=10
-VERSION_NAME=0.0.10
+# Optional local version overrides. Tagged Android releases use these defaults.
+VERSION_CODE=1008
+VERSION_NAME=0.0.11
 
 # Writingmate transcription configuration
 TRANSCRIPTION_API_KEY=your_writingmate_transcription_key_here


### PR DESCRIPTION
## Summary
- make Android GitHub releases run only from pushed android-v<versionName> tags
- replace the manual Play dev workflow with a tag-driven Play internal release workflow
- guard both release paths so tags must match the checked-in Android version and be reachable from origin/main
- bump Android to 0.0.11 (1008), because Play already accepted versionCode 1007 from the old dev flow

## Verification
- Ruby YAML parse for all workflow files
- git diff --check
- extracted Android version metadata as 0.0.11 / 1008
- ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --stacktrace
- ./gradlew :app:lintDebug --stacktrace