### PR TITLE
Fix iOS Parakeet runtime App Store packaging

### DIFF
--- a/Whishpermate/WhisperMateShared/Services/SharedParakeetTranscriptionService.swift
+++ b/Whishpermate/WhisperMateShared/Services/SharedParakeetTranscriptionService.swift
@@ -131,9 +131,7 @@ public final class SharedParakeetTranscriptionService: ObservableObject {
             return runtimeBridge
         }
 
-        guard let frameworkURL = Bundle.main.privateFrameworksURL?.appendingPathComponent("ParakeetRuntime.framework"),
-              let bundle = Bundle(url: frameworkURL)
-        else {
+        guard let bundle = runtimeFrameworkBundle() else {
             throw runtimeError("Offline mode is missing from this build.")
         }
 
@@ -154,6 +152,24 @@ public final class SharedParakeetTranscriptionService: ObservableObject {
         let bridge = bridgeClass.init()
         runtimeBridge = bridge
         return bridge
+    }
+
+    private func runtimeFrameworkBundle() -> Bundle? {
+        let frameworkName = "ParakeetRuntime.framework"
+        let appFrameworkURL = Bundle.main.privateFrameworksURL?.appendingPathComponent(frameworkName)
+        let containingAppFrameworkURL = Bundle.main.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Frameworks")
+            .appendingPathComponent(frameworkName)
+
+        for frameworkURL in [appFrameworkURL, containingAppFrameworkURL].compactMap({ $0 }) {
+            if let bundle = Bundle(url: frameworkURL) {
+                return bundle
+            }
+        }
+
+        return nil
     }
 
     private func initializeRuntimeBridge(_ bridge: NSObject) async throws {

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		B2D5E0052F9BF00100000005 /* ParakeetRuntime.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BD612DBBF5AF71F9E4D1B8A8 /* ParakeetRuntime.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B2D5E0032F9BF00100000003 /* WhisperMateKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C1CE64412ED8417000D24235 /* WhisperMateKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B2D5E0042F9BF00100000004 /* WhisperMateShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; };
-		B2D5E0062F9BF00100000006 /* ParakeetRuntime.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BD612DBBF5AF71F9E4D1B8A8 /* ParakeetRuntime.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BDFC47F5E1B86E447DC841F2 /* WhisperMateShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C12A3A102ED4CFAA002D97E6 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = C12A3A0F2ED4CFAA002D97E6 /* Supabase */; };
 		C12A3A142ED4D0AA002D97E6 /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = C12A3A132ED4D0AA002D97E6 /* Auth */; };
@@ -117,7 +116,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B2D5E0062F9BF00100000006 /* ParakeetRuntime.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -463,7 +461,6 @@
 				C1E7D3012EBA92C900A07338 /* Sources */,
 				C1E7D3022EBA92C900A07338 /* Frameworks */,
 				C1E7D3032EBA92C900A07338 /* Resources */,
-				C1E7D3202EBA94EE00A07338 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -720,6 +717,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.0.83;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;
@@ -750,6 +748,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.0.83;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
## Summary
- stop embedding ParakeetRuntime.framework inside the keyboard extension
- load the offline runtime from the containing app Frameworks directory when running in the keyboard
- add MARKETING_VERSION to ParakeetRuntime so generated Info.plist includes CFBundleShortVersionString

## Verification
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO
- verified built app contains ParakeetRuntime.framework only under WhisperMateIOS.app/Frameworks
- verified WhisperMateKeyboard.appex has no Frameworks directory
- verified ParakeetRuntime.framework Info.plist has CFBundleShortVersionString = 0.0.83

## Not tested
- altool upload after this packaging-only fix