### PR TITLE
Merge iOS 0.0.93 ASO release

### DIFF
--- a/AIDictationAndroid/app/src/main/play/listings/en-US/full-description.txt
+++ b/AIDictationAndroid/app/src/main/play/listings/en-US/full-description.txt
@@ -1,27 +1,41 @@
-AI Dictation turns your voice into clean text anywhere you type on Android.
+Keep the keyboard you already use. Add fast voice typing with a floating mic.
 
-Tap into a text field, use the floating mic, and speak naturally. AI Dictation records your speech, transcribes it, and places the finished text where you need it.
+AI Dictation is a speech-to-text app for Android that helps you write in messages, email, notes, documents, and web forms. When an editable text field is active, tap the floating microphone, speak naturally, and place the finished text at your cursor.
 
-Built for everyday writing:
-- Fast voice-to-text dictation for messages, notes, email, documents, and web forms
-- Floating microphone bubble that appears when text input is focused
-- Optional offline transcription for speech processing on your device
-- Cloud transcription for accurate speech recognition when you want it
-- AI cleanup for punctuation, formatting, and cleaner prose
-- Custom dictionary entries for names, technical terms, and repeated phrases
-- Context rules so dictation can adapt to different apps and writing styles
-- Voice shortcuts for frequently used text expansions
-- History view for recent recordings and generated text
+VOICE TYPING IN THE APPS YOU USE
 
-Privacy-minded by design:
-- The floating mic stays hidden in password and secure fields
-- On-device transcription can keep speech processing local
-- Cloud transcription is used only when enabled or required by your settings
-- Recordings are temporary unless saved in your local history
+• Keep using your regular Android keyboard
+• Tap the floating mic when a text field is active
+• Insert dictated text at the cursor or replace selected text
+• Select text to fix grammar or rewrite it with AI
+• Choose from 60+ languages for transcription
 
-AccessibilityService disclosure:
-AI Dictation uses Android AccessibilityService to provide dictation in other apps. With your permission, it detects when an editable text field is focused, shows the floating microphone, reads the current text and cursor position in the active field, and inserts or replaces dictated text only when you start dictation or apply a command. AI Dictation does not use AccessibilityService to read passwords, payment fields, or secure screens, and it does not use this access for unrelated tracking or background monitoring.
+OFFLINE AND CLOUD OPTIONS
 
-AI Dictation is useful for people who write a lot from thought: product managers drafting specs, developers writing notes, founders replying to customers, students capturing ideas, and anyone who wants to type less.
+Download the optional offline model for on-device speech recognition. Cloud transcription and AI writing actions are available when you want additional cleanup, formatting, or rewriting. When you use a cloud feature, the audio or relevant text needed to complete that action is sent for processing.
 
-Speak naturally. Get polished text. Keep writing.
+PERSONALIZE YOUR DICTATION
+
+Cloud features can use:
+
+• Dictionary hints for names and specialized terms
+• Context rules for different apps and writing styles
+• Spoken shortcuts that expand into text you use often
+• Automatic punctuation and formatting
+
+RECORD AND REVIEW IN THE APP
+
+Record directly in AI Dictation when you want to keep a local history. Review your transcript, replay the saved recording, and return to previous in-app recordings later. Audio captured through the floating mic is removed after processing and is not added to this history.
+
+WHY ACCESSIBILITY ACCESS IS NEEDED
+
+AI Dictation uses Android AccessibilityService so the floating mic can work with text fields in other apps. With your permission, it detects editable fields and selection state, shows the mic, inserts dictated text, and offers writing actions for selected text. The floating mic is not shown in password fields. This access is used to provide the dictation and editing features you request.
+
+GET STARTED
+
+1. Open AI Dictation and follow the setup guide.
+2. Allow microphone access and enable AI Dictation in Accessibility settings.
+3. Tap a text field in another app.
+4. Use the floating mic and start speaking.
+
+Speak naturally, type less, and keep your regular keyboard.

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -809,7 +809,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_LIVE_ACTIVITY_APPSTORE_PROFILE_NAME)";
@@ -902,7 +902,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1227,7 +1227,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1265,7 +1265,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_APPSTORE_PROFILE_NAME)";
@@ -1299,7 +1299,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1332,7 +1332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.92;
+				MARKETING_VERSION = 0.0.93;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_KEYBOARD_APPSTORE_PROFILE_NAME)";

--- a/Whishpermate/fastlane/metadata/en-US/description.txt
+++ b/Whishpermate/fastlane/metadata/en-US/description.txt
@@ -1,37 +1,40 @@
-Speak naturally. Get clean, useful text wherever you type.
+Turn your voice into useful text on your iPhone.
 
