### PR TITLE
Document the iOS App Store launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | App | Latest | Download |
 | --- | --- | --- |
 | macOS | v0.0.92 | [Download DMG](https://github.com/writingmate/aidictation/releases/download/v0.0.92/AIDictation-v0.0.92.dmg) |
-| iOS | TestFlight beta | [Join TestFlight](https://testflight.apple.com/join/934P27ed) |
+| iOS | v0.0.92 | [Download on the App Store](https://apps.apple.com/app/id6754910103) |
 | Windows | v0.0.4 | [Download installer](https://github.com/writingmate/aidictation/releases/download/windows-v0.0.4/AIDictation-Windows-Setup-v0.0.4.exe) · [Portable ZIP](https://github.com/writingmate/aidictation/releases/download/windows-v0.0.4/AIDictation-Windows-v0.0.4.zip) |
 | Android | v0.0.29 | [Download APK](https://github.com/writingmate/aidictation/releases/download/android-v0.0.29/AIDictation-Android-0.0.29.apk) · [Play upload AAB](https://github.com/writingmate/aidictation/releases/download/android-v0.0.29/AIDictation-Android-0.0.29.aab) · [Checksums](https://github.com/writingmate/aidictation/releases/download/android-v0.0.29/SHA256SUMS.txt) |
 
@@ -55,9 +55,9 @@ AIDictation turns your voice into text and inserts it into the app you are alrea
 
 ### iOS
 
-1. Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the App Store.
-2. Open the [AIDictation TestFlight invite](https://testflight.apple.com/join/934P27ed) on your iPhone or iPad.
-3. Tap Accept, install AIDictation, and follow setup.
+1. Download [AI Dictation from the App Store](https://apps.apple.com/app/id6754910103) on your iPhone or iPad.
+2. Open AI Dictation and follow the setup guide.
+3. Enable the AI Dictation keyboard to dictate anywhere you type.
 4. Enable microphone access when prompted.
 
 ### Windows

--- a/Whishpermate/fastlane/metadata/copyright.txt
+++ b/Whishpermate/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-© 2024-2025 WhisperMate. All rights reserved.
+© 2024-2026 AI Dictation. All rights reserved.

--- a/Whishpermate/fastlane/metadata/en-US/description.txt
+++ b/Whishpermate/fastlane/metadata/en-US/description.txt
@@ -1,47 +1,37 @@
-WhisperMate is the fastest way to turn your voice into text on iOS. Using advanced speech recognition, WhisperMate transcribes your voice with incredible accuracy, making typing feel effortless.
+Speak naturally. Get clean, useful text wherever you type.
 
-KEY FEATURES
+AI Dictation is a voice-to-text app and keyboard for iPhone and iPad. Use your voice for messages, email, notes, documents, and any other app with a text field.
 
-🎤 System-Wide Voice Keyboard
-Access WhisperMate's voice input from any app - Messages, Email, Notes, Safari, and more. No need to switch apps or copy-paste.
+DICTATE IN ANY APP
 
-⚡ Lightning-Fast Transcription
-Get instant, accurate transcriptions powered by state-of-the-art AI. Perfect for messages, emails, notes, and documents.
+Enable the AI Dictation keyboard once, then use it anywhere you normally type. Tap the microphone, speak naturally, and continue with text that is ready to use.
 
-🔒 Private & Secure
-Your voice data is processed securely. We respect your privacy - your recordings are never stored on our servers.
+OFFLINE OR CLOUD — YOU CHOOSE
 
-✨ Smart Text Formatting
-Automatic punctuation, capitalization, and formatting. Your transcriptions look professional without any extra effort.
+Use offline mode when you want transcription to stay on your device or when you do not have a connection. Choose cloud mode when you want additional cleanup and formatting. AI Dictation asks before sending audio for cloud transcription.
 
-🌍 Multilingual Support
-Speak in your preferred language. WhisperMate supports dozens of languages with native-quality transcription.
+CLEANER WRITING FROM NATURAL SPEECH
 
-📋 Quick Share
-Send your transcriptions directly to AI assistants like ChatGPT, Claude, Perplexity, or share via WhatsApp, Email, and more.
+AI Dictation adds punctuation and turns rough speech into readable text. Spend less time fixing filler words, sentence breaks, and formatting after you dictate.
 
-PERFECT FOR
+BUILT FOR THE WAY YOU WRITE
 
-• Composing messages while on the go
-• Taking quick notes during meetings
-• Writing emails hands-free
-• Journaling and creative writing
-• Anyone who prefers speaking to typing
+• Dictate messages, email, notes, and longer drafts
+• Choose from a broad set of languages
+• Add names and specialized terms to your personal dictionary
+• Use context rules to shape the result for different writing situations
+• Review, copy, and share previous transcriptions
+• Keep keyboard recording status visible while you work
 
-HOW IT WORKS
+PRIVATE WHEN IT MATTERS
 
-1. Enable WhisperMate keyboard in Settings
-2. Switch to WhisperMate in any app
-3. Tap the microphone button and speak
-4. Watch your words appear instantly
+Offline mode processes transcription on your device. Cloud mode is optional and clearly identified, so you can choose the right mode for each conversation or draft.
 
-WHY CHOOSE WHISPERMATE?
+GET STARTED IN MINUTES
 
-Unlike built-in voice dictation, WhisperMate offers:
-- Superior accuracy with advanced AI models
-- Custom text formatting rules
-- Direct integration with AI assistants
-- Fast, responsive performance
-- Clean, intuitive interface
+1. Open AI Dictation and follow the setup guide.
+2. Enable the AI Dictation keyboard in Settings.
+3. Choose offline mode or cloud mode.
+4. Open any text field, switch to AI Dictation, and start speaking.
 
-Whether you're sending a quick text, drafting an email, or capturing your thoughts, WhisperMate makes voice-to-text effortless and accurate.
+Whether you are replying to a message, capturing an idea, or drafting something longer, AI Dictation helps your words keep up with your thoughts.

--- a/Whishpermate/fastlane/metadata/en-US/marketing_url.txt
+++ b/Whishpermate/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://whispermate.ai
+https://aidictation.com

--- a/Whishpermate/fastlane/metadata/en-US/name.txt
+++ b/Whishpermate/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-WhisperMate
+AI Dictation

--- a/Whishpermate/fastlane/metadata/en-US/privacy_url.txt
+++ b/Whishpermate/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://whispermate.ai/privacy
+https://aidictation.com/privacy

--- a/Whishpermate/fastlane/metadata/en-US/promotional_text.txt
+++ b/Whishpermate/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Transform your voice into text instantly with WhisperMate. Speak naturally anywhere on your iPhone - in Messages, Notes, Email, or any app with a keyboard.
+Speak instead of typing on iPhone and iPad. AI Dictation turns your voice into clean text in any app, with private offline mode and optional cloud polish.

--- a/Whishpermate/fastlane/metadata/en-US/release_notes.txt
+++ b/Whishpermate/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,7 @@
-New in This Release
+AI Dictation is now available on the App Store.
 
-• 🎨 Improved UI with polished animations
-• ⚡ Enhanced copy button with visual feedback
-• 🔗 Updated share menu integration
-• 🐛 Bug fixes and performance improvements
-• 📱 Better iOS keyboard support
+• Dictate in any app with the AI Dictation keyboard.
+• Choose private offline mode or cloud mode for extra cleanup and formatting.
+• Switch languages more reliably from the keyboard.
+• See when keyboard dictation is listening and stop it without leaving your current app.
+• Improved setup, sign-in, long dictation handling, and overall stability.

--- a/Whishpermate/fastlane/metadata/en-US/support_url.txt
+++ b/Whishpermate/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/writingmate/whispermate/issues
+https://github.com/writingmate/aidictation/issues

--- a/references/ios_app_store_launch_announcement.md
+++ b/references/ios_app_store_launch_announcement.md
@@ -1,0 +1,31 @@
+# AI Dictation App Store launch announcement
+
+## Main announcement
+
+AI Dictation is now available on the App Store for iPhone and iPad.
+
+This is the public release we have been working toward: voice typing that follows you into the apps where you already write. Enable the AI Dictation keyboard, tap the microphone, and speak naturally in Messages, Mail, Notes, browsers, and other text fields.
+
+You can choose private offline mode for on-device transcription or cloud mode when you want additional cleanup and formatting. The app also includes multilingual dictation, a personal dictionary, context rules, transcription history, and clearer keyboard recording controls.
+
+Download AI Dictation on the App Store: https://apps.apple.com/app/id6754910103
+
+Thank you to everyone who tested the early builds, reported rough edges, and helped us get here. This release is the start of the public iPhone and iPad chapter, and we are excited to keep making it better.
+
+## Short social version
+
+AI Dictation is now on the App Store for iPhone and iPad. 🎉
+
+Dictate in any app, choose private offline mode or cloud mode, and turn natural speech into clean text wherever you write.
+
+Download it here: https://apps.apple.com/app/id6754910103
+
+## Community version
+
+We just released AI Dictation on the App Store for iPhone and iPad.
+
+The goal is simple: make voice typing useful beyond a standalone recorder. AI Dictation includes a keyboard you can use in other apps, private offline transcription, optional cloud cleanup, multilingual dictation, personal vocabulary, and transcription history.
+
+If you try it, we would especially value feedback on keyboard setup, switching between apps, longer dictations, and specialized names or terms.
+
+App Store: https://apps.apple.com/app/id6754910103

--- a/references/release_notes_v0.0.92_ios.md
+++ b/references/release_notes_v0.0.92_ios.md
@@ -1,0 +1,35 @@
+# AI Dictation for iOS 0.0.92
+
+Released on the App Store on July 10, 2026.
+
+## Highlights
+
+- First public App Store release for iPhone and iPad.
+- System-wide AI Dictation keyboard for writing in messages, email, notes, browsers, and other apps.
+- Offline mode for private on-device transcription and optional cloud mode for additional cleanup and formatting.
+- Multilingual dictation with language selection available from the keyboard.
+- Personal dictionary, context rules, transcription history, copy, and sharing workflows.
+
+## Reliability and usability
+
+- Made keyboard recording states clearer, including visible listening status and an in-keyboard stop control.
+- Improved the handoff between the keyboard and the main app so recording stays active and returns text more reliably.
+- Kept long dictations intact through upload and final cleanup.
+- Improved offline model download progress and made offline setup failures easier to understand.
+- Reduced sign-in friction and improved email entry on iPad.
+- Added a clear consent step before audio is sent for cloud transcription.
+
+## App Store notes
+
+AI Dictation is now available on the App Store.
+
+- Dictate in any app with the AI Dictation keyboard.
+- Choose private offline mode or cloud mode for extra cleanup and formatting.
+- Switch languages more reliably from the keyboard.
+- See when keyboard dictation is listening and stop it without leaving your current app.
+- Improved setup, sign-in, long dictation handling, and overall stability.
+
+## Links
+
+- App Store: https://apps.apple.com/app/id6754910103
+- Download page: https://aidictation.com/download


### PR DESCRIPTION
## What changed

- replace TestFlight install guidance with the public App Store listing
- rewrite iOS App Store metadata for the AI Dictation brand and shipped feature set
- add accurate 0.0.92 release notes
- add ready-to-post launch announcement variants
- update support, privacy, marketing, and copyright metadata

## Why

The first public iOS release is live, but the repository metadata still described the pre-launch WhisperMate/TestFlight experience.

## App Store state

- version 0.0.92 is READY_FOR_SALE
- Apple accepted the new promotional text immediately
- Apple locks description and What’s New after a version is ready for sale; those corrected files are now the source of truth for the next submission

## Validation

- metadata character limits checked
- stale TestFlight install links removed from README and active metadata
- diff check passed