### PR TITLE
Show offline model download progress bar

### DIFF
--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -538,19 +538,25 @@ struct ContentView: View {
                         .foregroundColor(.secondary)
 
                     if transcriptionProviderManager.transcriptionMode != .cloud {
-	                        Button(action: prepareOfflineModel) {
-	                            HStack {
-	                                Label(offlineModelStatusText, systemImage: offlineModelStatusIcon)
-	                                Spacer()
+                        Button(action: prepareOfflineModel) {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Label(offlineModelStatusText, systemImage: offlineModelStatusIcon)
+                                    Spacer()
+                                    if !offlineModelIsBusy {
+                                        Image(systemName: offlineModelTrailingIcon)
+                                            .foregroundColor(offlineModelStatusColor)
+                                    }
+                                }
+
                                 if offlineModelIsBusy {
                                     ProgressView()
-                                } else {
-	                                    Image(systemName: offlineModelTrailingIcon)
-	                                        .foregroundColor(offlineModelStatusColor)
-	                                }
-	                            }
-	                            .foregroundColor(.primary)
-	                        }
+                                        .progressViewStyle(.linear)
+                                        .tint(.secondary)
+                                }
+                            }
+                            .foregroundColor(.primary)
+                        }
                         .disabled(!SharedParakeetTranscriptionService.isRuntimeSupported || offlineModelIsBusy)
                     }
                 }


### PR DESCRIPTION
## Summary
- replace the offline model row spinner with a linear progress bar while downloading or preparing
- keep the bar indeterminate because the current Parakeet runtime bridge only exposes coarse state, not byte progress

## Verification
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -configuration Debug -destination 'platform=iOS Simulator,id=C2FBC267-8F51-47E6-ABCE-3FB364A4B786' build CODE_SIGNING_ALLOWED=NO

## Not tested
- real-device model download