-AI Dictation is a voice-to-text app and keyboard for iPhone and iPad. Use your voice for messages, email, notes, documents, and any other app with a text field.
+AI Dictation is a voice-to-text app and keyboard for messages, email, notes, documents, and longer recordings. Start from the keyboard in apps that support third-party keyboards, or record directly in AI Dictation, then insert, copy, or share the finished text.
 
-DICTATE IN ANY APP
+DICTATE WITH LESS TYPING
 
-Enable the AI Dictation keyboard once, then use it anywhere you normally type. Tap the microphone, speak naturally, and continue with text that is ready to use.
+Open a text field, switch to the AI Dictation keyboard, and start speaking. Your finished transcription is ready to insert where you were writing.
 
-OFFLINE OR CLOUD — YOU CHOOSE
+CHOOSE HOW YOUR SPEECH IS PROCESSED
 
-Use offline mode when you want transcription to stay on your device or when you do not have a connection. Choose cloud mode when you want additional cleanup and formatting. AI Dictation asks before sending audio for cloud transcription.
+Use Cloud, Offline, or Automatic mode. On iOS 17 and later, you can download the offline model for on-device speech recognition. Cloud transcription sends audio only after you give permission. Optional cloud formatting may send the transcript to organize or clean up the result, even when speech recognition runs offline.
 
-CLEANER WRITING FROM NATURAL SPEECH
+MORE THAN BASIC VOICE TYPING
 
-AI Dictation adds punctuation and turns rough speech into readable text. Spend less time fixing filler words, sentence breaks, and formatting after you dictate.
+Choose the result that fits what you are recording:
 
-BUILT FOR THE WAY YOU WRITE
+• Dictation for direct speech-to-text
+• Notes for structured ideas and action items
+• Meetings for summaries, speaker labels, timestamps, and action items
 
-• Dictate messages, email, notes, and longer drafts
-• Choose from a broad set of languages
+MAKE IT YOURS
+
 • Add names and specialized terms to your personal dictionary
-• Use context rules to shape the result for different writing situations
-• Review, copy, and share previous transcriptions
-• Keep keyboard recording status visible while you work
+• Create voice shortcuts for text you use often
+• Search your recent transcription history
+• Replay locally saved recordings
+• Copy or share previous results
 
-PRIVATE WHEN IT MATTERS
+KEEP TRACK WHILE YOU DICTATE
 
-Offline mode processes transcription on your device. Cloud mode is optional and clearly identified, so you can choose the right mode for each conversation or draft.
+On iOS 17 and later, a Live Activity shows when AI Dictation is listening or processing and gives you a quick way to stop.
 
-GET STARTED IN MINUTES
+GET STARTED
 
 1. Open AI Dictation and follow the setup guide.
 2. Enable the AI Dictation keyboard in Settings.
-3. Choose offline mode or cloud mode.
-4. Open any text field, switch to AI Dictation, and start speaking.
+3. Choose Cloud, Offline, or Automatic mode.
+4. Open a supported text field, switch keyboards, and start speaking.
 
-Whether you are replying to a message, capturing an idea, or drafting something longer, AI Dictation helps your words keep up with your thoughts.
+Whether you are replying to a message, capturing an idea, or turning a longer conversation into notes, AI Dictation helps your words keep up with your thoughts.

--- a/Whishpermate/fastlane/metadata/en-US/release_notes.txt
+++ b/Whishpermate/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,6 @@
-AI Dictation is now available on the App Store.
+This update makes it clearer how AI Dictation works on iPhone.
 
-• Dictate in any app with the AI Dictation keyboard.
-• Choose private offline mode or cloud mode for extra cleanup and formatting.
-• Switch languages more reliably from the keyboard.
-• See when keyboard dictation is listening and stop it without leaving your current app.
-• Improved setup, sign-in, long dictation handling, and overall stability.
+• More accurate guidance for dictation from the keyboard and inside the app.
+• Clear explanations of offline speech recognition and optional cloud processing.
+• Better details for Dictation, Notes, and Meetings.
+• Updated information about personal vocabulary, voice shortcuts, history, and Live Activity status.


### PR DESCRIPTION
Syncs the store-listing sources and iOS 0.0.93 marketing version that were used for the submitted releases.

- Google Play full description is already in review.
- iOS 0.0.93 build 93 is already waiting for App Review.
- Merge with `[skip ci]` to avoid uploading a duplicate iOS build from the `main` push.