### PR TITLE
Fix iOS Fastlane App Store signing

### DIFF
--- a/Whishpermate/fastlane/Fastfile
+++ b/Whishpermate/fastlane/Fastfile
@@ -124,10 +124,11 @@ platform :ios do
         auth_args = "-allowProvisioningUpdates -authenticationKeyPath #{File.expand_path(ENV["APP_STORE_CONNECT_API_KEY_KEY"])} -authenticationKeyID #{ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]} -authenticationKeyIssuerID #{ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"]}"
       end
 
-      gym_options[:xcargs] = "DEVELOPMENT_TEAM=#{team_id} CODE_SIGN_STYLE=Automatic #{auth_args}".strip
+      gym_options[:xcargs] = "DEVELOPMENT_TEAM=#{team_id} CODE_SIGN_STYLE=Automatic CODE_SIGN_IDENTITY=\"Apple Distribution\" #{auth_args}".strip
       gym_options[:export_options] = {
         teamID: team_id,
-        signingStyle: "automatic"
+        signingStyle: "automatic",
+        signingCertificate: "Apple Distribution"
       }
     else
       app_profile = ENV["IOS_APPSTORE_PROFILE_NAME"].to_s.empty? ? "73de4d13-37e6-49ca-a9f0-35378e49c33d" : ENV["IOS_APPSTORE_PROFILE_NAME"]


### PR DESCRIPTION
## Summary
- pin the automatic iOS App Store archive path to Apple Distribution signing
- set the export signing certificate to Apple Distribution
- avoid CI trying to create/use iOS Development certs and development profiles for App Store archives

## Verification
- ruby -c Whishpermate/fastlane/Fastfile
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -configuration Debug -destination 'platform=iOS Simulator,id=C2FBC267-8F51-47E6-ABCE-3FB364A4B786' build CODE_SIGNING_ALLOWED=NO

## Not tested
- fastlane ios build with App Store Connect credentials