### PR TITLE
Create iOS signing assets without Fastlane JWT

### DIFF
--- a/.github/workflows/ios-appstore-connect.yml
+++ b/.github/workflows/ios-appstore-connect.yml
@@ -189,6 +189,10 @@ jobs:
         shell: bash
         run: ./ci_scripts/ci_pre_xcodebuild.sh
 
+      - name: Prepare iOS signing assets
+        shell: bash
+        run: ./ci_scripts/prepare_ios_signing.js
+
       - name: Archive iOS app
         shell: bash
         working-directory: Whishpermate

--- a/Whishpermate/fastlane/Fastfile
+++ b/Whishpermate/fastlane/Fastfile
@@ -14,58 +14,9 @@ default_platform(:ios)
 #   )
 # end
 
-def app_store_connect_api_key_from_env
-  key_id = ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"].to_s
-  issuer_id = ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"].to_s
-  key_filepath = ENV["APP_STORE_CONNECT_API_KEY_KEY"].to_s
-  key_content = ENV["APP_STORE_CONNECT_API_KEY_P8"].to_s
-
-  if key_content.empty? && !ENV["APP_STORE_CONNECT_API_KEY_P8_BASE64"].to_s.empty?
-    require "base64"
-    key_content = Base64.decode64(ENV["APP_STORE_CONNECT_API_KEY_P8_BASE64"])
-  end
-
-  if key_id.empty? || issuer_id.empty? || (key_filepath.empty? && key_content.empty?)
-    return nil
-  end
-
-  params = {
-    key_id: key_id,
-    issuer_id: issuer_id,
-    in_house: false
-  }
-
-  if !key_filepath.empty?
-    params[:key_filepath] = File.expand_path(key_filepath)
-  else
-    params[:key_content] = key_content
-  end
-
-  app_store_connect_api_key(**params)
-end
-
 def provisioning_profile_settings(profile)
   uuid_pattern = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
   profile.match?(uuid_pattern) ? { profile_uuid: profile } : { profile_name: profile }
-end
-
-def app_store_profile(api_key:, team_id:, app_identifier:, filename:, provisioning_name:, cert_id:)
-  get_provisioning_profile(
-    api_key: api_key,
-    team_id: team_id,
-    app_identifier: app_identifier,
-    provisioning_name: provisioning_name,
-    filename: filename,
-    output_path: "./build/signing",
-    cert_id: cert_id,
-    force: true,
-    readonly: false
-  )
-
-  {
-    uuid: lane_context[SharedValues::SIGH_UUID],
-    name: lane_context[SharedValues::SIGH_NAME]
-  }
 end
 
 platform :ios do
@@ -105,8 +56,6 @@ platform :ios do
   #####################################
   desc "Build the app for App Store"
   lane :build do
-    setup_ci if ENV["CI"].to_s == "true"
-
     # Increment build number
     if !ENV["IOS_BUILD_NUMBER"].to_s.empty?
       committed_build_number = get_info_plist_value(
@@ -149,34 +98,10 @@ platform :ios do
       if !ENV["APP_STORE_CONNECT_API_KEY_KEY"].to_s.empty?
         auth_args = "-allowProvisioningUpdates -authenticationKeyPath #{File.expand_path(ENV["APP_STORE_CONNECT_API_KEY_KEY"])} -authenticationKeyID #{ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]} -authenticationKeyIssuerID #{ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"]}"
       end
