### PR TITLE
Add iOS Parakeet offline dictation and full keyboard

### DIFF
--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @StateObject private var shortcutManager = ShortcutManager.shared
     @StateObject private var authManager = AuthManager.shared
     @StateObject private var subscriptionManager = SubscriptionManager.shared
+    @StateObject private var transcriptionProviderManager = TranscriptionProviderManager()
     @StateObject private var inlineRecording = InlineRecordingCoordinator()
     @State private var showRecordingSheet = false
     @State private var showSettings = false
@@ -524,6 +525,32 @@ struct ContentView: View {
                     }
                 }
 
+                Section("Dictation Mode") {
+                    Picker("Mode", selection: Binding(
+                        get: { transcriptionProviderManager.transcriptionMode },
+                        set: { transcriptionProviderManager.setTranscriptionMode($0) }
+                    )) {
+                        ForEach(TranscriptionMode.availableCases) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+
+                    Text(transcriptionProviderManager.transcriptionMode.description)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    if transcriptionProviderManager.transcriptionMode != .cloud {
+                        Button(action: prepareOfflineModel) {
+                            HStack {
+                                Label("Offline Model", systemImage: "square.and.arrow.down")
+                                Spacer()
+                                Image(systemName: offlineModelStatusIcon)
+                                    .foregroundColor(offlineModelStatusColor)
+                            }
+                        }
+                    }
+                }
+
                 Section("About") {
                     HStack {
                         Text("Version")
@@ -578,6 +605,26 @@ struct ContentView: View {
         }
         // Fallback to general settings if keyboard shortcut doesn't work
         openAppSettings()
+    }
+
+    private var offlineModelStatusIcon: String {
+        guard SharedParakeetTranscriptionService.isRuntimeSupported else {
+            return "exclamationmark.triangle.fill"
+        }
+        return SharedParakeetTranscriptionService.shared.isModelDownloaded ? "checkmark.circle.fill" : "arrow.down.circle"
+    }
+
+    private var offlineModelStatusColor: Color {
+        guard SharedParakeetTranscriptionService.isRuntimeSupported else {
+            return .orange
+        }
+        return SharedParakeetTranscriptionService.shared.isModelDownloaded ? .green : .secondary
+    }
+
+    private func prepareOfflineModel() {
+        Task {
+            try? await SharedParakeetTranscriptionService.shared.initialize()
+        }
     }
 
     private func openLogin() {
@@ -889,59 +936,13 @@ private final class InlineRecordingCoordinator: ObservableObject {
             return
         }
 
-        let apiKey = KeychainHelper.get(key: "custom_transcription_api_key") ?? SecretsLoader.transcriptionKey(for: .custom)
-        let endpoint = SecretsLoader.customTranscriptionEndpoint() ?? "https://writingmate.ai/api/openai/v1/audio/transcriptions"
-        let model = SecretsLoader.customTranscriptionModel() ?? "groq/whisper-large-v3-turbo"
-
-        guard let apiKey else {
-            try? FileManager.default.removeItem(at: audioURL)
-            showError("API key not configured")
-            return
-        }
-
         do {
-            let config = OpenAIClient.Configuration(
-                transcriptionEndpoint: endpoint,
-                transcriptionModel: model,
-                chatCompletionEndpoint: "",
-                chatCompletionModel: "",
-                apiKey: apiKey
-            )
-
-            let openAIClient = OpenAIClient(config: config)
-            var sttPromptComponents: [String] = []
-            var postProcessingPromptComponents: [String] = []
-
-            let dictionaryHints = dictionaryManager.transcriptionHints
-            if !dictionaryHints.isEmpty {
-                sttPromptComponents.append("Vocabulary: \(dictionaryHints)")
-                postProcessingPromptComponents.append("Vocabulary: \(dictionaryHints)")
-            }
-
-            let shortcutHints = shortcutManager.transcriptionHints
-            if !shortcutHints.isEmpty {
-                sttPromptComponents.append("Phrases: \(shortcutHints)")
-                postProcessingPromptComponents.append("Phrases: \(shortcutHints)")
-            }
-
-            let styleInstructions = toneStyleManager.allInstructions
-            if !styleInstructions.isEmpty {
-                postProcessingPromptComponents.append(styleInstructions)
-            }
-
-            let sttPrompt = sttPromptComponents.joined(separator: "\n")
-            let postProcessingPrompt = postProcessingPromptComponents.joined(separator: "\n")
-
-            let result = try await openAIClient.transcribe(
+            let processedResult = try await SharedTranscriptionService.transcribe(
                 audioURL: audioURL,
-                prompt: sttPrompt.isEmpty ? nil : sttPrompt,
-                sttPrompt: sttPrompt.isEmpty ? nil : sttPrompt,
-                postProcessingPrompt: postProcessingPrompt.isEmpty ? nil : postProcessingPrompt
+                dictionaryManager: dictionaryManager,
+                toneStyleManager: toneStyleManager,
+                shortcutManager: shortcutManager
             )
-
-            var processedResult = dictionaryManager.applyReplacements(to: result)
-            processedResult = shortcutManager.expandShortcuts(in: processedResult)
-            processedResult = TranscriptionTextSanitizer.cleanedText(processedResult)
 
             guard !processedResult.isEmpty else {
                 DebugLog.info("Inline transcription was empty after sanitization; skipping history item", context: "ContentView")

--- a/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
+++ b/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
@@ -360,17 +360,6 @@ struct RecordingSheetView: View {
             return
         }
 
-        // Get API key from Secrets.plist or keychain
-        let apiKey = KeychainHelper.get(key: "custom_transcription_api_key") ?? SecretsLoader.transcriptionKey(for: .custom)
-        let endpoint = SecretsLoader.customTranscriptionEndpoint() ?? "https://writingmate.ai/api/openai/v1/audio/transcriptions"
-        let model = SecretsLoader.customTranscriptionModel() ?? "groq/whisper-large-v3-turbo"
-
-        guard let apiKey = apiKey else {
-            errorMessage = "API key not configured"
-            sheetState = .viewing
-            return
-        }
-
         withAnimation(.easeInOut(duration: 0.18)) {
             sheetState = .processing
             updateRecordingSurface(animated: false)
@@ -378,53 +367,12 @@ struct RecordingSheetView: View {
 
         Task {
             do {
-                let config = OpenAIClient.Configuration(
-                    transcriptionEndpoint: endpoint,
-                    transcriptionModel: model,
-                    chatCompletionEndpoint: "",
-                    chatCompletionModel: "",
-                    apiKey: apiKey
-                )
-
-                let openAIClient = OpenAIClient(config: config)
-
-                var sttPromptComponents: [String] = []
-                var postProcessingPromptComponents: [String] = []
-
-                // Add dictionary hints for better recognition
-                let dictionaryHints = dictionaryManager.transcriptionHints
-                if !dictionaryHints.isEmpty {
-                    sttPromptComponents.append("Vocabulary: \(dictionaryHints)")
-                    postProcessingPromptComponents.append("Vocabulary: \(dictionaryHints)")
-                }
-
-                // Add shortcut triggers for recognition
-                let shortcutHints = shortcutManager.transcriptionHints
-                if !shortcutHints.isEmpty {
-                    sttPromptComponents.append("Phrases: \(shortcutHints)")
-                    postProcessingPromptComponents.append("Phrases: \(shortcutHints)")
-                }
-
-                let styleInstructions = toneStyleManager.allInstructions
-                if !styleInstructions.isEmpty {
-                    postProcessingPromptComponents.append(styleInstructions)
-                }
-
-                let sttPrompt = sttPromptComponents.joined(separator: "\n")
-                let postProcessingPrompt = postProcessingPromptComponents.joined(separator: "\n")
-
-                let result = try await openAIClient.transcribe(
+                let processedResult = try await SharedTranscriptionService.transcribe(
                     audioURL: audioURL,
-                    prompt: sttPrompt.isEmpty ? nil : sttPrompt,
-                    sttPrompt: sttPrompt.isEmpty ? nil : sttPrompt,
-                    postProcessingPrompt: postProcessingPrompt.isEmpty ? nil : postProcessingPrompt
+                    dictionaryManager: dictionaryManager,
+                    toneStyleManager: toneStyleManager,
+                    shortcutManager: shortcutManager
                 )
-
-                // Apply post-processing: dictionary replacements and shortcut expansion
-                var processedResult = result
-                processedResult = dictionaryManager.applyReplacements(to: processedResult)
-                processedResult = shortcutManager.expandShortcuts(in: processedResult)
-                processedResult = TranscriptionTextSanitizer.cleanedText(processedResult)
 
                 guard !processedResult.isEmpty else {
                     DebugLog.info("Sheet transcription was empty after sanitization; skipping history item", context: "RecordingSheetView")

--- a/Whishpermate/WhisperMateKeyboard/KeyboardRecordingView.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardRecordingView.swift
@@ -7,16 +7,169 @@ typealias KeyboardRecordingViewModel = AIDictationRecordingViewModel
 
 struct KeyboardRecordingView: View {
     @ObservedObject var model: KeyboardRecordingViewModel
+    let isShifted: Bool
     let onPrimaryAction: () -> Void
     let onPauseAction: () -> Void
+    let onKeyPress: (String) -> Void
+    let onBackspace: () -> Void
+    let onSpace: () -> Void
+    let onReturn: () -> Void
+    let onShift: () -> Void
+    let onNextKeyboard: () -> Void
+
+    private let rows = [
+        ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+        ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+        ["z", "x", "c", "v", "b", "n", "m"],
+    ]
 
     var body: some View {
-        AIDictationRecordingSurface(
-            model: model,
-            backgroundColor: Color(uiColor: KeyboardPalette.backgroundColor),
-            onPrimaryAction: onPrimaryAction,
-            onPauseAction: onPauseAction
-        )
+        VStack(spacing: 7) {
+            recordBar
+            letterRow(rows[0])
+            letterRow(rows[1])
+                .padding(.horizontal, 18)
+
+            HStack(spacing: 6) {
+                KeyboardKey(title: "shift", systemImage: isShifted ? "shift.fill" : "shift", style: .utility, action: onShift)
+                    .frame(width: 42)
+                letterRow(rows[2])
+                KeyboardKey(title: "delete", systemImage: "delete.left", style: .utility, action: onBackspace)
+                    .frame(width: 42)
+            }
+
+            HStack(spacing: 6) {
+                KeyboardKey(title: "next keyboard", systemImage: "globe", style: .utility, action: onNextKeyboard)
+                    .frame(width: 44)
+                KeyboardKey(title: "space", text: "space", style: .space, action: onSpace)
+                KeyboardKey(title: "return", text: "return", style: .utility, action: onReturn)
+                    .frame(width: 76)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.top, 7)
+        .padding(.bottom, 6)
+        .background(Color(uiColor: KeyboardPalette.backgroundColor))
+    }
+
+    private var recordBar: some View {
+        HStack(spacing: 8) {
+            Button(action: onPrimaryAction) {
+                HStack(spacing: 8) {
+                    Image(systemName: recordIcon)
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(recordTitle)
+                        .font(.system(size: 15, weight: .semibold))
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 38)
+                .foregroundColor(.white)
+                .background(recordColor)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(model.state == .processing)
+
+            if model.state == .recording || model.state == .paused {
+                Button(action: onPauseAction) {
+                    Image(systemName: model.state == .paused ? "play.fill" : "pause.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 38, height: 38)
+                        .foregroundColor(.primary)
+                        .background(Color(uiColor: KeyboardPalette.utilityKeyColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func letterRow(_ keys: [String]) -> some View {
+        HStack(spacing: 6) {
+            ForEach(keys, id: \.self) { key in
+                KeyboardKey(
+                    title: key,
+                    text: isShifted ? key.uppercased() : key,
+                    style: .letter,
+                    action: { onKeyPress(isShifted ? key.uppercased() : key) }
+                )
+            }
+        }
+    }
+
+    private var recordTitle: String {
+        switch model.state {
+        case .idle: return "Record"
+        case .recording: return "Stop"
+        case .paused: return "Resume"
+        case .processing: return "Transcribing"
+        @unknown default: return "Record"
+        }
+    }
+
+    private var recordIcon: String {
+        switch model.state {
+        case .idle: return "mic.fill"
+        case .recording: return "stop.fill"
+        case .paused: return "play.fill"
+        case .processing: return "waveform"
+        @unknown default: return "mic.fill"
+        }
+    }
+
+    private var recordColor: Color {
+        switch model.state {
+        case .recording: return .red
+        case .paused: return .orange
+        case .processing: return .gray
+        case .idle: return Color(uiColor: .systemOrange)
+        @unknown default: return Color(uiColor: .systemOrange)
+        }
+    }
+}
+
+private struct KeyboardKey: View {
+    enum Style {
+        case letter
+        case utility
+        case space
+    }
+
+    let title: String
+    var text: String?
+    var systemImage: String?
+    let style: Style
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 17, weight: .medium))
+                } else {
+                    Text(text ?? title)
+                        .font(.system(size: style == .letter ? 22 : 15, weight: style == .letter ? .regular : .medium))
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: style == .space ? 40 : 42)
+            .foregroundColor(.primary)
+            .background(backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .shadow(color: .black.opacity(0.18), radius: 0, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .letter, .space:
+            return Color(uiColor: KeyboardPalette.keyColor)
+        case .utility:
+            return Color(uiColor: KeyboardPalette.utilityKeyColor)
+        }
     }
 }
 
@@ -25,5 +178,17 @@ enum KeyboardPalette {
         traitCollection.userInterfaceStyle == .dark
             ? UIColor(red: 0.17, green: 0.17, blue: 0.18, alpha: 1.0)
             : UIColor(red: 0.82, green: 0.84, blue: 0.88, alpha: 1.0)
+    }
+
+    static let keyColor = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.36, green: 0.36, blue: 0.38, alpha: 1.0)
+            : UIColor.white
+    }
+
+    static let utilityKeyColor = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.27, green: 0.27, blue: 0.29, alpha: 1.0)
+            : UIColor(red: 0.68, green: 0.71, blue: 0.76, alpha: 1.0)
     }
 }

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -8,7 +8,6 @@ class KeyboardViewController: UIInputViewController {
     // MARK: - Properties
 
     private var audioRecorder: AudioRecorder?
-    private var openAIClient: OpenAIClient!
     private var hostingController: UIHostingController<KeyboardRecordingView>!
     private var statusLabel: UILabel!
     private let recordingViewModel = KeyboardRecordingViewModel()
@@ -17,6 +16,7 @@ class KeyboardViewController: UIInputViewController {
     private var displayedFrequencyBands: [Float] = Array(repeating: 0.0, count: 10)
     private var recordingStartTime: Date?
     private var isProcessingTranscription = false
+    private var isShifted = false
     private var cancellables = Set<AnyCancellable>()
     private var keyboardHeightConstraint: NSLayoutConstraint?
 
@@ -83,28 +83,6 @@ class KeyboardViewController: UIInputViewController {
         return recorder
     }
 
-    private func makeOpenAIClient() -> OpenAIClient? {
-        // Try keychain first, then fall back to Secrets.plist
-        let apiKey = KeychainHelper.get(key: "custom_transcription_api_key") ?? SecretsLoader.transcriptionKey(for: .custom)
-        let endpoint = SecretsLoader.customTranscriptionEndpoint() ?? "https://writingmate.ai/api/openai/v1/audio/transcriptions"
-        let model = SecretsLoader.customTranscriptionModel() ?? "groq/whisper-large-v3-turbo"
-
-        guard let apiKey = apiKey else {
-            DebugLog.info("No API key found", context: "KeyboardViewController")
-            return nil
-        }
-
-        let config = OpenAIClient.Configuration(
-            transcriptionEndpoint: endpoint,
-            transcriptionModel: model,
-            chatCompletionEndpoint: "",
-            chatCompletionModel: "",
-            apiKey: apiKey
-        )
-
-        return OpenAIClient(config: config)
-    }
-
     private func setupUI() {
         view.backgroundColor = KeyboardPalette.backgroundColor
         view.isOpaque = true
@@ -112,11 +90,30 @@ class KeyboardViewController: UIInputViewController {
         // Create SwiftUI view
         let recordingView = KeyboardRecordingView(
             model: recordingViewModel,
+            isShifted: isShifted,
             onPrimaryAction: { [weak self] in
                 self?.handlePrimaryAction()
             },
             onPauseAction: { [weak self] in
                 self?.togglePauseRecording()
+            },
+            onKeyPress: { [weak self] text in
+                self?.insertKey(text)
+            },
+            onBackspace: { [weak self] in
+                self?.textDocumentProxy.deleteBackward()
+            },
+            onSpace: { [weak self] in
+                self?.textDocumentProxy.insertText(" ")
+            },
+            onReturn: { [weak self] in
+                self?.textDocumentProxy.insertText("\n")
+            },
+            onShift: { [weak self] in
+                self?.toggleShift()
+            },
+            onNextKeyboard: { [weak self] in
+                self?.advanceToNextInputMode()
             }
         )
 
@@ -160,6 +157,34 @@ class KeyboardViewController: UIInputViewController {
             statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
         ])
+    }
+
+    private func insertKey(_ text: String) {
+        textDocumentProxy.insertText(text)
+        if isShifted {
+            isShifted = false
+            refreshKeyboardRootView()
+        }
+    }
+
+    private func toggleShift() {
+        isShifted.toggle()
+        refreshKeyboardRootView()
+    }
+
+    private func refreshKeyboardRootView() {
+        hostingController.rootView = KeyboardRecordingView(
+            model: recordingViewModel,
+            isShifted: isShifted,
+            onPrimaryAction: { [weak self] in self?.handlePrimaryAction() },
+            onPauseAction: { [weak self] in self?.togglePauseRecording() },
+            onKeyPress: { [weak self] text in self?.insertKey(text) },
+            onBackspace: { [weak self] in self?.textDocumentProxy.deleteBackward() },
+            onSpace: { [weak self] in self?.textDocumentProxy.insertText(" ") },
+            onReturn: { [weak self] in self?.textDocumentProxy.insertText("\n") },
+            onShift: { [weak self] in self?.toggleShift() },
+            onNextKeyboard: { [weak self] in self?.advanceToNextInputMode() }
+        )
     }
 
     private func handlePrimaryAction() {
@@ -305,13 +330,7 @@ class KeyboardViewController: UIInputViewController {
                     throw OpenAIError.apiError(access.reason ?? "Open AI Dictation to log in and continue.")
                 }
 
-                guard let openAIClient = self.openAIClient ?? self.makeOpenAIClient() else {
-                    throw OpenAIError.apiError("API key not configured")
-                }
-                self.openAIClient = openAIClient
-
-                let rawTranscription = try await openAIClient.transcribe(audioURL: recordingURL)
-                let transcription = TranscriptionTextSanitizer.cleanedText(rawTranscription)
+                let transcription = try await SharedTranscriptionService.transcribe(audioURL: recordingURL)
 
                 guard !transcription.isEmpty else {
                     DebugLog.info("Keyboard transcription was empty after sanitization; skipping insert", context: "KeyboardViewController")

--- a/Whishpermate/WhisperMateShared/Models/APIProvider.swift
+++ b/Whishpermate/WhisperMateShared/Models/APIProvider.swift
@@ -4,6 +4,7 @@ public import Combine
 // MARK: - Transcription Provider
 
 public enum TranscriptionProvider: String, CaseIterable, Identifiable {
+    case onDevice
     case groq
     case openai
     case custom
@@ -12,6 +13,7 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
 
     public var displayName: String {
         switch self {
+        case .onDevice: return "Offline Mode"
         case .groq: return "Groq"
         case .openai: return "OpenAI"
         case .custom: return "Custom"
@@ -20,6 +22,7 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
 
     public var description: String {
         switch self {
+        case .onDevice: return "Private, works without internet"
         case .groq: return "Whisper Large V3"
         case .openai: return "Whisper API"
         case .custom: return "Enhanced Whisper + LLM"
@@ -28,6 +31,7 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
 
     public var defaultEndpoint: String {
         switch self {
+        case .onDevice: return ""
         case .groq: return "https://api.groq.com/openai/v1/audio/transcriptions"
         case .openai: return "https://api.openai.com/v1/audio/transcriptions"
         case .custom: return "https://writingmate.ai/api/openai/v1/audio/transcriptions"
@@ -36,6 +40,7 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
 
     public var defaultModel: String {
         switch self {
+        case .onDevice: return "apple-on-device"
         case .groq: return "whisper-large-v3-turbo"
         case .openai: return "whisper-1"
         case .custom: return "groq/whisper-large-v3-turbo"
@@ -50,22 +55,71 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
         switch self {
         case .groq, .openai:
             return true
-        case .custom:
+        case .onDevice, .custom:
             return false
+        }
+    }
+
+    public var isOnDevice: Bool {
+        self == .onDevice
+    }
+
+    public static var availableProviders: [TranscriptionProvider] {
+        allCases.filter { provider in
+            provider != .onDevice || SharedParakeetTranscriptionService.isRuntimeSupported
         }
     }
 }
 
+public enum TranscriptionMode: String, CaseIterable, Identifiable {
+    case cloud
+    case offline
+    case automatic
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .cloud: return "Cloud Mode"
+        case .offline: return "Offline Mode"
+        case .automatic: return "Automatic"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .cloud: return "Sends recordings to the cloud for transcription."
+        case .offline: return "Transcribes on this device without sending audio out."
+        case .automatic: return "Uses cloud mode when available and offline mode when needed."
+        }
+    }
+
+    public var isAvailable: Bool {
+        switch self {
+        case .cloud:
+            return true
+        case .offline, .automatic:
+            return SharedParakeetTranscriptionService.isRuntimeSupported
+        }
+    }
+
+    public static var availableCases: [TranscriptionMode] {
+        allCases.filter(\.isAvailable)
+    }
+}
+
 public class TranscriptionProviderManager: ObservableObject {
-    @Published var selectedProvider: TranscriptionProvider = .custom
-    @Published var customEndpoint: String = ""
-    @Published var customModel: String = ""
+    @Published public var selectedProvider: TranscriptionProvider = .custom
+    @Published public var transcriptionMode: TranscriptionMode = .cloud
+    @Published public var customEndpoint: String = ""
+    @Published public var customModel: String = ""
 
     private let providerKey = "selected_transcription_provider"
+    private let modeKey = "selected_transcription_mode"
     private let endpointKey = "transcription_custom_endpoint"
     private let modelKey = "transcription_custom_model"
 
-    init() {
+    public init() {
         loadSettings()
     }
 
@@ -78,15 +132,75 @@ public class TranscriptionProviderManager: ObservableObject {
             // Default to custom provider if no saved preference
             selectedProvider = .custom
         }
+
+        if let savedMode = AppDefaults.shared.string(forKey: modeKey),
+           let mode = TranscriptionMode(rawValue: savedMode),
+           mode.isAvailable
+        {
+            transcriptionMode = mode
+        } else if selectedProvider == .onDevice, TranscriptionMode.offline.isAvailable {
+            transcriptionMode = .offline
+        } else {
+            transcriptionMode = .cloud
+        }
+
+        if selectedProvider == .onDevice && !SharedParakeetTranscriptionService.isRuntimeSupported {
+            selectedProvider = .custom
+            AppDefaults.shared.set(selectedProvider.rawValue, forKey: providerKey)
+            transcriptionMode = .cloud
+            AppDefaults.shared.set(transcriptionMode.rawValue, forKey: modeKey)
+        }
+
         customEndpoint = AppDefaults.shared.string(forKey: endpointKey) ?? ""
         customModel = AppDefaults.shared.string(forKey: modelKey) ?? ""
         DebugLog.info("Loaded: \(selectedProvider.displayName)", context: "TranscriptionProviderManager")
     }
 
     public func setProvider(_ provider: TranscriptionProvider) {
+        guard provider != .onDevice || SharedParakeetTranscriptionService.isRuntimeSupported else {
+            setTranscriptionMode(.cloud)
+            return
+        }
+
         selectedProvider = provider
         AppDefaults.shared.set(provider.rawValue, forKey: providerKey)
+        transcriptionMode = provider == .onDevice ? .offline : .cloud
+        AppDefaults.shared.set(transcriptionMode.rawValue, forKey: modeKey)
         DebugLog.info("Set provider: \(provider.displayName)", context: "TranscriptionProviderManager")
+    }
+
+    public func setTranscriptionMode(_ mode: TranscriptionMode) {
+        guard mode.isAvailable else {
+            transcriptionMode = .cloud
+            selectedProvider = .custom
+            AppDefaults.shared.set(transcriptionMode.rawValue, forKey: modeKey)
+            AppDefaults.shared.set(selectedProvider.rawValue, forKey: providerKey)
+            return
+        }
+
+        transcriptionMode = mode
+        AppDefaults.shared.set(mode.rawValue, forKey: modeKey)
+
+        switch mode {
+        case .offline:
+            selectedProvider = .onDevice
+        case .cloud, .automatic:
+            if selectedProvider == .onDevice {
+                selectedProvider = .custom
+            }
+        }
+        AppDefaults.shared.set(selectedProvider.rawValue, forKey: providerKey)
+    }
+
+    public var shouldUseOnDeviceTranscription: Bool {
+        switch transcriptionMode {
+        case .offline:
+            return SharedParakeetTranscriptionService.isRuntimeSupported
+        case .automatic:
+            return SharedParakeetTranscriptionService.isRuntimeSupported && !hasCloudCredentials
+        case .cloud:
+            return false
+        }
     }
 
     public func saveCustomSettings(endpoint: String, model: String) {
@@ -97,6 +211,10 @@ public class TranscriptionProviderManager: ObservableObject {
     }
 
     public var effectiveEndpoint: String {
+        if selectedProvider == .onDevice {
+            return ""
+        }
+
         // For custom provider, check Secrets.plist first
         if selectedProvider == .custom {
             if let secretEndpoint = SecretsLoader.customTranscriptionEndpoint(), !secretEndpoint.isEmpty {
@@ -111,6 +229,10 @@ public class TranscriptionProviderManager: ObservableObject {
     }
 
     public var effectiveModel: String {
+        if selectedProvider == .onDevice {
+            return selectedProvider.defaultModel
+        }
+
         // For custom provider, check Secrets.plist first
         if selectedProvider == .custom {
             if let secretModel = SecretsLoader.customTranscriptionModel(), !secretModel.isEmpty {
@@ -122,6 +244,11 @@ public class TranscriptionProviderManager: ObservableObject {
             return customModel
         }
         return selectedProvider.defaultModel
+    }
+
+    private var hasCloudCredentials: Bool {
+        let cloudProvider = selectedProvider == .onDevice ? TranscriptionProvider.custom : selectedProvider
+        return KeychainHelper.get(key: cloudProvider.apiKeyName) != nil || SecretsLoader.transcriptionKey(for: cloudProvider) != nil
     }
 }
 

--- a/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
+++ b/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
@@ -12,6 +12,8 @@ public enum SecretsLoader {
 
     public static func transcriptionKey(for provider: TranscriptionProvider) -> String? {
         switch provider {
+        case .onDevice:
+            return nil
         case .groq:
             return sanitizedSecret("GroqTranscriptionKey")
         case .custom:

--- a/Whishpermate/WhisperMateShared/Services/SharedParakeetTranscriptionService.swift
+++ b/Whishpermate/WhisperMateShared/Services/SharedParakeetTranscriptionService.swift
@@ -1,0 +1,224 @@
+import Foundation
+public import Combine
+
+public final class SharedParakeetTranscriptionService: ObservableObject {
+    public static let shared = SharedParakeetTranscriptionService()
+
+    public enum ServiceState {
+        case notInitialized
+        case downloading
+        case initializing
+        case ready
+        case transcribing
+        case error(String)
+    }
+
+    @Published public private(set) var state: ServiceState = .notInitialized
+    @Published public private(set) var isModelDownloaded = false
+
+    public static var isRuntimeSupported: Bool {
+        #if os(iOS)
+            if #available(iOS 17.0, *) {
+                return true
+            }
+            return false
+        #else
+            if #available(macOS 14.0, *) {
+                return true
+            }
+            return false
+        #endif
+    }
+
+    public static var unavailableMessage: String {
+        #if os(iOS)
+            return "Offline mode is not available in this build."
+        #else
+            return "Offline mode requires macOS 14 or later."
+        #endif
+    }
+
+    private var runtimeBridge: NSObject?
+
+    private init() {}
+
+    public func initialize() async throws {
+        guard Self.isRuntimeSupported else {
+            await setUnavailableState()
+            throw runtimeError(Self.unavailableMessage)
+        }
+
+        let currentState = await MainActor.run { state }
+        guard case .notInitialized = currentState else {
+            return
+        }
+
+        await MainActor.run {
+            state = .downloading
+        }
+
+        let bridge = try loadRuntimeBridge()
+
+        do {
+            try await initializeRuntimeBridge(bridge)
+            await MainActor.run {
+                state = .ready
+                isModelDownloaded = true
+            }
+        } catch {
+            await MainActor.run {
+                state = .error(error.localizedDescription)
+                isModelDownloaded = false
+            }
+            throw error
+        }
+    }
+
+    public func transcribe(audioURL: URL) async throws -> String {
+        guard Self.isRuntimeSupported else {
+            await setUnavailableState()
+            throw runtimeError(Self.unavailableMessage)
+        }
+
+        let currentState = await MainActor.run { state }
+        if case .notInitialized = currentState {
+            try await initialize()
+        }
+
+        let bridge = try loadRuntimeBridge()
+
+        await MainActor.run {
+            state = .transcribing
+        }
+
+        do {
+            let text = try await transcribeWithRuntimeBridge(bridge, audioPath: audioURL.path)
+            await MainActor.run {
+                state = .ready
+            }
+            return text
+        } catch {
+            await MainActor.run {
+                state = .error(error.localizedDescription)
+            }
+            throw error
+        }
+    }
+
+    public func cleanup() {
+        let bridge = runtimeBridge
+        runtimeBridge = nil
+
+        if let bridge {
+            callVoidSelector("cleanupRuntime", on: bridge)
+        }
+
+        Task { @MainActor in
+            state = .notInitialized
+            isModelDownloaded = false
+        }
+    }
+
+    private func setUnavailableState() async {
+        await MainActor.run {
+            state = .error(Self.unavailableMessage)
+            isModelDownloaded = false
+        }
+    }
+
+    private func loadRuntimeBridge() throws -> NSObject {
+        if let runtimeBridge {
+            return runtimeBridge
+        }
+
+        guard let frameworkURL = Bundle.main.privateFrameworksURL?.appendingPathComponent("ParakeetRuntime.framework"),
+              let bundle = Bundle(url: frameworkURL)
+        else {
+            throw runtimeError("Offline mode is missing from this build.")
+        }
+
+        if !bundle.isLoaded {
+            do {
+                try bundle.loadAndReturnError()
+            } catch {
+                throw runtimeError(error.localizedDescription)
+            }
+        }
+
+        let runtimeClass: AnyClass? = NSClassFromString("ParakeetRuntime.ParakeetRuntimeBridge")
+            ?? NSClassFromString("ParakeetRuntimeBridge")
+        guard let bridgeClass = runtimeClass as? NSObject.Type else {
+            throw runtimeError("Could not find the offline transcription runtime.")
+        }
+
+        let bridge = bridgeClass.init()
+        runtimeBridge = bridge
+        return bridge
+    }
+
+    private func initializeRuntimeBridge(_ bridge: NSObject) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let selector = NSSelectorFromString("initializeWithCompletion:")
+            guard bridge.responds(to: selector),
+                  let method = bridge.method(for: selector)
+            else {
+                continuation.resume(throwing: runtimeError("Offline runtime does not support initialization."))
+                return
+            }
+
+            let completion: @convention(block) (Bool, NSString?) -> Void = { success, message in
+                if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: self.runtimeError((message as String?) ?? "Offline model initialization failed."))
+                }
+            }
+
+            typealias Function = @convention(c) (AnyObject, Selector, @escaping @convention(block) (Bool, NSString?) -> Void) -> Void
+            unsafeBitCast(method, to: Function.self)(bridge, selector, completion)
+        }
+    }
+
+    private func transcribeWithRuntimeBridge(_ bridge: NSObject, audioPath: String) async throws -> String {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            let selector = NSSelectorFromString("transcribeAudioAtPath:completion:")
+            guard bridge.responds(to: selector),
+                  let method = bridge.method(for: selector)
+            else {
+                continuation.resume(throwing: runtimeError("Offline runtime does not support transcription."))
+                return
+            }
+
+            let completion: @convention(block) (NSString?, NSString?) -> Void = { text, message in
+                if let text {
+                    continuation.resume(returning: text as String)
+                } else {
+                    continuation.resume(throwing: self.runtimeError((message as String?) ?? "Offline transcription failed."))
+                }
+            }
+
+            typealias Function = @convention(c) (AnyObject, Selector, NSString, @escaping @convention(block) (NSString?, NSString?) -> Void) -> Void
+            unsafeBitCast(method, to: Function.self)(bridge, selector, audioPath as NSString, completion)
+        }
+    }
+
+    private func callVoidSelector(_ selectorName: String, on bridge: NSObject) {
+        let selector = NSSelectorFromString(selectorName)
+        guard bridge.responds(to: selector),
+              let method = bridge.method(for: selector)
+        else {
+            return
+        }
+
+        typealias Function = @convention(c) (AnyObject, Selector) -> Void
+        unsafeBitCast(method, to: Function.self)(bridge, selector)
+    }
+
+    private func runtimeError(_ message: String) -> NSError {
+        NSError(
+            domain: "SharedParakeetTranscriptionService",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}

--- a/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
+++ b/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+public enum SharedTranscriptionService {
+    public static func transcribe(
+        audioURL: URL,
+        dictionaryManager: DictionaryManager = .shared,
+        toneStyleManager: ToneStyleManager = .shared,
+        shortcutManager: ShortcutManager = .shared
+    ) async throws -> String {
+        let providerManager = TranscriptionProviderManager()
+
+        let rawResult: String
+        if providerManager.shouldUseOnDeviceTranscription {
+            rawResult = try await SharedParakeetTranscriptionService.shared.transcribe(audioURL: audioURL)
+        } else {
+            let provider = providerManager.selectedProvider == .onDevice ? TranscriptionProvider.custom : providerManager.selectedProvider
+            let apiKey = KeychainHelper.get(key: provider.apiKeyName) ?? SecretsLoader.transcriptionKey(for: provider)
+
+            guard let apiKey else {
+                throw error("API key not configured")
+            }
+
+            let config = OpenAIClient.Configuration(
+                transcriptionEndpoint: providerManager.effectiveEndpoint.isEmpty ? provider.defaultEndpoint : providerManager.effectiveEndpoint,
+                transcriptionModel: providerManager.effectiveModel,
+                chatCompletionEndpoint: "",
+                chatCompletionModel: "",
+                apiKey: apiKey
+            )
+
+            let openAIClient = OpenAIClient(config: config)
+            let prompts = buildPrompts(
+                dictionaryManager: dictionaryManager,
+                toneStyleManager: toneStyleManager,
+                shortcutManager: shortcutManager
+            )
+
+            rawResult = try await openAIClient.transcribe(
+                audioURL: audioURL,
+                prompt: prompts.stt.isEmpty ? nil : prompts.stt,
+                sttPrompt: prompts.stt.isEmpty ? nil : prompts.stt,
+                postProcessingPrompt: prompts.postProcessing.isEmpty ? nil : prompts.postProcessing
+            )
+        }
+
+        var processedResult = dictionaryManager.applyReplacements(to: rawResult)
+        processedResult = shortcutManager.expandShortcuts(in: processedResult)
+        return TranscriptionTextSanitizer.cleanedText(processedResult)
+    }
+
+    private static func buildPrompts(
+        dictionaryManager: DictionaryManager,
+        toneStyleManager: ToneStyleManager,
+        shortcutManager: ShortcutManager
+    ) -> (stt: String, postProcessing: String) {
+        var sttPromptComponents: [String] = []
+        var postProcessingPromptComponents: [String] = []
+
+        let dictionaryHints = dictionaryManager.transcriptionHints
+        if !dictionaryHints.isEmpty {
+            sttPromptComponents.append("Vocabulary: \(dictionaryHints)")
+            postProcessingPromptComponents.append("Vocabulary: \(dictionaryHints)")
+        }
+
+        let shortcutHints = shortcutManager.transcriptionHints
+        if !shortcutHints.isEmpty {
+            sttPromptComponents.append("Phrases: \(shortcutHints)")
+            postProcessingPromptComponents.append("Phrases: \(shortcutHints)")
+        }
+
+        let styleInstructions = toneStyleManager.allInstructions
+        if !styleInstructions.isEmpty {
+            postProcessingPromptComponents.append(styleInstructions)
+        }
+
+        return (
+            stt: sttPromptComponents.joined(separator: "\n"),
+            postProcessing: postProcessingPromptComponents.joined(separator: "\n")
+        )
+    }
+
+    private static func error(_ message: String) -> NSError {
+        NSError(
+            domain: "SharedTranscriptionService",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -11,8 +11,10 @@
 		7F4FEE534A3C48F98F9F7620 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = C1FA00022F0B000000000002 /* FluidAudio */; };
 		B2D5E0012F9BF00100000001 /* WhisperMateShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; };
 		B2D5E0022F9BF00100000002 /* WhisperMateShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B2D5E0052F9BF00100000005 /* ParakeetRuntime.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BD612DBBF5AF71F9E4D1B8A8 /* ParakeetRuntime.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B2D5E0032F9BF00100000003 /* WhisperMateKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C1CE64412ED8417000D24235 /* WhisperMateKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B2D5E0042F9BF00100000004 /* WhisperMateShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; };
+		B2D5E0062F9BF00100000006 /* ParakeetRuntime.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BD612DBBF5AF71F9E4D1B8A8 /* ParakeetRuntime.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BDFC47F5E1B86E447DC841F2 /* WhisperMateShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C12A3A102ED4CFAA002D97E6 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = C12A3A0F2ED4CFAA002D97E6 /* Supabase */; };
 		C12A3A142ED4D0AA002D97E6 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = C12A3A132ED4D0AA002D97E6 /* Auth */; };
@@ -28,6 +30,20 @@
 
 /* Begin PBXContainerItemProxy section */
 		42E01EF2CF78A5915AA93F0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C18566CB2EA0D31000B46F55 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 75F76DD9E51FB4E901E3F114;
+			remoteInfo = ParakeetRuntime;
+		};
+		42E01EF3CF78A5915AA93F0F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C18566CB2EA0D31000B46F55 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 75F76DD9E51FB4E901E3F114;
+			remoteInfo = ParakeetRuntime;
+		};
+		42E01EF4CF78A5915AA93F10 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C18566CB2EA0D31000B46F55 /* Project object */;
 			proxyType = 1;
@@ -90,6 +106,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				B2D5E0022F9BF00100000002 /* WhisperMateShared.framework in Embed Frameworks */,
+				B2D5E0052F9BF00100000005 /* ParakeetRuntime.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -100,6 +117,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				B2D5E0062F9BF00100000006 /* ParakeetRuntime.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -428,6 +446,7 @@
 			dependencies = (
 				C1E7D30B2EBA92C900A07338 /* PBXTargetDependency */,
 				C1E7D31A2EBA94A600A07338 /* PBXTargetDependency */,
+				931DC8AE381DB1589850BC93 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				C1E7D2EF2EBA92A500A07338 /* WhisperMateIOS */,
@@ -450,6 +469,7 @@
 			);
 			dependencies = (
 				C1E7D31F2EBA94EE00A07338 /* PBXTargetDependency */,
+				931DC8AF381DB1589850BC94 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				C1E7D3062EBA92C900A07338 /* WhisperMateKeyboard */,
@@ -639,6 +659,18 @@
 			target = 75F76DD9E51FB4E901E3F114 /* ParakeetRuntime */;
 			targetProxy = 42E01EF2CF78A5915AA93F0E /* PBXContainerItemProxy */;
 		};
+		931DC8AE381DB1589850BC93 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ParakeetRuntime;
+			target = 75F76DD9E51FB4E901E3F114 /* ParakeetRuntime */;
+			targetProxy = 42E01EF3CF78A5915AA93F0F /* PBXContainerItemProxy */;
+		};
+		931DC8AF381DB1589850BC94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ParakeetRuntime;
+			target = 75F76DD9E51FB4E901E3F114 /* ParakeetRuntime */;
+			targetProxy = 42E01EF4CF78A5915AA93F10 /* PBXContainerItemProxy */;
+		};
 		D1B200012F6500020000000D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PermissionFlowRuntime;
@@ -686,11 +718,12 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
-				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -715,11 +748,12 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
-				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
## Summary
- route iOS app and keyboard transcription through a shared service with Parakeet-backed offline mode
- add offline/cloud/automatic dictation mode controls and offline model preparation UI
- replace the keyboard extension surface with a full keyboard plus top recording controls

## Verification
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO

## Risks
- Parakeet/FluidAudio requires iOS 17 for the runtime target
- real-device keyboard extension model loading and microphone behavior still needs device QA