### PR TITLE
Fail closed on incomplete macOS realtime transcripts

### DIFF
--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -2054,7 +2054,12 @@ class AppState: ObservableObject {
                 let finishTimeout = snapshot.provider == .custom ? 6.0 : 2.0
                 let result = await realtimeClient?.finish(timeout: finishTimeout)?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-                realtimeResult = (result?.isEmpty == false) ? result : nil
+                if result?.isEmpty == false {
+                    realtimeResult = result
+                } else {
+                    realtimeClient?.close()
+                    realtimeResult = nil
+                }
             } else {
                 realtimeResult = nil
             }
@@ -2091,12 +2096,11 @@ class AppState: ObservableObject {
                     }
                 }
                 if let realtimeResult {
-                    let raw = snapshot.applyReplacements(to: realtimeResult)
-                    try await session.checkpoint(raw)
-                    try await session.markRawResultReady(raw)
+                    try await session.checkpoint(realtimeResult)
+                    try await session.markRawResultReady(realtimeResult)
                     try await session.beginCleanup()
                     return try await self.applyLLMPassWithFallback(
-                        rawText: raw,
+                        rawText: realtimeResult,
                         client: OpenAIClient(config: .init()),
                         snapshot: snapshot
                     )
@@ -2658,18 +2662,6 @@ class AppState: ObservableObject {
                 diarization: rule.transcriptionOptions.diarization
             )
         }
-        let replacements = dictionaryManager.entries
-            .filter { $0.isEnabled && $0.replacement != nil }
-            .sorted { $0.trigger.count > $1.trigger.count }
-            .compactMap { entry in
-                entry.replacement.map {
-                    MacTranscriptionAttemptSnapshot.Replacement(
-                        trigger: entry.trigger,
-                        replacement: $0
-                    )
-                }
-            }
-
         return MacTranscriptionAttemptSnapshot(
             outputMode: outputMode,
             transcriptionOptions: transcriptionOptions,
@@ -2698,8 +2690,7 @@ class AppState: ObservableObject {
             screenContext: screenContext,
             vadEnabled: vadSettingsManager.vadEnabled,
             vadThreshold: vadSettingsManager.sensitivityThreshold,
-            networkWasConnected: NetworkMonitor.shared.isConnected,
-            replacements: replacements
+            networkWasConnected: NetworkMonitor.shared.isConnected
         )
     }
 
