### PR TITLE
Prepare iOS 0.0.94 cleanup reliability release

### DIFF
--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -809,7 +809,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_LIVE_ACTIVITY_APPSTORE_PROFILE_NAME)";
@@ -902,7 +902,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1227,7 +1227,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1265,7 +1265,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_APPSTORE_PROFILE_NAME)";
@@ -1299,7 +1299,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1332,7 +1332,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.93;
+				MARKETING_VERSION = 0.0.94;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_KEYBOARD_APPSTORE_PROFILE_NAME)";

--- a/Whishpermate/fastlane/metadata/en-US/release_notes.txt
+++ b/Whishpermate/fastlane/metadata/en-US/release_notes.txt
@@ -1,6 +1,5 @@
-This update makes it clearer how AI Dictation works on iPhone.
+This update improves cloud cleanup reliability.
 
-• More accurate guidance for dictation from the keyboard and inside the app.
-• Clear explanations of offline speech recognition and optional cloud processing.
-• Better details for Dictation, Notes, and Meetings.
-• Updated information about personal vocabulary, voice shortcuts, history, and Live Activity status.
+• Personal vocabulary now guides recognition without being copied into your dictation.
+• Longer dictations are preserved through the final sentence.
+• Cleanup is less likely to add invented or repeated words.


### PR DESCRIPTION
## Summary
- bump the iOS app and extensions to 0.0.94
- describe the prompt-only cloud cleanup reliability fix in release notes
- preserve the generic prompt-routing implementation already verified with the customer recording

## Verification
- `python3 scripts/validate_transcription_prompt_routing.py`
- `xcodebuild -showBuildSettings` reports iOS marketing version 0.0.94

This corrective release is needed because App Store Connect locked pre-fix build 93 into the already-approved 0.0.93 version; fixed build 94 could not replace it.