-      api_key = app_store_connect_api_key_from_env
-      UI.user_error!("App Store Connect API key is required for CI signing") if api_key.nil?
-
-      get_certificates(
-        api_key: api_key,
-        team_id: team_id,
-        type: "distribution",
-        output_path: "./build/signing",
-        generate_apple_certs: true
-      )
-      distribution_cert_id = lane_context[SharedValues::CERT_CERTIFICATE_ID]
-
-      app_profile = app_store_profile(
-        api_key: api_key,
-        team_id: team_id,
-        app_identifier: app_identifier,
-        filename: "WhisperMateIOS_AppStore.mobileprovision",
-        provisioning_name: "WhisperMate iOS App Store CI",
-        cert_id: distribution_cert_id
-      )
-      keyboard_profile = app_store_profile(
-        api_key: api_key,
-        team_id: team_id,
-        app_identifier: "#{app_identifier}.keyboard",
-        filename: "WhisperMateKeyboard_AppStore.mobileprovision",
-        provisioning_name: "WhisperMate Keyboard App Store CI",
-        cert_id: distribution_cert_id
-      )
+      app_profile = ENV["IOS_APPSTORE_PROFILE_NAME"].to_s
+      keyboard_profile = ENV["IOS_KEYBOARD_APPSTORE_PROFILE_NAME"].to_s
+      UI.user_error!("IOS_APPSTORE_PROFILE_NAME is required for CI signing") if app_profile.empty?
+      UI.user_error!("IOS_KEYBOARD_APPSTORE_PROFILE_NAME is required for CI signing") if keyboard_profile.empty?
 
       update_code_signing_settings(
         use_automatic_signing: false,
@@ -185,7 +110,7 @@ platform :ios do
         targets: ["WhisperMateIOS"],
         build_configurations: ["Release"],
         code_sign_identity: "Apple Distribution",
-        profile_uuid: app_profile[:uuid]
+        **provisioning_profile_settings(app_profile)
       )
 
       update_code_signing_settings(
@@ -195,7 +120,7 @@ platform :ios do
         targets: ["WhisperMateKeyboard"],
         build_configurations: ["Release"],
         code_sign_identity: "Apple Distribution",
-        profile_uuid: keyboard_profile[:uuid]
+        **provisioning_profile_settings(keyboard_profile)
       )
 
       update_code_signing_settings(
@@ -213,8 +138,8 @@ platform :ios do
         signingStyle: "manual",
         signingCertificate: "Apple Distribution",
         provisioningProfiles: {
-          "com.whispermate.ios" => app_profile[:name],
-          "com.whispermate.ios.keyboard" => keyboard_profile[:name]
+          "com.whispermate.ios" => app_profile,
+          "com.whispermate.ios.keyboard" => keyboard_profile
         }
       }
     else

