### PR TITLE
Export CI signing p12 for macOS import

### DIFF
--- a/ci_scripts/prepare_ios_signing.js
+++ b/ci_scripts/prepare_ios_signing.js
@@ -188,6 +188,7 @@ async function main() {
     certificatePemPath,
     "-out",
     p12Path,
+    "-legacy",
     "-passout",
     `pass:${p12Password}`
   ]);


### PR DESCRIPTION
## Summary
- export generated iOS distribution PKCS#12 files with OpenSSL legacy compatibility so macOS security can import them

## Verification
- node --check ci_scripts/prepare_ios_signing.js
- git diff --check