### PR TITLE
Align Android release package with Play Console

### DIFF
--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -23,6 +23,10 @@ Google Play version codes are monotonic across every track. Because an earlier
 internal upload used version code `1007`, Android release version codes must be
 greater than `1007`.
 
+The Play Console package name is `com.aidictation.app`. The Kotlin/Android
+namespace remains `com.whispermate.aidictation`, but `applicationId` must stay
+aligned with `com.aidictation.app` for Play uploads.
+
 ## Required repository secrets
 
 These are written into `local.properties` on the runner before Gradle

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -47,11 +47,11 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.whispermate.aidictation"
+        applicationId = "com.aidictation.app"
         minSdk = 26
         targetSdk = 35
-        versionCode = configValue("VERSION_CODE", "1008").toInt()
-        versionName = configValue("VERSION_NAME", "0.0.11")
+        versionCode = configValue("VERSION_CODE", "1009").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.12")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/AIDictationAndroid/app/src/main/AndroidManifest.xml
+++ b/AIDictationAndroid/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.whispermate.aidictation.action.TOGGLE_DICTATION" />
+                <action android:name="com.aidictation.app.action.TOGGLE_DICTATION" />
             </intent-filter>
         </receiver>
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/service/OverlayDictationAccessibilityService.kt
@@ -64,7 +64,7 @@ import kotlin.math.roundToInt
 class OverlayDictationAccessibilityService : AccessibilityService() {
 
     companion object {
-        const val ACTION_START_DICTATION = "com.whispermate.aidictation.action.START_DICTATION"
+        const val ACTION_START_DICTATION = "com.aidictation.app.action.START_DICTATION"
         private const val TAG = "OverlayDictationSvc"
         private const val BUBBLE_PREFS = "overlay_bubble"
         private const val BUBBLE_X_KEY = "bubble_x"

--- a/AIDictationAndroid/app/src/main/res/xml/shortcuts.xml
+++ b/AIDictationAndroid/app/src/main/res/xml/shortcuts.xml
@@ -7,8 +7,8 @@
         android:shortcutShortLabel="@string/shortcut_start_dictation"
         android:shortcutLongLabel="@string/shortcut_start_dictation">
         <intent
-            android:action="com.whispermate.aidictation.action.START_DICTATION"
-            android:targetPackage="com.whispermate.aidictation"
+            android:action="com.aidictation.app.action.START_DICTATION"
+            android:targetPackage="com.aidictation.app"
             android:targetClass="com.whispermate.aidictation.ShortcutActivity" />
         <categories android:name="android.shortcut.conversation" />
     </shortcut>

--- a/AIDictationAndroid/local.properties.template
+++ b/AIDictationAndroid/local.properties.template
@@ -5,8 +5,8 @@
 sdk.dir=/path/to/Android/Sdk
 
 # Optional local version overrides. Tagged Android releases use these defaults.
-VERSION_CODE=1008
-VERSION_NAME=0.0.11
+VERSION_CODE=1009
+VERSION_NAME=0.0.12
 
 # Writingmate transcription configuration
 TRANSCRIPTION_API_KEY=your_writingmate_transcription_key_here


### PR DESCRIPTION
## Summary
- set Android release applicationId to the Play Console package `com.aidictation.app`
- update shortcut/broadcast action package strings to match the release app ID
- bump Android to `0.0.12 (1009)` for a new tag after the failed `0.0.11` Play attempt
- document the Play package ID contract

## Why
The tag-driven Play workflow ran from `main`, but Google Play rejected `com.whispermate.aidictation` with `Package not found`. The previously successful Play upload was built from a branch using `com.aidictation.app`, so `main` needs to use that same immutable Play package ID.

## Verification
- `git diff --check`
- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:lintDebug --stacktrace`