### PR TITLE
Use Android waveform record button on iOS

### DIFF
--- a/Whishpermate/WhisperMateIOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Whishpermate/WhisperMateIOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0x6E",
-          "red" : "0xF1"
+          "green" : "0x63",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -29,7 +29,6 @@ struct ContentView: View {
     var body: some View {
         // Use iPhone layout for all devices (scales nicely on iPad)
         iPhoneLayout
-            .tint(Color.dsPrimary)
             .alert("Login Unavailable", isPresented: $showLoginConfigurationAlert) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -119,16 +118,13 @@ struct ContentView: View {
             VStack {
                 Spacer()
                 Button(action: handleInlineRecordingTap) {
-                    ZStack {
-                        Circle()
-                            .fill(Color.dsPrimary)
-                            .frame(width: 64, height: 64)
-                            .shadow(color: .black.opacity(inlineRecording.isActive ? 0.28 : 0.2), radius: inlineRecording.isActive ? 10 : 4, x: 0, y: inlineRecording.isActive ? 5 : 2)
-
-                        InlineRecordingPrimaryIcon(isActive: inlineRecording.isActive)
-                            .id(inlineRecording.isActive ? "stop" : "mic")
-                            .transition(.opacity.combined(with: .scale(scale: 0.76)))
-                    }
+                    AIDictationMicButtonVisual(
+                        state: inlineRecording.visualState,
+                        audioLevel: inlineRecording.audioLevel,
+                        frequencyBands: inlineRecording.frequencyBands,
+                        size: 64
+                    )
+                    .shadow(color: .black.opacity(inlineRecording.isActive ? 0.28 : 0.2), radius: inlineRecording.isActive ? 10 : 4, x: 0, y: inlineRecording.isActive ? 5 : 2)
                 }
                 .buttonStyle(.plain)
                 .disabled(inlineRecording.state == .processing || inlineRecording.state == .completing)
@@ -150,16 +146,8 @@ struct ContentView: View {
             openRecordingSheet()
         }) {
             VStack(spacing: 16) {
-                ZStack {
-                    Circle()
-                        .fill(Color.dsPrimary)
-                        .frame(width: 120, height: 120)
-                        .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
-
-                    Image(systemName: "mic.fill")
-                        .font(.system(size: 50, weight: .semibold))
-                        .foregroundColor(.white)
-                }
+                AIDictationMicButtonVisual(state: .idle, size: 120)
+                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
 
                 Text("Tap to Record")
                     .font(.system(size: 20, weight: .medium, design: .default))
@@ -226,7 +214,7 @@ struct ContentView: View {
                     HStack {
                         Text("Manage Settings")
                             .font(.body)
-                            .foregroundColor(Color.dsPrimary)
+                            .foregroundColor(.primary)
                         Spacer()
                         Image(systemName: "chevron.right")
                             .font(.caption)
@@ -416,7 +404,6 @@ struct ContentView: View {
                             } label: {
                                 Label("Copy", systemImage: "doc.on.doc")
                             }
-                            .tint(Color.dsPrimary)
 
                             if recording.audioFileURL != nil {
                                 Button {
@@ -509,6 +496,7 @@ struct ContentView: View {
                     } else {
                         Button(action: openLogin) {
                             Label("Log In to Get More", systemImage: "person.crop.circle.badge.plus")
+                                .foregroundColor(.primary)
                         }
                     }
                 }
@@ -518,20 +506,22 @@ struct ContentView: View {
                         HStack {
                             Label("Microphone Access", systemImage: "mic.fill")
                             Spacer()
-                            Image(systemName: checkMicrophonePermission() == .granted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                                .foregroundColor(checkMicrophonePermission() == .granted ? .green : .orange)
-                        }
-                    }
+	                            Image(systemName: checkMicrophonePermission() == .granted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+	                                .foregroundColor(checkMicrophonePermission() == .granted ? .green : .orange)
+	                        }
+	                        .foregroundColor(.primary)
+	                    }
 
-                    Button(action: openKeyboardSettings) {
-                        HStack {
-                            Label("Keyboard Settings", systemImage: "keyboard")
+	                    Button(action: openKeyboardSettings) {
+	                        HStack {
+	                            Label("Keyboard Settings", systemImage: "keyboard")
                             Spacer()
-                            Image(systemName: "arrow.up.forward.square")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                }
+	                            Image(systemName: "arrow.up.forward.square")
+	                                .foregroundColor(.secondary)
+	                        }
+	                        .foregroundColor(.primary)
+	                    }
+	                }
 
                 Section("Dictation Mode") {
                     Picker("Mode", selection: Binding(
@@ -548,18 +538,19 @@ struct ContentView: View {
                         .foregroundColor(.secondary)
 
                     if transcriptionProviderManager.transcriptionMode != .cloud {
-                        Button(action: prepareOfflineModel) {
-                            HStack {
-                                Label(offlineModelStatusText, systemImage: offlineModelStatusIcon)
-                                Spacer()
+	                        Button(action: prepareOfflineModel) {
+	                            HStack {
+	                                Label(offlineModelStatusText, systemImage: offlineModelStatusIcon)
+	                                Spacer()
                                 if offlineModelIsBusy {
                                     ProgressView()
                                 } else {
-                                    Image(systemName: offlineModelTrailingIcon)
-                                        .foregroundColor(offlineModelStatusColor)
-                                }
-                            }
-                        }
+	                                    Image(systemName: offlineModelTrailingIcon)
+	                                        .foregroundColor(offlineModelStatusColor)
+	                                }
+	                            }
+	                            .foregroundColor(.primary)
+	                        }
                         .disabled(!SharedParakeetTranscriptionService.isRuntimeSupported || offlineModelIsBusy)
                     }
                 }
@@ -573,11 +564,12 @@ struct ContentView: View {
                     }
                 }
 
-                Section("Transcription") {
-                    NavigationLink(destination: TranscriptionSettingsView(dictionaryManager: dictionaryManager, toneStyleManager: toneStyleManager, shortcutManager: shortcutManager)) {
-                        Label("Transcription Settings", systemImage: "text.badge.checkmark")
-                    }
-                }
+	                Section("Transcription") {
+	                    NavigationLink(destination: TranscriptionSettingsView(dictionaryManager: dictionaryManager, toneStyleManager: toneStyleManager, shortcutManager: shortcutManager)) {
+	                        Label("Transcription Settings", systemImage: "text.badge.checkmark")
+	                            .foregroundColor(.primary)
+	                    }
+	                }
 
                 Section("Data") {
                     Button("Clear All History", role: .destructive) {
@@ -763,13 +755,13 @@ private struct UsageSummaryView: View {
                 Label("Words This Month", systemImage: "text.word.spacing")
                     .font(.body.weight(.medium))
                 Spacer()
-                Text(planLabel)
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(Color.dsPrimary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.dsPrimary.opacity(0.12))
-                    .clipShape(Capsule())
+	                Text(planLabel)
+	                    .font(.caption.weight(.semibold))
+	                    .foregroundColor(.secondary)
+	                    .padding(.horizontal, 8)
+	                    .padding(.vertical, 4)
+	                    .background(Color(uiColor: .tertiarySystemFill))
+	                    .clipShape(Capsule())
             }
 
             if let email {
@@ -795,10 +787,10 @@ private struct UsageSummaryView: View {
                     .foregroundColor(.secondary)
             }
 
-            if !usage.isPro {
-                ProgressView(value: min(max(usage.percentage, 0), 1))
-                    .tint(Color.dsPrimary)
-            }
+	            if !usage.isPro {
+	                ProgressView(value: min(max(usage.percentage, 0), 1))
+	                    .tint(.secondary)
+	            }
         }
         .padding(.vertical, 6)
     }
@@ -832,6 +824,19 @@ private final class InlineRecordingCoordinator: ObservableObject {
 
     var isActive: Bool {
         state == .recording || state == .paused || state == .processing
+    }
+
+    var visualState: AIDictationRecordingState {
+        switch state {
+        case .idle:
+            return .idle
+        case .recording:
+            return .recording
+        case .paused:
+            return .paused
+        case .processing, .completing:
+            return .processing
+        }
     }
 
     var isPanelVisible: Bool {
@@ -1201,24 +1206,6 @@ private struct InlineRecordingPanel: View {
             Button("Dismiss", action: dismissErrorAction)
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundColor(Color.dsPrimary)
-        }
-    }
-}
-
-private struct InlineRecordingPrimaryIcon: View {
-    let isActive: Bool
-
-    var body: some View {
-        ZStack {
-            if isActive {
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(Color.white)
-                    .frame(width: 22, height: 22)
-            } else {
-                Image(systemName: "mic.fill")
-                    .font(.system(size: 28, weight: .semibold))
-                    .foregroundColor(.white)
-            }
         }
     }
 }

--- a/Whishpermate/WhisperMateShared/AIDictationRecordingSurface.swift
+++ b/Whishpermate/WhisperMateShared/AIDictationRecordingSurface.swift
@@ -53,8 +53,6 @@ public struct AIDictationRecordingSurface: View {
     private let primaryButtonSize: CGFloat = 80
     private let secondaryButtonSize: CGFloat = 54
     private let buttonGap: CGFloat = 14
-    private let stopIconSize: CGFloat = 23
-    private let recordColor = Color(red: 1.0, green: 0.20, blue: 0.24)
     private let visualColor = Color.white
     private let stateAnimation = Animation.spring(response: 0.32, dampingFraction: 0.82, blendDuration: 0.06)
     private let fadeAnimation = Animation.easeInOut(duration: 0.18)
@@ -157,32 +155,16 @@ public struct AIDictationRecordingSurface: View {
 
     private var primaryButton: some View {
         Button(action: onPrimaryAction) {
-            ZStack {
-                Circle()
-                    .fill(recordColor)
-                    .frame(width: primaryButtonSize, height: primaryButtonSize)
-                    .shadow(color: .black.opacity(state.isActive ? 0.45 : 0.18), radius: state.isActive ? 10 : 8, x: 0, y: 5)
-
-                primaryIcon
-                    .id(state == .idle ? "mic" : "stop")
-                    .transition(.opacity.combined(with: .scale(scale: 0.74)))
-            }
+            AIDictationMicButtonVisual(
+                state: state,
+                audioLevel: model.audioLevel,
+                frequencyBands: model.frequencyBands,
+                size: primaryButtonSize
+            )
+            .shadow(color: .black.opacity(state.isActive ? 0.45 : 0.18), radius: state.isActive ? 10 : 8, x: 0, y: 5)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(state == .idle ? "Start recording" : "Stop recording")
-    }
-
-    @ViewBuilder
-    private var primaryIcon: some View {
-        if state == .idle {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 36, weight: .semibold))
-                .foregroundColor(.white)
-        } else {
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.white)
-                .frame(width: stopIconSize, height: stopIconSize)
-        }
     }
 
     private var pauseButton: some View {

--- a/Whishpermate/WhisperMateShared/AudioVisualizationView.swift
+++ b/Whishpermate/WhisperMateShared/AudioVisualizationView.swift
@@ -1,5 +1,147 @@
 import SwiftUI
 
+public struct AIDictationMicButtonVisual: View {
+    public let state: AIDictationRecordingState
+    public let audioLevel: Float
+    public let frequencyBands: [Float]?
+    public var size: CGFloat
+
+    public init(
+        state: AIDictationRecordingState,
+        audioLevel: Float = 0,
+        frequencyBands: [Float]? = nil,
+        size: CGFloat = 100
+    ) {
+        self.state = state
+        self.audioLevel = audioLevel
+        self.frequencyBands = frequencyBands
+        self.size = size
+    }
+
+    public var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+            let phase = timeline.date.timeIntervalSinceReferenceDate
+                .truncatingRemainder(dividingBy: MicButtonMetrics.processingDuration)
+                / MicButtonMetrics.processingDuration
+
+            ZStack {
+                Circle()
+                    .fill(Color.dsPrimary)
+                    .frame(width: size, height: size)
+
+                HStack(spacing: MicButtonMetrics.barSpacing * scale) {
+                    ForEach(0 ..< MicButtonMetrics.barCount, id: \.self) { index in
+                        RoundedRectangle(cornerRadius: MicButtonMetrics.barWidth * scale / 2)
+                            .fill(Color.white)
+                            .frame(
+                                width: MicButtonMetrics.barWidth * scale,
+                                height: barHeight(at: index, phase: phase)
+                            )
+                            .animation(.spring(response: 0.32, dampingFraction: 0.72), value: audioLevel)
+                            .animation(.spring(response: 0.32, dampingFraction: 0.72), value: frequencyBands ?? [])
+                    }
+                }
+            }
+            .frame(width: size, height: size)
+        }
+    }
+
+    private var scale: CGFloat {
+        size / MicButtonMetrics.referenceSize
+    }
+
+    private func barHeight(at index: Int, phase: TimeInterval) -> CGFloat {
+        let dotSize = MicButtonMetrics.barWidth * scale
+        let maxHeight = MicButtonMetrics.maxBarHeight * scale
+        let heightRange = maxHeight - dotSize
+        let normalizedHeight: CGFloat
+
+        switch state {
+        case .idle, .paused:
+            normalizedHeight = MicButtonMetrics.frozenHeights[index]
+        case .recording:
+            normalizedHeight = recordingHeight(at: index)
+        case .processing:
+            let progress = CGFloat(phase)
+            let normalizedIndex = CGFloat(index) / CGFloat(MicButtonMetrics.barCount - 1)
+            let wavePosition = (normalizedIndex * 2 * .pi) - (progress * 2 * .pi)
+            let sineValue = (sin(wavePosition) + 1) / 2
+            normalizedHeight = sineValue * MicButtonMetrics.circleEnvelopeHeights[index]
+        }
+
+        return dotSize + (heightRange * normalizedHeight)
+    }
+
+    private func recordingHeight(at index: Int) -> CGFloat {
+        let boostedLevel = boostWaveformLevel(CGFloat(audioLevel))
+        let activeBarCount = min(
+            MicButtonMetrics.barCount,
+            max(MicButtonMetrics.minimumActiveBars, MicButtonMetrics.minimumActiveBars + Int(CGFloat(MicButtonMetrics.barCount - MicButtonMetrics.minimumActiveBars) * boostedLevel * 2.5))
+        )
+        let barsFromEdge = (MicButtonMetrics.barCount - activeBarCount) / 2
+        let minimumDistanceFromEdge = min(index, MicButtonMetrics.barCount - 1 - index)
+
+        guard minimumDistanceFromEdge >= barsFromEdge else {
+            return 0
+        }
+
+        let bandValue = recordingBandValue(at: index)
+        let boostedBand = boostWaveformLevel(bandValue, overallLevel: CGFloat(audioLevel))
+        return boostedBand * MicButtonMetrics.circleEnvelopeHeights[index]
+    }
+
+    private func recordingBandValue(at index: Int) -> CGFloat {
+        guard let frequencyBands, !frequencyBands.isEmpty else {
+            return CGFloat(audioLevel).clamped(to: 0 ... 1)
+        }
+
+        let sourcePosition = CGFloat(index) * CGFloat(frequencyBands.count - 1) / CGFloat(MicButtonMetrics.barCount - 1)
+        let lowerIndex = min(max(Int(sourcePosition), 0), frequencyBands.count - 1)
+        let upperIndex = min(lowerIndex + 1, frequencyBands.count - 1)
+        let fraction = sourcePosition - CGFloat(lowerIndex)
+        let lower = CGFloat(frequencyBands[lowerIndex]).clamped(to: 0 ... 1)
+        let upper = CGFloat(frequencyBands[upperIndex]).clamped(to: 0 ... 1)
+        let interpolated = lower + ((upper - lower) * fraction)
+        let average = frequencyBands
+            .map { CGFloat($0).clamped(to: 0 ... 1) }
+            .reduce(0, +) / CGFloat(frequencyBands.count)
+        let contrasted = interpolated + ((interpolated - average) * MicButtonMetrics.waveformContrast)
+        let floor = audioLevel > Float(MicButtonMetrics.waveformFloorThreshold) ? CGFloat(audioLevel) * 0.18 : 0
+        return max(contrasted, floor).clamped(to: 0 ... 1)
+    }
+
+    private func boostWaveformLevel(_ level: CGFloat, overallLevel: CGFloat? = nil) -> CGFloat {
+        let mixedOverallLevel = overallLevel ?? level
+        let mixed = ((level * MicButtonMetrics.waveformLevelGain) + (mixedOverallLevel * MicButtonMetrics.waveformLevelMix)).clamped(to: 0 ... 1)
+        let eased = sqrt(mixed)
+        let floor = mixedOverallLevel > MicButtonMetrics.waveformFloorThreshold ? MicButtonMetrics.waveformActiveFloor : 0
+        return max(eased, floor).clamped(to: 0 ... 1)
+    }
+}
+
+private enum MicButtonMetrics {
+    static let referenceSize: CGFloat = 100
+    static let barCount = 5
+    static let minimumActiveBars = 3
+    static let barWidth: CGFloat = 9.2
+    static let barSpacing: CGFloat = 4.4
+    static let maxBarHeight: CGFloat = 49.6
+    static let processingDuration: TimeInterval = 0.9
+    static let frozenHeights: [CGFloat] = [0.56, 1, 0.56, 1, 0.56]
+    static let circleEnvelopeHeights: [CGFloat] = [0.72, 0.94, 1, 0.94, 0.72]
+    static let waveformLevelGain: CGFloat = 1.35
+    static let waveformLevelMix: CGFloat = 0.08
+    static let waveformContrast: CGFloat = 0.8
+    static let waveformFloorThreshold: CGFloat = 0.045
+    static let waveformActiveFloor: CGFloat = 0.16
+}
+
+private extension CGFloat {
+    func clamped(to range: ClosedRange<CGFloat>) -> CGFloat {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}
+
 public struct AudioVisualizationView: View {
     public let audioLevel: Float
     public let frequencyBands: [Float]?


### PR DESCRIPTION
## Summary
- port the Android circular five-bar record affordance into shared SwiftUI
- use it for the iOS floating record button and recording sheet primary control
- correct iOS brand color to #FF6300
- keep settings/menu controls on standard iOS colors per HIG, reserving brand color for recording affordances

## Verification
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -configuration Debug -destination 'platform=iOS Simulator,id=C2FBC267-8F51-47E6-ABCE-3FB364A4B786' build CODE_SIGNING_ALLOWED=NO
- installed and relaunched on the iPhone 17 simulator

## Not tested
- physical iOS device visual QA