### PR TITLE
Let Fastlane detect CI keychain setup

### DIFF
--- a/Whishpermate/fastlane/Fastfile
+++ b/Whishpermate/fastlane/Fastfile
@@ -105,7 +105,7 @@ platform :ios do
   #####################################
   desc "Build the app for App Store"
   lane :build do
-    setup_ci(provider: "github_actions") if ENV["CI"].to_s == "true"
+    setup_ci if ENV["CI"].to_s == "true"
 
     # Increment build number
     if !ENV["IOS_BUILD_NUMBER"].to_s.empty?


### PR DESCRIPTION
## Summary
- remove unsupported explicit setup_ci provider value
- keep CI keychain setup before certificate/profile provisioning

## Verification
- ruby -c Whishpermate/fastlane/Fastfile
- git diff --check