### PR TITLE
Rename Android Play listing to AI Dictation

### DIFF
--- a/.github/workflows/android-play-listing.yml
+++ b/.github/workflows/android-play-listing.yml
@@ -1,0 +1,91 @@
+name: Android Play Listing
+
+on:
+  workflow_dispatch:
+    inputs:
+      play_track:
+        description: 'Google Play track'
+        required: true
+        default: production
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-play-listing-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '17'
+  ANDROID_PROJECT_DIR: AIDictationAndroid
+
+jobs:
+  publish-listing:
+    name: Publish Play listing
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.ANDROID_PROJECT_DIR }}
+
+    env:
+      PLAY_TRACK: ${{ inputs.play_track || vars.ANDROID_PLAY_TRACK || 'production' }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+      ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.ANDROID_PUBLISHER_CREDENTIALS }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate track
+        shell: bash
+        run: |
+          case "${PLAY_TRACK}" in
+            internal|alpha|beta|production) ;;
+            *)
+              echo "Unsupported PLAY_TRACK '${PLAY_TRACK}'. Use internal, alpha, beta, or production." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: platform-tools platforms;android-35 build-tools;35.0.0
+
+      - name: Decode Google Play credentials
+        run: |
+          credentials_path="$RUNNER_TEMP/google-play-service-account.json"
+          if [ -n "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64}" ]; then
+            echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64 -d > "$credentials_path"
+          elif [ -n "${ANDROID_PUBLISHER_CREDENTIALS}" ]; then
+            printf '%s' "$ANDROID_PUBLISHER_CREDENTIALS" > "$credentials_path"
+          else
+            echo "Set GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 or ANDROID_PUBLISHER_CREDENTIALS." >&2
+            exit 1
+          fi
+          python3 -m json.tool "$credentials_path" >/dev/null
+          echo "PLAY_SERVICE_ACCOUNT_CREDENTIALS=$credentials_path" >> "$GITHUB_ENV"
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Publish Play listing assets
+        run: |
+          ./gradlew \
+            :app:publishReleaseListing \
+            -PPLAY_TRACK="${PLAY_TRACK}" \
+            -PPLAY_SERVICE_ACCOUNT_CREDENTIALS="${PLAY_SERVICE_ACCOUNT_CREDENTIALS}" \
+            --stacktrace

--- a/AIDictationAndroid/app/src/main/play/listings/en-US/full-description.txt
+++ b/AIDictationAndroid/app/src/main/play/listings/en-US/full-description.txt
@@ -1,6 +1,6 @@
-AIDictation turns your voice into clean text anywhere you type on Android.
+AI Dictation turns your voice into clean text anywhere you type on Android.
 
-Tap into a text field, use the floating mic, and speak naturally. AIDictation records your speech, transcribes it, and places the finished text where you need it.
+Tap into a text field, use the floating mic, and speak naturally. AI Dictation records your speech, transcribes it, and places the finished text where you need it.
 
 Built for everyday writing:
 - Fast voice-to-text dictation for messages, notes, email, documents, and web forms
@@ -20,8 +20,8 @@ Privacy-minded by design:
 - Recordings are temporary unless saved in your local history
 
 AccessibilityService disclosure:
-AIDictation uses Android AccessibilityService to provide dictation in other apps. With your permission, it detects when an editable text field is focused, shows the floating microphone, reads the current text and cursor position in the active field, and inserts or replaces dictated text only when you start dictation or apply a command. AIDictation does not use AccessibilityService to read passwords, payment fields, or secure screens, and it does not use this access for unrelated tracking or background monitoring.
+AI Dictation uses Android AccessibilityService to provide dictation in other apps. With your permission, it detects when an editable text field is focused, shows the floating microphone, reads the current text and cursor position in the active field, and inserts or replaces dictated text only when you start dictation or apply a command. AI Dictation does not use AccessibilityService to read passwords, payment fields, or secure screens, and it does not use this access for unrelated tracking or background monitoring.
 
-AIDictation is useful for people who write a lot from thought: product managers drafting specs, developers writing notes, founders replying to customers, students capturing ideas, and anyone who wants to type less.
+AI Dictation is useful for people who write a lot from thought: product managers drafting specs, developers writing notes, founders replying to customers, students capturing ideas, and anyone who wants to type less.
 
 Speak naturally. Get polished text. Keep writing.

--- a/AIDictationAndroid/app/src/main/play/listings/en-US/title.txt
+++ b/AIDictationAndroid/app/src/main/play/listings/en-US/title.txt
@@ -1,1 +1,1 @@
-AIDictation
+AI Dictation


### PR DESCRIPTION
Updates the Android Play Store listing name and visible English listing copy from AIDictation to AI Dictation. Adds a listing-only Play publishing workflow so metadata can be shipped without uploading a new app bundle.