--- a/ci_scripts/prepare_ios_signing.js
+++ b/ci_scripts/prepare_ios_signing.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+const childProcess = require("child_process");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const appBundleId = "com.whispermate.ios";
+const keyboardBundleId = "com.whispermate.ios.keyboard";
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function run(command, args, options = {}) {
+  childProcess.execFileSync(command, args, {
+    stdio: options.stdio || "inherit",
+    ...options
+  });
+}
+
+function output(command, args, options = {}) {
+  return childProcess.execFileSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    ...options
+  }).trim();
+}
+
+function base64url(input) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function token() {
+  const keyId = requiredEnv("APP_STORE_CONNECT_API_KEY_KEY_ID");
+  const issuerId = requiredEnv("APP_STORE_CONNECT_API_KEY_ISSUER_ID");
+  const keyPath = requiredEnv("APP_STORE_CONNECT_API_KEY_KEY");
+  const key = fs.readFileSync(keyPath, "utf8");
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "ES256", kid: keyId, typ: "JWT" };
+  const payload = {
+    iss: issuerId,
+    iat: now,
+    exp: now + 20 * 60,
+    aud: "appstoreconnect-v1"
+  };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto.sign("sha256", Buffer.from(signingInput), {
+    key,
+    dsaEncoding: "ieee-p1363"
+  });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+async function request(method, route, body) {
+  const response = await fetch(`https://api.appstoreconnect.apple.com${route}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token()}`,
+      "Content-Type": "application/json"
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  const text = await response.text();
+  const json = text ? JSON.parse(text) : {};
+  if (!response.ok) {
+    throw new Error(`App Store Connect API ${method} ${route} failed (${response.status}): ${text}`);
+  }
+  return json;
+}
+
+async function bundleIdFor(identifier) {
+  const response = await request("GET", `/v1/bundleIds?filter[identifier]=${encodeURIComponent(identifier)}&limit=1`);
+  const bundle = response.data && response.data[0];
+  if (!bundle) {
+    throw new Error(`No Apple Developer bundle ID found for ${identifier}`);
+  }
+  return bundle.id;
+}
+
+async function createCertificate(csrContent) {
+  const response = await request("POST", "/v1/certificates", {
+    data: {
+      type: "certificates",
+      attributes: {
+        certificateType: "IOS_DISTRIBUTION",
+        csrContent
+      }
+    }
+  });
+  return {
+    id: response.data.id,
+    content: response.data.attributes.certificateContent
+  };
+}
+
+async function createProfile({ name, bundleId, certificateId }) {
+  const response = await request("POST", "/v1/profiles", {
+    data: {
+      type: "profiles",
+      attributes: {
+        name,
+        profileType: "IOS_APP_STORE"
+      },
+      relationships: {
+        bundleId: {
+          data: {
+            type: "bundleIds",
+            id: bundleId
+          }
+        },
+        certificates: {
+          data: [
+            {
+              type: "certificates",
+              id: certificateId
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  return {
+    uuid: response.data.attributes.uuid,
+    name: response.data.attributes.name,
+    content: response.data.attributes.profileContent
+  };
+}
+
+function installProfile(profile) {
+  const dir = path.join(os.homedir(), "Library", "MobileDevice", "Provisioning Profiles");
+  fs.mkdirSync(dir, { recursive: true });
+  const profilePath = path.join(dir, `${profile.uuid}.mobileprovision`);
+  fs.writeFileSync(profilePath, Buffer.from(profile.content, "base64"));
+  console.log(`Installed provisioning profile ${profile.name} (${profile.uuid})`);
+}
+
+function appendGitHubEnv(values) {
+  const envPath = requiredEnv("GITHUB_ENV");
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(envPath, `${lines.join("\n")}\n`);
+}
+
+async function main() {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "whispermate-ios-signing-"));
+  const keychainPassword = crypto.randomBytes(24).toString("hex");
+  const keychainPath = path.join(workDir, "ios-signing.keychain-db");
+  const privateKeyPath = path.join(workDir, "distribution.key");
+  const csrPath = path.join(workDir, "distribution.csr");
+  const certificateDerPath = path.join(workDir, "distribution.cer");
+  const certificatePemPath = path.join(workDir, "distribution.pem");
+  const p12Path = path.join(workDir, "distribution.p12");
+  const p12Password = crypto.randomBytes(24).toString("hex");
+
+  run("security", ["create-keychain", "-p", keychainPassword, keychainPath]);
+  run("security", ["set-keychain-settings", "-lut", "21600", keychainPath]);
+  run("security", ["unlock-keychain", "-p", keychainPassword, keychainPath]);
+  const existingKeychains = output("security", ["list-keychains", "-d", "user"])
+    .split("\n")
+    .map((line) => line.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+  run("security", ["list-keychains", "-d", "user", "-s", keychainPath, ...existingKeychains]);
+  run("security", ["default-keychain", "-s", keychainPath]);
+
+  run("openssl", ["ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", privateKeyPath]);
+  run("openssl", ["req", "-new", "-key", privateKeyPath, "-out", csrPath, "-subj", "/CN=WhisperMate iOS CI"]);
+  const csrContent = fs.readFileSync(csrPath, "utf8");
+  const certificate = await createCertificate(csrContent);
+  fs.writeFileSync(certificateDerPath, Buffer.from(certificate.content, "base64"));
+  run("openssl", ["x509", "-inform", "DER", "-in", certificateDerPath, "-out", certificatePemPath]);
+  run("openssl", [
+    "pkcs12",
+    "-export",
+    "-inkey",
+    privateKeyPath,
+    "-in",
+    certificatePemPath,
+    "-out",
+    p12Path,
+    "-passout",
+    `pass:${p12Password}`
+  ]);
+  run("security", ["import", p12Path, "-k", keychainPath, "-P", p12Password, "-T", "/usr/bin/codesign", "-T", "/usr/bin/security"]);
+  run("security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainPath]);
+
+  const runId = process.env.GITHUB_RUN_ID || Date.now().toString();
+  const appProfile = await createProfile({
+    name: `WhisperMate iOS App Store CI ${runId}`,
+    bundleId: await bundleIdFor(appBundleId),
+    certificateId: certificate.id
+  });
+  const keyboardProfile = await createProfile({
+    name: `WhisperMate Keyboard App Store CI ${runId}`,
+    bundleId: await bundleIdFor(keyboardBundleId),
+    certificateId: certificate.id
+  });
+
+  installProfile(appProfile);
+  installProfile(keyboardProfile);
+
+  appendGitHubEnv({
+    IOS_APPSTORE_PROFILE_NAME: appProfile.uuid,
+    IOS_KEYBOARD_APPSTORE_PROFILE_NAME: keyboardProfile.uuid
+  });
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Node signing-prep script that uses App Store Connect REST directly to create/install iOS distribution signing assets
- install fresh App Store provisioning profiles for the app and keyboard extension before Fastlane archives
- simplify Fastlane back to consuming installed profile UUIDs instead of using its broken App Store Connect JWT path

## Verification
- node --check ci_scripts/prepare_ios_signing.js
- ruby -c Whishpermate/fastlane/Fastfile
- git diff --check
- xcodebuild -project Whishpermate/Whispermate.xcodeproj -scheme WhisperMateIOS -configuration Debug -destination 'platform=iOS Simulator,id=C2FBC267-8F51-47E6-ABCE-3FB364A4B786' build CODE_SIGNING_ALLOWED=NO

## Notes
The final proof is the GitHub Actions run because only CI has the App Store Connect API credentials.