### PR TITLE
Polish iOS dictation settings and sharing

### DIFF
--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     @State private var offlineModelMessage = ""
     @State private var newlyInsertedRecordingID: UUID?
     @State private var historySearchText = ""
+    @State private var recordingToShare: Recording?
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
@@ -83,6 +84,9 @@ struct ContentView: View {
             }
             .sheet(item: $selectedRecording) { recording in
                 RecordingSheetView(historyManager: historyManager, dictionaryManager: dictionaryManager, toneStyleManager: toneStyleManager, shortcutManager: shortcutManager, recording: recording)
+            }
+            .sheet(item: $recordingToShare) { recording in
+                ShareSheet(activityItems: [recording.transcription])
             }
         }
         .navigationViewStyle(.stack)
@@ -265,12 +269,12 @@ struct ContentView: View {
                             .background(Color(uiColor: .secondarySystemGroupedBackground))
                             .cornerRadius(10)
                         }
-                        .contextMenu {
-                            Button(action: {
-                                UIPasteboard.general.string = recording.transcription
-                            }) {
-                                Label("Copy", systemImage: "doc.on.doc")
-                            }
+	                        .contextMenu {
+	                            Button(action: {
+	                                recordingToShare = recording
+	                            }) {
+	                                Label("Share", systemImage: "square.and.arrow.up")
+	                            }
 
                             Button(role: .destructive, action: {
                                 historyManager.deleteRecording(recording)
@@ -313,20 +317,6 @@ struct ContentView: View {
                 Divider()
                     .padding(.vertical, 8)
 
-                // App Info
-                HStack {
-                    Text("Version")
-                        .font(.body)
-                    Spacer()
-                    Text("0.0.20")
-                        .font(.body)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
-                .background(Color(uiColor: .secondarySystemGroupedBackground))
-                .cornerRadius(10)
-
                 // Clear History
                 Button(action: {
                     historyManager.clearAll()
@@ -342,6 +332,20 @@ struct ContentView: View {
                     .cornerRadius(10)
                 }
                 .disabled(historyManager.recordings.isEmpty)
+
+                // App Info
+                HStack {
+                    Text("Version")
+                        .font(.body)
+                    Spacer()
+                    Text(appVersionText)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                .cornerRadius(10)
             }
         }
     }
@@ -400,9 +404,9 @@ struct ContentView: View {
                             }
 
                             Button {
-                                UIPasteboard.general.string = recording.transcription
+                                recordingToShare = recording
                             } label: {
-                                Label("Copy", systemImage: "doc.on.doc")
+                                Label("Share", systemImage: "square.and.arrow.up")
                             }
 
                             if recording.audioFileURL != nil {
@@ -437,6 +441,9 @@ struct ContentView: View {
             }
             .sheet(item: $selectedRecording) { recording in
                 RecordingSheetView(historyManager: historyManager, dictionaryManager: dictionaryManager, toneStyleManager: toneStyleManager, shortcutManager: shortcutManager, recording: recording)
+            }
+            .sheet(item: $recordingToShare) { recording in
+                ShareSheet(activityItems: [recording.transcription])
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
@@ -524,64 +531,70 @@ struct ContentView: View {
 	                }
 
                 Section("Dictation Mode") {
-                    Picker("Mode", selection: Binding(
-                        get: { transcriptionProviderManager.transcriptionMode },
-                        set: { transcriptionProviderManager.setTranscriptionMode($0) }
-                    )) {
-                        ForEach(TranscriptionMode.availableCases) { mode in
-                            Text(mode.displayName).tag(mode)
+                    NavigationLink {
+                        TranscriptionModeSelectionView(
+                            transcriptionProviderManager: transcriptionProviderManager,
+                            parakeetService: parakeetService,
+                            offlineModelStatusText: offlineModelStatusText,
+                            offlineModelStatusIcon: offlineModelStatusIcon,
+                            offlineModelTrailingIcon: offlineModelTrailingIcon,
+                            offlineModelStatusColor: offlineModelStatusColor,
+                            offlineModelIsBusy: offlineModelIsBusy,
+                            prepareOfflineModel: prepareOfflineModel
+                        )
+                    } label: {
+                        HStack {
+                            Label("Model", systemImage: "waveform.badge.magnifyingglass")
+                            Spacer()
+                            Text(transcriptionProviderManager.transcriptionMode.displayName)
+                                .foregroundColor(.secondary)
                         }
                     }
+                }
 
-                    Text(transcriptionProviderManager.transcriptionMode.description)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    if transcriptionProviderManager.transcriptionMode != .cloud {
-                        Button(action: prepareOfflineModel) {
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Label(offlineModelStatusText, systemImage: offlineModelStatusIcon)
-                                    Spacer()
-                                    if !offlineModelIsBusy {
-                                        Image(systemName: offlineModelTrailingIcon)
-                                            .foregroundColor(offlineModelStatusColor)
-                                    }
-                                }
-
-                                if offlineModelIsBusy {
-                                    ProgressView()
-                                        .progressViewStyle(.linear)
-                                        .tint(.secondary)
-                                }
-                            }
+                Section("Transcription") {
+                    NavigationLink {
+                        DictionaryView(manager: dictionaryManager)
+                            .navigationTitle("Dictionary")
+                            .navigationBarTitleDisplayMode(.inline)
+                    } label: {
+                        Label("Dictionary", systemImage: "text.badge.checkmark")
                             .foregroundColor(.primary)
-                        }
-                        .disabled(!SharedParakeetTranscriptionService.isRuntimeSupported || offlineModelIsBusy)
+                    }
+
+                    NavigationLink {
+                        ToneStyleView(manager: toneStyleManager)
+                            .navigationTitle("Tone & Style")
+                            .navigationBarTitleDisplayMode(.inline)
+                    } label: {
+                        Label("Tone & Style", systemImage: "wand.and.stars")
+                            .foregroundColor(.primary)
+                    }
+
+                    NavigationLink {
+                        ShortcutsView(manager: shortcutManager)
+                            .navigationTitle("Shortcuts")
+                            .navigationBarTitleDisplayMode(.inline)
+                    } label: {
+                        Label("Shortcuts", systemImage: "text.append")
+                            .foregroundColor(.primary)
                     }
                 }
-
-                Section("About") {
-                    HStack {
-                        Text("Version")
-                        Spacer()
-                        Text("0.0.20")
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-	                Section("Transcription") {
-	                    NavigationLink(destination: TranscriptionSettingsView(dictionaryManager: dictionaryManager, toneStyleManager: toneStyleManager, shortcutManager: shortcutManager)) {
-	                        Label("Transcription Settings", systemImage: "text.badge.checkmark")
-	                            .foregroundColor(.primary)
-	                    }
-	                }
 
                 Section("Data") {
                     Button("Clear All History", role: .destructive) {
                         historyManager.clearAll()
                     }
                     .disabled(historyManager.recordings.isEmpty)
+                }
+
+                Section {
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        Text(appVersionText)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
             .navigationTitle("Settings")
@@ -618,15 +631,31 @@ struct ContentView: View {
         openAppSettings()
     }
 
+    private var appVersionText: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+
+        switch (version?.isEmpty == false ? version : nil, build?.isEmpty == false ? build : nil) {
+        case let (.some(version), .some(build)):
+            return "\(version) (\(build))"
+        case let (.some(version), .none):
+            return version
+        case let (.none, .some(build)):
+            return build
+        case (.none, .none):
+            return "Unknown"
+        }
+    }
+
     private var offlineModelStatusIcon: String {
         guard SharedParakeetTranscriptionService.isRuntimeSupported else {
             return "exclamationmark.triangle.fill"
         }
-        switch parakeetService.state {
-        case .downloading:
-            return "arrow.down.circle"
-        case .initializing:
-            return "gearshape"
+	        switch parakeetService.state {
+	        case .downloading:
+	            return "arrow.down.circle"
+	        case .initializing:
+	            return "arrow.down.circle"
         case .ready, .transcribing:
             return "checkmark.circle.fill"
         case .error:
@@ -799,6 +828,130 @@ private struct UsageSummaryView: View {
 	            }
         }
         .padding(.vertical, 6)
+    }
+}
+
+private struct TranscriptionModeSelectionView: View {
+    @ObservedObject var transcriptionProviderManager: TranscriptionProviderManager
+    @ObservedObject var parakeetService: SharedParakeetTranscriptionService
+    let offlineModelStatusText: String
+    let offlineModelStatusIcon: String
+    let offlineModelTrailingIcon: String
+    let offlineModelStatusColor: Color
+    let offlineModelIsBusy: Bool
+    let prepareOfflineModel: () -> Void
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(TranscriptionMode.availableCases) { mode in
+                    modeButton(for: mode)
+                }
+            } footer: {
+                Text("Choose cloud for best accuracy, offline for private on-device speed, or automatic to let AIDictation choose.")
+            }
+
+            if transcriptionProviderManager.transcriptionMode != .cloud {
+                Section("Offline Model") {
+                    Button(action: prepareOfflineModel) {
+                        VStack(alignment: .leading, spacing: 8) {
+	                            HStack {
+	                                Label {
+	                                    HStack(spacing: 8) {
+	                                        Text(offlineModelStatusText)
+	                                        if offlineModelIsBusy {
+	                                            ProgressView()
+	                                                .controlSize(.small)
+	                                        }
+	                                    }
+	                                } icon: {
+	                                    Image(systemName: offlineModelStatusIcon)
+	                                }
+	                                Spacer()
+                                if !offlineModelIsBusy {
+                                    Image(systemName: offlineModelTrailingIcon)
+                                        .foregroundColor(offlineModelStatusColor)
+                                }
+                            }
+
+                            if offlineModelIsBusy {
+                                ProgressView()
+                                    .progressViewStyle(.linear)
+                                    .tint(.secondary)
+                            }
+                        }
+                        .foregroundColor(.primary)
+                    }
+                    .disabled(!SharedParakeetTranscriptionService.isRuntimeSupported || offlineModelIsBusy)
+                }
+            }
+        }
+        .navigationTitle("Model")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func modeButton(for mode: TranscriptionMode) -> some View {
+        let isSelected = transcriptionProviderManager.transcriptionMode == mode
+        let rating = modeRating(for: mode)
+
+        return Button {
+            transcriptionProviderManager.setTranscriptionMode(mode)
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundColor(isSelected ? .primary : .secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(mode.displayName)
+                        .font(.body.weight(.medium))
+                        .foregroundColor(.primary)
+
+                    Text(mode.description)
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                modeStars(speed: rating.speed, accuracy: rating.accuracy)
+            }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func modeStars(speed: Int, accuracy: Int) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            ratingRow(title: "Speed", value: speed)
+            ratingRow(title: "Accuracy", value: accuracy)
+        }
+    }
+
+    private func ratingRow(title: String, value: Int) -> some View {
+        HStack(spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .frame(width: 50, alignment: .leading)
+
+            ForEach(0 ..< 4, id: \.self) { index in
+                Image(systemName: index < value ? "star.fill" : "star")
+                    .font(.caption2)
+                    .foregroundColor(index < value ? .primary : .secondary.opacity(0.45))
+            }
+        }
+    }
+
+    private func modeRating(for mode: TranscriptionMode) -> (speed: Int, accuracy: Int) {
+        switch mode {
+        case .cloud: return (speed: 3, accuracy: 4)
+        case .offline: return (speed: 4, accuracy: 3)
+        case .automatic: return (speed: 4, accuracy: 4)
+        @unknown default: return (speed: 3, accuracy: 3)
+        }
     }
 }
 

--- a/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
+++ b/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
@@ -17,7 +17,7 @@ struct RecordingSheetView: View {
     @State private var transcription = ""
     @State private var errorMessage = ""
     @State private var recordingStartTime: Date?
-    @State private var showCopiedNotification = false
+    @State private var showShareSheet = false
     @State private var currentRecording: Recording?
     @State private var audioPlayer: AVAudioPlayer?
     @State private var isPlaying = false
@@ -187,13 +187,12 @@ struct RecordingSheetView: View {
 
             // Bottom toolbar
             VStack(spacing: 0) {
-                Button(action: copyTranscription) {
-                    Label(showCopiedNotification ? "Copied" : "Copy",
-                          systemImage: showCopiedNotification ? "checkmark" : "doc.on.doc")
+                Button(action: shareTranscription) {
+                    Label("Share", systemImage: "square.and.arrow.up")
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(showCopiedNotification ? Color.green : Color.dsPrimary)
+                .tint(Color.dsPrimary)
                 .controlSize(.large)
                 .padding(.horizontal, 20)
                 .padding(.top, 16)
@@ -202,6 +201,9 @@ struct RecordingSheetView: View {
             .background(Color.white)
         }
         .background(Color.white)
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(activityItems: [transcription])
+        }
     }
 
     // MARK: - Actions
@@ -490,20 +492,9 @@ struct RecordingSheetView: View {
         }
     }
 
-    private func copyTranscription() {
+    private func shareTranscription() {
         guard !transcription.isEmpty else { return }
-
-        UIPasteboard.general.string = transcription
-
-        // Show copied notification
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
-            showCopiedNotification = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                showCopiedNotification = false
-            }
-        }
+        showShareSheet = true
     }
 
     private func togglePlayback(audioURL: URL) {

--- a/Whishpermate/WhisperMateIOS/ShareSheet.swift
+++ b/Whishpermate/WhisperMateIOS/ShareSheet.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context _: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}

--- a/Whishpermate/WhisperMateIOS/TranscriptionSettingsView.swift
+++ b/Whishpermate/WhisperMateIOS/TranscriptionSettingsView.swift
@@ -40,7 +40,6 @@ struct TranscriptionSettingsView: View {
 struct DictionaryView: View {
     @ObservedObject var manager: DictionaryManager
     @State private var newTrigger = ""
-    @State private var newReplacement = ""
     @State private var editingEntry: DictionaryEntry?
 
     var body: some View {
@@ -51,9 +50,6 @@ struct DictionaryView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(entry.trigger)
                                 .font(.body)
-                            Text("→ \(entry.replacement)")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
                         }
 
                         Spacer()
@@ -62,6 +58,10 @@ struct DictionaryView: View {
                             get: { entry.isEnabled },
                             set: { _ in manager.toggleEntry(entry) }
                         ))
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        editingEntry = entry
                     }
                 }
                 .onDelete { indexSet in
@@ -74,10 +74,9 @@ struct DictionaryView: View {
 
             Section(header: Text("Add New Entry"), footer: Text("Dictionary entries help recognize and format specific words correctly")) {
                 VStack(spacing: 12) {
-                    TextField("Trigger word", text: $newTrigger)
-                    TextField("Replacement", text: $newReplacement)
+                    TextField("Word or phrase", text: $newTrigger)
 
-                    if !newTrigger.isEmpty && !newReplacement.isEmpty {
+                    if !newTrigger.isEmpty {
                         Button(action: addEntry) {
                             Label("Add Entry", systemImage: "plus.circle.fill")
                                 .frame(maxWidth: .infinity)
@@ -87,13 +86,57 @@ struct DictionaryView: View {
                 }
             }
         }
+        .sheet(item: $editingEntry) { entry in
+            EditDictionaryEntrySheet(manager: manager, entry: entry)
+        }
     }
 
     private func addEntry() {
-        guard !newTrigger.isEmpty, !newReplacement.isEmpty else { return }
-        manager.addEntry(trigger: newTrigger, replacement: newReplacement)
+        guard !newTrigger.isEmpty else { return }
+        manager.addEntry(trigger: newTrigger, replacement: nil)
         newTrigger = ""
-        newReplacement = ""
+    }
+}
+
+struct EditDictionaryEntrySheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var manager: DictionaryManager
+    let entry: DictionaryEntry
+
+    @State private var trigger: String
+
+    init(manager: DictionaryManager, entry: DictionaryEntry) {
+        self.manager = manager
+        self.entry = entry
+        _trigger = State(initialValue: entry.trigger)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Entry") {
+                    TextField("Word or phrase", text: $trigger)
+                }
+            }
+            .navigationTitle("Edit Dictionary")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        manager.updateEntry(
+                            entry,
+                            trigger: trigger,
+                            replacement: nil
+                        )
+                        dismiss()
+                    }
+                    .disabled(trigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
     }
 }
 
@@ -102,6 +145,7 @@ struct DictionaryView: View {
 struct ToneStyleView: View {
     @ObservedObject var manager: ToneStyleManager
     @State private var showingAddSheet = false
+    @State private var editingStyle: ContextRule?
 
     var body: some View {
         List {
@@ -131,6 +175,10 @@ struct ToneStyleView: View {
                         }
                     }
                     .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        editingStyle = style
+                    }
                 }
                 .onDelete { indexSet in
                     for index in indexSet {
@@ -148,6 +196,9 @@ struct ToneStyleView: View {
         }
         .sheet(isPresented: $showingAddSheet) {
             AddToneStyleSheet(manager: manager, isPresented: $showingAddSheet)
+        }
+        .sheet(item: $editingStyle) { style in
+            EditToneStyleSheet(manager: manager, style: style)
         }
     }
 }
@@ -206,12 +257,69 @@ struct AddToneStyleSheet: View {
     }
 }
 
+struct EditToneStyleSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var manager: ToneStyleManager
+    let style: ContextRule
+
+    @State private var name: String
+    @State private var appBundleIds: String
+    @State private var instructions: String
+
+    init(manager: ToneStyleManager, style: ContextRule) {
+        self.manager = manager
+        self.style = style
+        _name = State(initialValue: style.name)
+        _appBundleIds = State(initialValue: style.appBundleIds.joined(separator: ", "))
+        _instructions = State(initialValue: style.instructions)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Name") {
+                    TextField("e.g., Slack - Professional", text: $name)
+                }
+
+                Section(header: Text("App Bundle IDs"), footer: Text("Comma-separated list of app bundle IDs. Leave empty to apply to all apps.")) {
+                    TextField("e.g., com.tinyspeck.chatlyio", text: $appBundleIds)
+                }
+
+                Section(header: Text("Instructions"), footer: Text("Describe the tone, style, and formatting for this app")) {
+                    TextEditor(text: $instructions)
+                        .frame(minHeight: 100)
+                }
+            }
+            .navigationTitle("Edit Tone/Style")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let bundleIds = appBundleIds
+                            .split(separator: ",")
+                            .map { $0.trimmingCharacters(in: .whitespaces) }
+                            .filter { !$0.isEmpty }
+
+                        manager.updateStyle(style, name: name, appBundleIds: bundleIds, instructions: instructions)
+                        dismiss()
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || instructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Shortcuts View
 
 struct ShortcutsView: View {
     @ObservedObject var manager: ShortcutManager
     @State private var newTrigger = ""
     @State private var newExpansion = ""
+    @State private var editingShortcut: Shortcut?
 
     var body: some View {
         List {
@@ -233,6 +341,10 @@ struct ShortcutsView: View {
                             get: { shortcut.isEnabled },
                             set: { _ in manager.toggleShortcut(shortcut) }
                         ))
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        editingShortcut = shortcut
                     }
                 }
                 .onDelete { indexSet in
@@ -258,6 +370,9 @@ struct ShortcutsView: View {
                 }
             }
         }
+        .sheet(item: $editingShortcut) { shortcut in
+            EditShortcutSheet(manager: manager, shortcut: shortcut)
+        }
     }
 
     private func addShortcut() {
@@ -265,5 +380,46 @@ struct ShortcutsView: View {
         manager.addShortcut(voiceTrigger: newTrigger, expansion: newExpansion)
         newTrigger = ""
         newExpansion = ""
+    }
+}
+
+struct EditShortcutSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var manager: ShortcutManager
+    let shortcut: Shortcut
+
+    @State private var voiceTrigger: String
+    @State private var expansion: String
+
+    init(manager: ShortcutManager, shortcut: Shortcut) {
+        self.manager = manager
+        self.shortcut = shortcut
+        _voiceTrigger = State(initialValue: shortcut.voiceTrigger)
+        _expansion = State(initialValue: shortcut.expansion)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Shortcut") {
+                    TextField("Voice trigger", text: $voiceTrigger)
+                    TextField("Expansion text", text: $expansion)
+                }
+            }
+            .navigationTitle("Edit Shortcut")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        manager.updateShortcut(shortcut, voiceTrigger: voiceTrigger, expansion: expansion)
+                        dismiss()
+                    }
+                    .disabled(voiceTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || expansion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
     }
 }

--- a/Whishpermate/WhisperMateShared/AudioVisualizationView.swift
+++ b/Whishpermate/WhisperMateShared/AudioVisualizationView.swift
@@ -29,20 +29,29 @@ public struct AIDictationMicButtonVisual: View {
                     .fill(Color.dsPrimary)
                     .frame(width: size, height: size)
 
-                HStack(spacing: MicButtonMetrics.barSpacing * scale) {
-                    ForEach(0 ..< MicButtonMetrics.barCount, id: \.self) { index in
-                        RoundedRectangle(cornerRadius: MicButtonMetrics.barWidth * scale / 2)
-                            .fill(Color.white)
-                            .frame(
-                                width: MicButtonMetrics.barWidth * scale,
-                                height: barHeight(at: index, phase: phase)
-                            )
-                            .animation(.spring(response: 0.32, dampingFraction: 0.72), value: audioLevel)
-                            .animation(.spring(response: 0.32, dampingFraction: 0.72), value: frequencyBands ?? [])
+                if state == .recording {
+                    RoundedRectangle(cornerRadius: MicButtonMetrics.stopCornerRadius * scale, style: .continuous)
+                        .fill(Color.white)
+                        .frame(width: MicButtonMetrics.stopSize * scale, height: MicButtonMetrics.stopSize * scale)
+                        .transition(.opacity.combined(with: .scale(scale: 0.76)))
+                } else {
+                    HStack(spacing: MicButtonMetrics.barSpacing * scale) {
+                        ForEach(0 ..< MicButtonMetrics.barCount, id: \.self) { index in
+                            RoundedRectangle(cornerRadius: MicButtonMetrics.barWidth * scale / 2)
+                                .fill(Color.white)
+                                .frame(
+                                    width: MicButtonMetrics.barWidth * scale,
+                                    height: barHeight(at: index, phase: phase)
+                                )
+                                .animation(.spring(response: 0.32, dampingFraction: 0.72), value: audioLevel)
+                                .animation(.spring(response: 0.32, dampingFraction: 0.72), value: frequencyBands ?? [])
+                        }
                     }
+                    .transition(.opacity.combined(with: .scale(scale: 0.84)))
                 }
             }
             .frame(width: size, height: size)
+            .animation(.spring(response: 0.28, dampingFraction: 0.82), value: state)
         }
     }
 
@@ -126,6 +135,8 @@ private enum MicButtonMetrics {
     static let barWidth: CGFloat = 9.2
     static let barSpacing: CGFloat = 4.4
     static let maxBarHeight: CGFloat = 49.6
+    static let stopSize: CGFloat = 34
+    static let stopCornerRadius: CGFloat = 6
     static let processingDuration: TimeInterval = 0.9
     static let frozenHeights: [CGFloat] = [0.56, 1, 0.56, 1, 0.56]
     static let circleEnvelopeHeights: [CGFloat] = [0.72, 0.94, 1, 0.94, 0.72]

--- a/Whishpermate/WhisperMateShared/Managers/ContextRulesManager.swift
+++ b/Whishpermate/WhisperMateShared/Managers/ContextRulesManager.swift
@@ -129,6 +129,10 @@ public class ContextRulesManager: ObservableObject {
         toggleRule(style)
     }
 
+    public func updateStyle(_ style: ContextRule, name: String, appBundleIds: [String], instructions: String) {
+        updateRule(style, name: name, appBundleIds: appBundleIds, instructions: instructions)
+    }
+
     // MARK: - Context Matching
 
     /// Get instructions for a specific app bundle ID and window title

--- a/Whishpermate/WhisperMateShared/Managers/DictionaryManager.swift
+++ b/Whishpermate/WhisperMateShared/Managers/DictionaryManager.swift
@@ -30,16 +30,13 @@ public class DictionaryManager: ObservableObject {
             entries = decoded
             DebugLog.info("Loaded \(entries.count) dictionary entries", context: "DictionaryManager")
         } else {
-            // Add default entries with real-world examples (all disabled by default)
+            // Add default vocabulary examples (all disabled by default)
             entries = [
-                // Words needing correction (with replacements)
-                DictionaryEntry(trigger: "AI dictation", replacement: "AIDictation", isEnabled: false),
-                DictionaryEntry(trigger: "calendly", replacement: "Calendly", isEnabled: false),
-                DictionaryEntry(trigger: "open AI", replacement: "OpenAI", isEnabled: false),
-                DictionaryEntry(trigger: "chat GPT", replacement: "ChatGPT", isEnabled: false),
-                DictionaryEntry(trigger: "git hub", replacement: "GitHub", isEnabled: false),
-
-                // Technical terms (no replacement - just for recognition)
+                DictionaryEntry(trigger: "AIDictation", replacement: nil, isEnabled: false),
+                DictionaryEntry(trigger: "Calendly", replacement: nil, isEnabled: false),
+                DictionaryEntry(trigger: "OpenAI", replacement: nil, isEnabled: false),
+                DictionaryEntry(trigger: "ChatGPT", replacement: nil, isEnabled: false),
+                DictionaryEntry(trigger: "GitHub", replacement: nil, isEnabled: false),
                 DictionaryEntry(trigger: "API", replacement: nil, isEnabled: false),
                 DictionaryEntry(trigger: "iOS", replacement: nil, isEnabled: false),
                 DictionaryEntry(trigger: "macOS", replacement: nil, isEnabled: false),

--- a/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
+++ b/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
@@ -43,8 +43,7 @@ public enum SharedTranscriptionService {
             )
         }
 
-        var processedResult = dictionaryManager.applyReplacements(to: rawResult)
-        processedResult = shortcutManager.expandShortcuts(in: processedResult)
+        let processedResult = shortcutManager.expandShortcuts(in: rawResult)
         return TranscriptionTextSanitizer.cleanedText(processedResult)
     }
 


### PR DESCRIPTION
## Summary
- make active recording show a stop button
- replace copy actions with native sharing for history rows and recording details
- add a dedicated iOS model selector with speed/accuracy tradeoffs
- flatten transcription settings into top-level Dictionary, Tone & Style, and Shortcuts rows
- make Dictionary vocabulary-only while keeping substitutions in Shortcuts
- fix default Dictionary items to correctly spelled vocabulary terms
- move Version to the bottom and read it from the app bundle

## Verification
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -configuration Debug -destination 'platform=iOS Simulator,id=C2FBC267-8F51-47E6-ABCE-3FB364A4B786' build CODE_SIGNING_ALLOWED=NO
- installed and relaunched on the iPhone 17 simulator

## Not tested
- physical iOS device share sheet and offline model download