@@ -2829,7 +2820,7 @@ class AppState: ObservableObject {
 
             DebugLog.info("Using on-device Parakeet transcription", context: "AppState")
 
-            var text: String
+            let text: String
             if transcriptionOptions.diarization {
                 text = try await withTimeout(seconds: diarizationTimeoutSeconds) {
                     try await ParakeetTranscriptionService.shared.transcribeDiarized(audioURL: audioURL)
@@ -2837,7 +2828,6 @@ class AppState: ObservableObject {
             } else {
                 text = try await ParakeetTranscriptionService.shared.transcribe(audioURL: audioURL)
             }
-            text = snapshot.applyReplacements(to: text)
             let durableRaw = text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !durableRaw.isEmpty else {
                 throw NSError(

--- a/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
+++ b/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
@@ -6,11 +6,6 @@ import WhisperMateShared
 /// Every mutable preference needed by recognition and cleanup, captured before
 /// an attempt begins. Running attempts never consult the live manager objects.
 nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
-    struct Replacement: Sendable {
-        let trigger: String
-        let replacement: String
-    }
-
     struct ContextRuleSnapshot: Sendable {
         let name: String
         let appBundleIDs: [String]
@@ -98,7 +93,6 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
     let vadEnabled: Bool
     let vadThreshold: Float
     let networkWasConnected: Bool
-    let replacements: [Replacement]
 
     func withContext(
         appContext: String?,
@@ -159,18 +153,7 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
             screenContext: screenContext,
             vadEnabled: vadEnabled,
             vadThreshold: vadThreshold,
-            networkWasConnected: networkWasConnected,
-            replacements: replacements
+            networkWasConnected: networkWasConnected
         )
-    }
-
-    func applyReplacements(to text: String) -> String {
-        replacements.reduce(text) { result, replacement in
-            result.replacingOccurrences(
-                of: replacement.trigger,
-                with: replacement.replacement,
-                options: .caseInsensitive
-            )
-        }
     }
 }

--- a/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
+++ b/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
@@ -221,8 +221,7 @@ final class OpenAIRealtimeTranscriptionClient {
     private var accumulatedTranscript = ""
     private var finalTranscript: String?
     private var failedMessage: String?
-    private var finishContinuation: CheckedContinuation<String?, Never>?
-    private var finishTimeoutTask: Task<Void, Never>?
+    private lazy var finishGate = RealtimeTranscriptionFinishGate(queue: sendQueue)
     private var didRequestFinish = false
     private var audioChunkCount = 0
     private var audioByteCount = 0
@@ -282,6 +281,8 @@ final class OpenAIRealtimeTranscriptionClient {
     func start() {
         sendQueue.async { [weak self] in
             guard let self else { return }
+            self.requireSendQueue()
+            self.finishGate.resolve(with: nil)
             self.isClosed = false
             self.audioChunkCount = 0
             self.audioByteCount = 0
@@ -346,45 +347,43 @@ final class OpenAIRealtimeTranscriptionClient {
     }
 
     func finish(timeout: TimeInterval = 1.5) async -> String? {
-        DebugLog.info(
-            "Realtime finish requested timeout=\(timeout)s accumulatedLength=\(accumulatedTranscript.count) finalLength=\(finalTranscript?.count ?? 0) failed=\(failedMessage != nil)",
-            context: "OpenAIRealtime"
-        )
-        if failedMessage != nil {
-            return nil
-        }
-
         return await withCheckedContinuation { continuation in
-            if uncommittedAudioByteCount == 0,
-               pendingCommitAcknowledgements == 0,
-               pendingCompletionItemIDs.isEmpty,
-               let finalTranscript
-            {
-                continuation.resume(returning: finalTranscript)
-                return
-            }
-            if failedMessage != nil {
-                continuation.resume(returning: nil)
-                return
-            }
-
-            finishContinuation = continuation
-            let currentTranscript = accumulatedTranscript.isEmpty ? nil : accumulatedTranscript
-            DebugLog.info(
-                "Realtime commit queued chunks=\(audioChunkCount) bytes=\(audioByteCount) currentLength=\(currentTranscript?.count ?? 0)",
-                context: "OpenAIRealtime"
-            )
-            didRequestFinish = true
-            finishTimeoutTask = Task { [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            sendQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                self.requireSendQueue()
                 DebugLog.info(
-                    "Realtime finish timeout elapsed finalLength=\(self?.finalTranscript?.count ?? 0) accumulatedLength=\(self?.accumulatedTranscript.count ?? 0)",
+                    "Realtime finish requested timeout=\(timeout)s accumulatedLength=\(self.accumulatedTranscript.count) finalLength=\(self.finalTranscript?.count ?? 0) failed=\(self.failedMessage != nil)",
                     context: "OpenAIRealtime"
                 )
-                self?.resumeFinishIfNeeded(with: self?.finalTranscript ?? currentTranscript)
-            }
-            sendQueue.async { [weak self] in
-                guard let self else { return }
+                guard self.failedMessage == nil else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                if self.isTransportDrained, let finalTranscript = self.finalTranscript {
+                    self.abandonTransportOnQueue()
+                    continuation.resume(returning: finalTranscript)
+                    return
+                }
+
+                self.didRequestFinish = true
+                self.finishGate.begin(
+                    timeout: timeout,
+                    continuation: continuation
+                ) { [weak self] in
+                    guard let self else { return }
+                    DebugLog.info(
+                        "Realtime finish timeout elapsed; discarding unproven stream finalLength=\(self.finalTranscript?.count ?? 0) accumulatedLength=\(self.accumulatedTranscript.count)",
+                        context: "OpenAIRealtime"
+                    )
+                    self.abandonTransportOnQueue()
+                }
+                DebugLog.info(
+                    "Realtime commit queued chunks=\(self.audioChunkCount) bytes=\(self.audioByteCount) currentLength=\(self.accumulatedTranscript.count)",
+                    context: "OpenAIRealtime"
+                )
                 self.commitAudioBuffer(reason: "finish")
                 self.resumeFinishIfReady()
             }
@@ -392,21 +391,18 @@ final class OpenAIRealtimeTranscriptionClient {
     }
 
     func close() {
-        finishTimeoutTask?.cancel()
-        finishTimeoutTask = nil
-        resumeFinishIfNeeded(with: finalTranscript ?? (accumulatedTranscript.isEmpty ? nil : accumulatedTranscript))
         sendQueue.async { [weak self] in
             guard let self else { return }
-            self.isClosed = true
-            self.pendingEvents.removeAll()
-            self.task?.cancel(with: .normalClosure, reason: nil)
-            self.task = nil
+            self.requireSendQueue()
+            self.abandonTransportOnQueue()
+            self.finishGate.resolve(with: nil)
         }
     }
 
     private func openSocket(authorization: WritingmateRealtimeClientSecretProvider.Authorization) {
         sendQueue.async { [weak self] in
             guard let self, self.task == nil, !self.isClosed else { return }
+            self.requireSendQueue()
 
             var request = URLRequest(url: authorization.webSocketURL)
             request.setValue("Bearer \(authorization.token)", forHTTPHeaderField: "Authorization")
@@ -482,23 +478,8 @@ final class OpenAIRealtimeTranscriptionClient {
         sendEventOnQueue(["type": "input_audio_buffer.commit"])
     }
 
-    private func sendEvent(_ event: [String: Any]) {
-        sendQueue.async { [weak self] in
-            guard let self else { return }
-            guard !self.isClosed else { return }
-            if self.task == nil {
-                DebugLog.info(
-                    "Realtime event queued before socket type=\((event["type"] as? String) ?? "unknown") pending=\(self.pendingEvents.count + 1)",
-                    context: "OpenAIRealtime"
-                )
-                self.pendingEvents.append(event)
-                return
-            }
-            self.sendEventOnQueue(event)
-        }
-    }
-
     private func sendEventOnQueue(_ event: [String: Any]) {
+        requireSendQueue()
         guard let task else {
             pendingEvents.append(event)
             return
@@ -506,9 +487,8 @@ final class OpenAIRealtimeTranscriptionClient {
         guard let data = try? JSONSerialization.data(withJSONObject: event),
               let message = String(data: data, encoding: .utf8)
         else {
-            DebugLog.warning(
-                "Realtime event serialization failed type=\((event["type"] as? String) ?? "unknown")",
-                context: "OpenAIRealtime"
+            failOnQueue(
+                "Realtime event serialization failed for \((event["type"] as? String) ?? "unknown")"
             )
             return
         }
@@ -517,31 +497,34 @@ final class OpenAIRealtimeTranscriptionClient {
         if eventType != "input_audio_buffer.append" {
             DebugLog.info("Realtime send event type=\(eventType)", context: "OpenAIRealtime")
         }
-        let onError = onError
-        task.send(.string(message)) { error in
-            if let error {
-                Task { @MainActor in
-                    onError("OpenAI Realtime send failed: \(error.localizedDescription)")
+        task.send(.string(message)) { [weak self] error in
+            guard let self, let error else { return }
+            self.fail("OpenAI Realtime send failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func receiveNextMessage() {
+        requireSendQueue()
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            self.sendQueue.async { [weak self] in
+                guard let self, !self.isClosed else { return }
+                self.requireSendQueue()
+                switch result {
+                case .success(let message):
+                    self.handle(message)
+                    self.receiveNextMessage()
+                case .failure(let error):
+                    self.failOnQueue(
+                        "OpenAI Realtime receive failed: \(error.localizedDescription)"
+                    )
                 }
             }
         }
     }
 
-    private func receiveNextMessage() {
-        task?.receive { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case .success(let message):
-                self.handle(message)
-                self.receiveNextMessage()
-            case .failure(let error):
-                self.fail("OpenAI Realtime receive failed: \(error.localizedDescription)")
-            }
-        }
-    }
-
     private func handle(_ message: URLSessionWebSocketTask.Message) {
+        requireSendQueue()
         let data: Data?
         switch message {
         case .string(let text):
@@ -565,21 +548,20 @@ final class OpenAIRealtimeTranscriptionClient {
                 pendingCommitAcknowledgements -= 1
             }
 
-            if let itemID = payload["item_id"] as? String {
-                trackItem(itemID)
-                if !completedItemIDs.contains(itemID) {
-                    pendingCompletionItemIDs.insert(itemID)
-                }
-                DebugLog.info(
-                    "Realtime buffer committed itemIDPresent=true pendingAcks=\(pendingCommitAcknowledgements) pendingItems=\(pendingCompletionItemIDs.count)",
-                    context: "OpenAIRealtime"
-                )
-            } else {
-                DebugLog.info(
-                    "Realtime buffer committed itemIDPresent=false pendingAcks=\(pendingCommitAcknowledgements)",
-                    context: "OpenAIRealtime"
-                )
+            guard let itemID = payload["item_id"] as? String,
+                  !itemID.isEmpty
+            else {
+                failOnQueue("Realtime commit acknowledgement was missing its item ID")
+                return
             }
+            trackItem(itemID)
+            if !completedItemIDs.contains(itemID) {
+                pendingCompletionItemIDs.insert(itemID)
+            }
+            DebugLog.info(
+                "Realtime buffer committed itemIDPresent=true pendingAcks=\(pendingCommitAcknowledgements) pendingItems=\(pendingCompletionItemIDs.count)",
+                context: "OpenAIRealtime"
+            )
             resumeFinishIfReady()
         case "conversation.item.input_audio_transcription.delta":
             guard let delta = payload["delta"] as? String, !delta.isEmpty else { return }
@@ -617,7 +599,7 @@ final class OpenAIRealtimeTranscriptionClient {
             let code = (error?["code"] as? String) ?? "unknown"
             let message = (error?["message"] as? String) ?? "OpenAI Realtime error"
             DebugLog.warning("Realtime error event code=\(code) message=\(message)", context: "OpenAIRealtime")
-            fail(message)
+            failOnQueue(message)
         case "session.created", "session.updated":
             DebugLog.info("Realtime event received type=\(type)", context: "OpenAIRealtime")
         default:
@@ -673,30 +655,51 @@ final class OpenAIRealtimeTranscriptionClient {
     }
 
     private func fail(_ message: String) {
+        sendQueue.async { [weak self] in
+            self?.failOnQueue(message)
+        }
+    }
+
+    private func failOnQueue(_ message: String) {
+        requireSendQueue()
+        guard !isClosed else { return }
         if failedMessage != nil {
             return
         }
         failedMessage = message
         DebugLog.warning("Realtime failed message=\(message)", context: "OpenAIRealtime")
-        resumeFinishIfNeeded(with: nil)
+        abandonTransportOnQueue()
+        finishGate.resolve(with: nil)
         Task { @MainActor in
             onError(message)
         }
     }
 
-    private func resumeFinishIfReady() {
-        guard didRequestFinish else { return }
-        guard uncommittedAudioByteCount == 0 else { return }
-        guard pendingCommitAcknowledgements == 0 else { return }
-        guard pendingCompletionItemIDs.isEmpty else { return }
-        resumeFinishIfNeeded(with: finalTranscript ?? (accumulatedTranscript.isEmpty ? nil : accumulatedTranscript))
+    private var isTransportDrained: Bool {
+        uncommittedAudioByteCount == 0
+            && pendingCommitAcknowledgements == 0
+            && pendingCompletionItemIDs.isEmpty
+            && trackedItemIDs.isSubset(of: completedItemIDs)
     }
 
-    private func resumeFinishIfNeeded(with transcript: String?) {
-        guard let continuation = finishContinuation else { return }
-        finishContinuation = nil
-        finishTimeoutTask?.cancel()
-        finishTimeoutTask = nil
-        continuation.resume(returning: transcript)
+    private func resumeFinishIfReady() {
+        requireSendQueue()
+        guard didRequestFinish else { return }
+        guard isTransportDrained else { return }
+        let completedTranscript = finalTranscript
+        abandonTransportOnQueue()
+        finishGate.resolve(with: completedTranscript)
+    }
+
+    private func abandonTransportOnQueue() {
+        requireSendQueue()
+        isClosed = true
+        pendingEvents.removeAll()
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+    }
+
+    private func requireSendQueue() {
+        dispatchPrecondition(condition: .onQueue(sendQueue))
     }
 }

--- a/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
+++ b/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Resolves one realtime finalization attempt on its owning serial queue.
+///
+/// The generation check prevents a cancelled timeout from resolving a later
+/// attempt, while `resolve` guarantees that completion, timeout, failure, and
+/// close can race without resuming a continuation more than once.
+final class RealtimeTranscriptionFinishGate: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private var continuation: CheckedContinuation<String?, Never>?
+    private var timeoutWorkItem: DispatchWorkItem?
+    private var generation: UInt64 = 0
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    func begin(
+        timeout: TimeInterval,
+        continuation: CheckedContinuation<String?, Never>,
+        onTimeout: @escaping @Sendable () -> Void
+    ) {
+        requireOwningQueue()
+        guard self.continuation == nil else {
+            continuation.resume(returning: nil)
+            return
+        }
+
+        generation &+= 1
+        let activeGeneration = generation
+        self.continuation = continuation
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.requireOwningQueue()
+            guard self.generation == activeGeneration,
+                  self.continuation != nil
+            else {
+                return
+            }
+            onTimeout()
+            self.resolve(with: nil)
+        }
+        timeoutWorkItem = workItem
+        queue.asyncAfter(
+            deadline: .now() + max(0, timeout),
+            execute: workItem
+        )
+    }
+
+    @discardableResult
+    func resolve(with transcript: String?) -> Bool {
+        requireOwningQueue()
+        guard let continuation else { return false }
+
+        self.continuation = nil
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        continuation.resume(returning: transcript)
+        return true
+    }
+
+    private func requireOwningQueue() {
+        dispatchPrecondition(condition: .onQueue(queue))
+    }
+}

--- a/scripts/validate_apple_audio_recovery.sh
+++ b/scripts/validate_apple_audio_recovery.sh
@@ -64,6 +64,13 @@ swiftc -parse-as-library -strict-concurrency=complete -warnings-as-errors \
   -o "$work_dir/validate-macos-snapshot"
 "$work_dir/validate-macos-snapshot"
 
+swiftc -parse-as-library -strict-concurrency=complete -warnings-as-errors \
+  -module-cache-path "$module_cache" \
+  Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift \
+  scripts/validate_macos_realtime_finalization.swift \
+  -o "$work_dir/validate-macos-realtime-finalization"
+"$work_dir/validate-macos-realtime-finalization"
+
 swiftc -parse-as-library -module-cache-path "$module_cache" \
   Whishpermate/WhisperMateShared/WhisperMateShared.swift \
   Whishpermate/WhisperMateShared/Models/TranscriptionOutputMode.swift \

--- a/scripts/validate_macos_realtime_finalization.swift
+++ b/scripts/validate_macos_realtime_finalization.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private func waitForFinish(
+    gate: RealtimeTranscriptionFinishGate,
+    queue: DispatchQueue,
+    timeout: TimeInterval,
+    timeoutCounter: LockedCounter
+) async -> String? {
+    await withCheckedContinuation { continuation in
+        queue.async {
+            gate.begin(
+                timeout: timeout,
+                continuation: continuation,
+                onTimeout: {
+                    timeoutCounter.increment()
+                }
+            )
+        }
+    }
+}
+
+@main
+struct ValidateMacOSRealtimeFinalization {
+    static func main() async throws {
+        let queue = DispatchQueue(label: "realtime-finish-validator")
+        let gate = RealtimeTranscriptionFinishGate(queue: queue)
+
+        let completionTimeouts = LockedCounter()
+        queue.asyncAfter(deadline: .now() + 0.01) {
+            precondition(gate.resolve(with: "complete"))
+            precondition(!gate.resolve(with: "late"))
+        }
+        let completed = await waitForFinish(
+            gate: gate,
+            queue: queue,
+            timeout: 0.05,
+            timeoutCounter: completionTimeouts
+        )
+        precondition(completed == "complete")
+        try await Task.sleep(for: .milliseconds(60))
+        precondition(completionTimeouts.value == 0)
+
+        let closeTimeouts = LockedCounter()
+        queue.asyncAfter(deadline: .now() + 0.01) {
+            precondition(gate.resolve(with: nil))
+            precondition(!gate.resolve(with: "partial"))
+        }
+        let closed = await waitForFinish(
+            gate: gate,
+            queue: queue,
+            timeout: 0.05,
+            timeoutCounter: closeTimeouts
+        )
+        precondition(closed == nil)
+        try await Task.sleep(for: .milliseconds(60))
+        precondition(closeTimeouts.value == 0)
+
+        let pendingTimeouts = LockedCounter()
+        let timedOut = await waitForFinish(
+            gate: gate,
+            queue: queue,
+            timeout: 0.01,
+            timeoutCounter: pendingTimeouts
+        )
+        precondition(timedOut == nil)
+        precondition(pendingTimeouts.value == 1)
+
+        let clientSource = try String(
+            contentsOfFile: "Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift",
+            encoding: .utf8
+        )
+        precondition(clientSource.contains(
+            "func finish(timeout: TimeInterval = 1.5) async -> String? {\n"
+                + "        return await withCheckedContinuation { continuation in\n"
+                + "            sendQueue.async"
+        ))
+        precondition(clientSource.contains(
+            "guard self.isTransportDrained, let finalTranscript = self.finalTranscript"
+        ) || clientSource.contains(
+            "if self.isTransportDrained, let finalTranscript = self.finalTranscript"
+        ))
+        precondition(clientSource.contains(
+            "trackedItemIDs.isSubset(of: completedItemIDs)"
+        ))
+        precondition(clientSource.contains(
+            "self.abandonTransportOnQueue()\n"
+                + "            self.finishGate.resolve(with: nil)"
+        ))
+        precondition(clientSource.contains(
+            "Realtime finish timeout elapsed; discarding unproven stream"
+        ))
+        precondition(clientSource.contains(
+            "context: \"OpenAIRealtime\"\n"
+                + "                    )\n"
+                + "                    self.abandonTransportOnQueue()"
+        ))
+        precondition(clientSource.contains(
+            "self.sendQueue.async { [weak self] in\n"
+                + "                guard let self, !self.isClosed else { return }"
+        ))
+        precondition(clientSource.contains(
+            "failOnQueue(\"Realtime commit acknowledgement was missing its item ID\")"
+        ))
+        precondition(clientSource.contains(
+            "self.fail(\"OpenAI Realtime send failed:"
+        ))
+        precondition(clientSource.contains(
+            "failedMessage = message\n"
+                + "        DebugLog.warning"
+        ))
+        precondition(clientSource.contains(
+            "abandonTransportOnQueue()\n"
+                + "        finishGate.resolve(with: nil)"
+        ))
+        precondition(clientSource.contains(
+            "guard !self.isClosed else { return }"
+        ))
+        precondition(!clientSource.contains("finalTranscript ?? currentTranscript"))
+        precondition(!clientSource.contains("resumeFinishIfNeeded"))
+
+        print("macOS realtime finalization is queue-confined and fails closed")
+    }
+}

--- a/scripts/validate_macos_transcription_attempt_snapshot.swift
+++ b/scripts/validate_macos_transcription_attempt_snapshot.swift
@@ -42,7 +42,6 @@ private struct MutableAttemptSettings {
     var language = "en"
     var vadThreshold: Float = 0.31
     var prompt = ["Before vocabulary"]
-    var replacement = "BeforeCanonical"
 }
 
 private func capture(_ settings: MutableAttemptSettings) -> MacTranscriptionAttemptSnapshot {
@@ -93,8 +92,7 @@ private func capture(_ settings: MutableAttemptSettings) -> MacTranscriptionAtte
         screenContext: "Before screen",
         vadEnabled: true,
         vadThreshold: settings.vadThreshold,
-        networkWasConnected: true,
-        replacements: [.init(trigger: "before", replacement: settings.replacement)]
+        networkWasConnected: true
     )
 }
 
@@ -116,7 +114,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         settings.language = "fr"
         settings.vadThreshold = 0.99
         settings.prompt.append("After rule")
-        settings.replacement = "AfterCanonical"
 
         precondition(snapshot.transcriptionEndpoint == "https://before.example/transcribe")
         precondition(snapshot.transcriptionModel == "before-model")
@@ -129,7 +126,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         precondition(snapshot.languageCode == "en")
         precondition(snapshot.vadThreshold == 0.31)
         precondition(snapshot.cleanupPromptComponents == ["Before vocabulary"])
-        precondition(snapshot.applyReplacements(to: "BEFORE value") == "BeforeCanonical value")
         let contextualSnapshot = snapshot.withContext(
             appContext: "Captured app",
             screenContext: "Captured screen"
@@ -140,11 +136,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         precondition(contextualSnapshot.transcriptionModel == snapshot.transcriptionModel)
         precondition(contextualSnapshot.llmEndpoint == snapshot.llmEndpoint)
         precondition(contextualSnapshot.cleanupPromptComponents == snapshot.cleanupPromptComponents)
-        precondition(
-            contextualSnapshot.applyReplacements(to: "BEFORE value")
-                == snapshot.applyReplacements(to: "BEFORE value"),
-            "Adding captured context changed frozen attempt settings"
-        )
         let currentContextSnapshot = snapshot.withContext(
             appContext: "Current app",
             screenContext: "Current screen",
@@ -171,12 +162,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
                 == currentContextSnapshot.cleanupPromptComponents,
             "Resolving captured context twice duplicated frozen instructions"
         )
-        let literalDictation = "Keep (round) [square] {curly} <speaker> tagged text verbatim."
-        precondition(
-            snapshot.applyReplacements(to: literalDictation) == literalDictation,
-            "Durable raw text lost literal dictated delimiters or tags"
-        )
-
         let appStatePath = "Whishpermate/Whispermate/Services/AppState.swift"
         let source = try String(contentsOfFile: appStatePath, encoding: .utf8)
         guard let start = source.range(of: "    private func performTranscription("),
@@ -248,9 +233,19 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
             )
         }
         precondition(source.contains("if let realtimeResult"))
-        precondition(source.contains("try await session.markRawResultReady(raw)"))
+        precondition(source.contains("try await session.checkpoint(realtimeResult)"))
+        precondition(source.contains("try await session.markRawResultReady(realtimeResult)"))
         precondition(source.contains("try await session.beginCleanup()"))
-        precondition(source.contains("rawText: raw,\n                        client: OpenAIClient(config: .init())"))
+        precondition(source.contains(
+            "rawText: realtimeResult,\n                        client: OpenAIClient(config: .init())"
+        ))
+        precondition(
+            !source.contains("applyReplacements(to:"),
+            "Recognizer text is being transformed before the durable raw checkpoint"
+        )
+        precondition(source.contains(
+            "let durableRaw = text.trimmingCharacters(in: .whitespacesAndNewlines)"
+        ))
         guard let cleanupStart = source.range(of: "    private func applyLLMPass("),
               let cleanupEnd = source.range(
                 of: "    private func applyOutputModeFormatting(",


### PR DESCRIPTION
## Summary
- keep realtime and Parakeet recognizer output unmodified through the durable raw checkpoint and cleanup fallback
- serialize realtime finish/timeout/close/failure state on one queue and discard unproven prefixes
- batch-fallback on timeout, socket/send failure, malformed commit acknowledgement, or close
- add deterministic exactly-once finalization and raw-order recovery contracts

## Verification
- Apple audio recovery contract matrix
- macOS Debug build
- iOS + keyboard simulator build
- focused code review: 0 critical/high/medium findings
- git diff --check