### PR TITLE
Default clients to Cloudflare authentication

### DIFF
--- a/AIDictation.Windows/AIDictation/Helpers/BuildConfig.cs
+++ b/AIDictation.Windows/AIDictation/Helpers/BuildConfig.cs
@@ -19,7 +19,7 @@ public static class BuildConfig
         public const string TranscriptionModel = "groq/whisper-large-v3-turbo";
         public const string PostProcessingEndpoint = "https://writingmate.ai/api/openai/v1/chat/completions";
         public const string PostProcessingModel = "openai/gpt-oss-20b";
-        public const string AuthWebUrl = "https://voicesinmyhead.co/auth";
+        public const string AuthWebUrl = "https://aidictation.com/auth";
     }
 
     // MARK: - Private Properties

--- a/BACKEND_IMPLEMENTATION.md
+++ b/BACKEND_IMPLEMENTATION.md
@@ -347,9 +347,9 @@ serve(async (req) => {
 
 ---
 
-## 4. Supabase Auth Configuration
+## 4. Cloudflare Auth Configuration
 
-In Supabase Dashboard → Authentication → URL Configuration:
+The production auth service is hosted at `https://aidictation.com/auth/v1`.
 
 **Site URL:**
 ```
@@ -381,12 +381,12 @@ whispermate://payment/cancel
 
 ### Set up Webhook:
 1. Stripe Dashboard → Developers → Webhooks
-2. Add endpoint: `https://YOUR_PROJECT.supabase.co/functions/v1/stripe-webhook`
+2. Add endpoint: `https://aidictation.com/functions/v1/stripe-webhook`
 3. Select events:
    - `checkout.session.completed`
    - `customer.subscription.updated`
    - `customer.subscription.deleted`
-4. Copy webhook signing secret → Add to Supabase Edge Function secrets
+4. Copy the webhook signing secret into the Cloudflare production secrets
 
 ---
 
@@ -394,7 +394,7 @@ whispermate://payment/cancel
 
 ### Base URL:
 ```
-https://YOUR_PROJECT.supabase.co
+https://aidictation.com
 ```
 
 ### Endpoints:
@@ -503,8 +503,8 @@ Response (Limit Reached - 403):
 
 Once complete, please provide:
 
-1. **Supabase Project URL**: `https://xxxxx.supabase.co`
-2. **Supabase Anon Key**: `eyJhbG...` (public key, safe for client)
+1. **Cloud service URL**: `https://aidictation.com`
+2. **Public client key**: the configured public key (safe for the client)
 3. **Stripe Payment Link**: `https://buy.stripe.com/xxxxx`
 
 These will be added to the Mac app's `Secrets.plist`.

--- a/Whishpermate/WEB_AUTH_IMPLEMENTATION.md
+++ b/Whishpermate/WEB_AUTH_IMPLEMENTATION.md
@@ -1,6 +1,6 @@
 # Web Authentication Implementation Guide
 
-This document describes how to implement the web-based authentication page at `https://voicesinmyhead.co/auth` that redirects back to the WhisperMate macOS app.
+This document describes the web-based authentication page at `https://aidictation.com/auth` that redirects back to the AI Dictation macOS app.
 
 ## Overview
 
@@ -42,7 +42,7 @@ WhisperMate uses **Implicit Flow** for web-based authentication where:
 
 Your web page receives:
 ```
-https://voicesinmyhead.co/auth?redirect_to=whispermate://auth-callback
+https://aidictation.com/auth?redirect_to=whispermate://auth-callback
 ```
 
 Extract the `redirect_to` parameter:
@@ -57,7 +57,7 @@ const redirectTo = params.get('redirect_to') || 'whispermate://auth-callback';
 import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
-  'https://rfhdborvqhqzwsgbgzmz.supabase.co',
+  'https://aidictation.com',
   'YOUR_SUPABASE_ANON_KEY'
 )
 ```
@@ -150,7 +150,7 @@ function redirectToApp(session) {
   <script>
     // Initialize Supabase
     const supabase = supabase.createClient(
-      'https://rfhdborvqhqzwsgbgzmz.supabase.co',
+      'https://aidictation.com',
       'YOUR_SUPABASE_ANON_KEY'
     )
 
@@ -282,7 +282,7 @@ The implicit flow passes tokens in URL fragments. This is acceptable for desktop
 ### Test Sign Up Flow
 ```bash
 # Open in browser:
-open "https://voicesinmyhead.co/auth?redirect_to=whispermate://auth-callback"
+open "https://aidictation.com/auth?redirect_to=whispermate://auth-callback"
 
 # Expected:
 # 1. Form appears

--- a/scripts/validate_release_transcription_config.py
+++ b/scripts/validate_release_transcription_config.py
@@ -24,6 +24,7 @@ from urllib import error, parse, request
 
 
 EXPECTED_WRITINGMATE_MODEL = "groq/whisper-large-v3-turbo"
+RELEASE_VALIDATOR_USER_AGENT = "AIDictation-Release-Validator/1.0"
 STALE_TRANSCRIPTION_MODELS = {
     "gpt-4o-transcribe",
     "gpt-4o-mini-transcribe",
@@ -124,7 +125,11 @@ def http_json(url: str, headers: dict[str, str], payload: dict[str, Any]) -> Any
     req = request.Request(
         url,
         data=data,
-        headers={**headers, "Content-Type": "application/json"},
+        headers={
+            **headers,
+            "Content-Type": "application/json",
+            "User-Agent": RELEASE_VALIDATOR_USER_AGENT,
+        },
         method="POST",
     )
     try:
@@ -136,7 +141,11 @@ def http_json(url: str, headers: dict[str, str], payload: dict[str, Any]) -> Any
 
 
 def http_get_json(url: str, headers: dict[str, str]) -> Any:
-    req = request.Request(url, headers=headers, method="GET")
+    req = request.Request(
+        url,
+        headers={**headers, "User-Agent": RELEASE_VALIDATOR_USER_AGENT},
+        method="GET",
+    )
     try:
         with request.urlopen(req, timeout=30) as response:
             return json.loads(response.read().decode("utf-8"))
@@ -157,6 +166,7 @@ def transcribe(endpoint: str, api_key: str, model: str, audio: Path, label: str)
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "User-Agent": RELEASE_VALIDATOR_USER_AGENT,
     }
     req = request.Request(endpoint, data=body, headers=headers, method="POST")
     try:


### PR DESCRIPTION
## Summary\n- make the Windows client default to the Cloudflare-hosted authentication page\n- update the macOS web-auth implementation guide to the production Cloudflare URLs\n\n## Context\nThis removes the remaining shipped/default client references to the legacy hosted auth endpoint after the website and database cutover. Stripe remains the billing authority; RevenueCat migration is deferred.