### PR TITLE
Fix and gate the Windows account release

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -177,9 +177,11 @@ jobs:
       TRANSCRIPTION_MODEL: ${{ secrets.TRANSCRIPTION_MODEL }}
       AIDICTATION_POST_PROCESSING_KEY: ${{ secrets.AIDICTATION_POST_PROCESSING_KEY }}
       AIDICTATION_POST_PROCESSING_ENDPOINT: ${{ secrets.AIDICTATION_POST_PROCESSING_ENDPOINT }}
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-      AUTH_WEB_URL: ${{ secrets.AUTH_WEB_URL }}
+      # The public browser and packaged profile client must use one account
+      # service. Do not allow a stale organization secret to split them again.
+      SUPABASE_URL: https://aidictation.com
+      SUPABASE_ANON_KEY: public-anon-key
+      AUTH_WEB_URL: https://aidictation.com/auth
       STRIPE_PAYMENT_LINK: ${{ secrets.STRIPE_PAYMENT_LINK }}
 
     steps:
@@ -228,10 +230,43 @@ jobs:
         -InstallerDir ./installer
         -Version ${{ steps.version.outputs.VERSION }}
 
+    - name: Validate packaged version and account flow
+      shell: pwsh
+      env:
+        AIDICTATION_RELEASE_TEST_EMAIL: ${{ secrets.AIDICTATION_RELEASE_TEST_EMAIL }}
+        AIDICTATION_RELEASE_TEST_PASSWORD: ${{ secrets.AIDICTATION_RELEASE_TEST_PASSWORD }}
+      run: |
+        $version = "${{ steps.version.outputs.VERSION }}"
+        $installer = "./installer/AIDictation-Windows-Setup-v$version.exe"
+        $installerVersion = [regex]::Match(
+          (Get-Item $installer).VersionInfo.ProductVersion,
+          '^\d+\.\d+\.\d+'
+        ).Value
+        if ($installerVersion -ne $version) {
+          throw "Installer reports $installerVersion; expected $version."
+        }
+        AIDictation.Windows/scripts/validate-release-auth.ps1 `
+          -AppPath ./release/AIDictation.exe `
+          -ExpectedVersion $version
+
     - name: Create ZIP
       shell: pwsh
       run: |
         Compress-Archive -Path ./release/* -DestinationPath ./AIDictation-Windows-v${{ steps.version.outputs.VERSION }}.zip
+
+    - name: Create release checksums
+      shell: pwsh
+      run: |
+        $version = "${{ steps.version.outputs.VERSION }}"
+        $assets = @(
+          "./installer/AIDictation-Windows-Setup-v$version.exe",
+          "./AIDictation-Windows-v$version.zip"
+        )
+        $lines = foreach ($asset in $assets) {
+          $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLowerInvariant()
+          "$hash  $([System.IO.Path]::GetFileName($asset))"
+        }
+        Set-Content -Path ./SHA256SUMS.txt -Value $lines -Encoding ascii
 
     - name: Upload Release Artifact
       uses: actions/upload-artifact@v4
@@ -247,7 +282,14 @@ jobs:
         path: ./installer/AIDictation-Windows-Setup-v${{ steps.version.outputs.VERSION }}.exe
         retention-days: 90
 
-    - name: Publish GitHub Release
+    - name: Upload Release Checksum Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: AIDictation-Windows-Checksums-v${{ steps.version.outputs.VERSION }}
+        path: ./SHA256SUMS.txt
+        retention-days: 90
+
+    - name: Stage draft GitHub Release
       shell: pwsh
       env:
         GH_TOKEN: ${{ github.token }}
@@ -261,19 +303,216 @@ jobs:
         }
         $zip = "./AIDictation-Windows-v$version.zip"
         $installer = "./installer/AIDictation-Windows-Setup-v$version.exe"
+        $checksums = "./SHA256SUMS.txt"
         $notes = @"
         Classic Windows installer and portable ZIP for AIDictation Windows v$version.
 
         Built automatically from release tag $tag.
         "@
 
-        gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
+        $existingDraft = gh release view $tag `
+          --json isDraft `
+          --jq '.isDraft' `
+          --repo $env:GITHUB_REPOSITORY 2> $null
         if ($LASTEXITCODE -eq 0) {
-          gh release upload $tag $installer $zip --clobber --repo $env:GITHUB_REPOSITORY
+          if ($existingDraft.Trim() -ne "true") {
+            throw "Refusing to replace an already-published Windows release."
+          }
+          gh release upload $tag $installer $zip $checksums --clobber --repo $env:GITHUB_REPOSITORY
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not update the staged Windows release assets."
+          }
           gh release edit $tag --title "AIDictation Windows v$version" --notes $notes --repo $env:GITHUB_REPOSITORY
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not update the staged Windows release metadata."
+          }
         } else {
-          gh release create $tag $installer $zip `
+          gh release create $tag $installer $zip $checksums `
+            --draft `
+            --verify-tag `
             --title "AIDictation Windows v$version" `
             --notes $notes `
             --repo $env:GITHUB_REPOSITORY
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not stage the draft Windows release."
+          }
         }
+
+  verify-and-publish-release:
+    name: Verify staged installer and publish release
+    needs: release
+    runs-on: windows-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/windows-v')
+    permissions:
+      contents: write
+    env:
+      SUPABASE_URL: https://aidictation.com
+      SUPABASE_ANON_KEY: public-anon-key
+      AUTH_WEB_URL: https://aidictation.com/auth
+      AIDICTATION_RELEASE_TEST_EMAIL: ${{ secrets.AIDICTATION_RELEASE_TEST_EMAIL }}
+      AIDICTATION_RELEASE_TEST_PASSWORD: ${{ secrets.AIDICTATION_RELEASE_TEST_PASSWORD }}
+
+    steps:
+    - name: Checkout release source
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.sha }}
+
+    - name: Download staged release assets
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $tag = "${{ github.ref_name }}"
+        $downloadDir = Join-Path $env:RUNNER_TEMP "aidictation-staged-release"
+        New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
+        gh release download $tag `
+          --pattern '*.exe' `
+          --pattern '*.zip' `
+          --pattern 'SHA256SUMS.txt' `
+          --dir $downloadDir `
+          --clobber `
+          --repo $env:GITHUB_REPOSITORY
+        if ($LASTEXITCODE -ne 0) {
+          throw "Could not download the staged Windows release assets."
+        }
+        "STAGED_RELEASE_DIR=$downloadDir" >> $env:GITHUB_ENV
+
+    - name: Verify staged asset names and checksums
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $version = "${{ github.ref_name }}" -replace '^windows-v', ''
+        $expectedNames = @(
+          "AIDictation-Windows-Setup-v$version.exe",
+          "AIDictation-Windows-v$version.zip",
+          "SHA256SUMS.txt"
+        )
+        $releaseNames = @(gh release view "${{ github.ref_name }}" `
+          --json assets `
+          --jq '.assets[].name' `
+          --repo $env:GITHUB_REPOSITORY)
+        if ($LASTEXITCODE -ne 0 -or
+            (Compare-Object ($expectedNames | Sort-Object) ($releaseNames | Sort-Object))) {
+          throw "The staged release does not contain exactly the expected Windows assets."
+        }
+
+        $manifestPath = Join-Path $env:STAGED_RELEASE_DIR "SHA256SUMS.txt"
+        $manifest = Get-Content -Raw $manifestPath
+        foreach ($name in $expectedNames | Where-Object { $_ -ne "SHA256SUMS.txt" }) {
+          $pattern = '(?im)^([0-9a-f]{64})\s+' + [regex]::Escape($name) + '\r?$'
+          $match = [regex]::Match($manifest, $pattern)
+          if (-not $match.Success) {
+            throw "SHA256SUMS.txt is missing $name."
+          }
+          $actual = (Get-FileHash `
+            -Algorithm SHA256 `
+            -Path (Join-Path $env:STAGED_RELEASE_DIR $name)).Hash.ToLowerInvariant()
+          if ($actual -ne $match.Groups[1].Value.ToLowerInvariant()) {
+            throw "Checksum verification failed for $name."
+          }
+        }
+
+    - name: Install and validate staged release
+      shell: pwsh
+      run: |
+        $version = "${{ github.ref_name }}" -replace '^windows-v', ''
+        $installer = Join-Path $env:STAGED_RELEASE_DIR "AIDictation-Windows-Setup-v$version.exe"
+        $installDir = Join-Path $env:RUNNER_TEMP "aidictation-installed-$version"
+        $install = Start-Process `
+          -FilePath $installer `
+          -ArgumentList @(
+            '/VERYSILENT',
+            '/SUPPRESSMSGBOXES',
+            '/NORESTART',
+            '/SP-',
+            "/DIR=$installDir"
+          ) `
+          -PassThru `
+          -Wait
+        if ($install.ExitCode -ne 0) {
+          throw "The staged Windows installer exited with code $($install.ExitCode)."
+        }
+        $appPath = Join-Path $installDir "AIDictation.exe"
+        if (-not (Test-Path $appPath)) {
+          throw "The staged installer did not install AIDictation.exe."
+        }
+        AIDictation.Windows/scripts/validate-release-auth.ps1 `
+          -AppPath $appPath `
+          -ExpectedVersion $version
+
+    - name: Publish verified release
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $tag = "${{ github.ref_name }}"
+        gh release edit $tag `
+          --draft=false `
+          --latest `
+          --repo $env:GITHUB_REPOSITORY
+        if ($LASTEXITCODE -ne 0) {
+          throw "The verified Windows release could not be published."
+        }
+
+    - name: Verify public release and download route
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $tag = "${{ github.ref_name }}"
+        $version = $tag -replace '^windows-v', ''
+        $release = gh api `
+          -H 'Accept: application/vnd.github+json' `
+          "repos/$env:GITHUB_REPOSITORY/releases/tags/$tag" | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0 -or $release.draft -or $release.prerelease) {
+          throw "The verified Windows release is not publicly published."
+        }
+        $tagSha = (git rev-list -n 1 "refs/tags/$tag").Trim()
+        if ($release.tag_name -ne $tag -or $tagSha -ne $env:GITHUB_SHA) {
+          throw "The public release tag does not target the verified source commit."
+        }
+
+        $assetName = "AIDictation-Windows-Setup-v$version.exe"
+        $asset = $release.assets | Where-Object { $_.name -eq $assetName }
+        if (-not $asset -or -not $asset.browser_download_url) {
+          throw "The public release is missing its Windows installer."
+        }
+        $publicDir = Join-Path $env:RUNNER_TEMP "aidictation-public-release"
+        New-Item -ItemType Directory -Force -Path $publicDir | Out-Null
+        $publicInstaller = Join-Path $publicDir $assetName
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $publicInstaller
+        $stagedHash = (Get-FileHash `
+          -Algorithm SHA256 `
+          -Path (Join-Path $env:STAGED_RELEASE_DIR $assetName)).Hash
+        $publicHash = (Get-FileHash -Algorithm SHA256 -Path $publicInstaller).Hash
+        if ($publicHash -ne $stagedHash) {
+          throw "The public installer differs from the verified staged installer."
+        }
+
+        $headers = @{ 'User-Agent' = 'AIDictation-Windows-Release-Verification' }
+        # The download page uses the first stable windows-v* item returned by
+        # this public GitHub feed, so verify that exact selection rule.
+        $currentWindows = $null
+        for ($attempt = 1; $attempt -le 12; $attempt++) {
+          $publicReleases = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/$env:GITHUB_REPOSITORY/releases?per_page=100" `
+            -Headers $headers
+          $currentWindows = $publicReleases |
+            Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -match '^windows-v\d+\.\d+\.\d+$' } |
+            Select-Object -First 1
+          if ($currentWindows -and $currentWindows.tag_name -eq $tag) {
+            break
+          }
+          Start-Sleep -Seconds 5
+        }
+        if (-not $currentWindows -or $currentWindows.tag_name -ne $tag) {
+          throw "The public release feed does not expose $tag as the current Windows download."
+        }
+        $downloadPage = Invoke-WebRequest -Uri 'https://aidictation.com/download'
+        if ($downloadPage.StatusCode -ne 200) {
+          throw "The public AIDictation download page is unavailable."
+        }
+        Write-Host "PASS: public Windows $version installer matches the end-to-end verified package"

--- a/AIDictation.Windows/AIDictation/App.xaml.cs
+++ b/AIDictation.Windows/AIDictation/App.xaml.cs
@@ -2,16 +2,19 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Threading;
+using AIDictation.Helpers;
 using AIDictation.Models;
 using AIDictation.Services;
 using AIDictation.Views;
 using H.NotifyIcon;
 using Microsoft.Win32;
+using Newtonsoft.Json;
 
 namespace AIDictation;
 
@@ -52,6 +55,23 @@ public partial class App : Application
 
     protected override async void OnStartup(StartupEventArgs e)
     {
+        if (TryGetReleaseValidationReportPath(e.Args, "--validate-release-config", out var configReportPath))
+        {
+            _isValidationOnly = true;
+            base.OnStartup(e);
+            WriteReleaseConfigReport(configReportPath);
+            return;
+        }
+
+        if (TryGetReleaseValidationReportPath(e.Args, "--validate-release-auth", out var authReportPath))
+        {
+            _isValidationOnly = true;
+            base.OnStartup(e);
+            RegisterUrlScheme();
+            await WriteReleaseAuthReportAsync(authReportPath);
+            return;
+        }
+
         // Single instance enforcement; forward our launch URL (e.g. the
         // aidictation://auth-callback from the browser) to the running instance.
         if (!EnsureSingleInstance())
@@ -96,6 +116,110 @@ public partial class App : Application
         await ShowStartupWindowAsync();
 
         SubscribeRuntimeEvents();
+    }
+
+    // MARK: - Release Validation
+
+    private static bool TryGetReleaseValidationReportPath(
+        string[] args,
+        string option,
+        out string reportPath)
+    {
+        reportPath = string.Empty;
+        var optionIndex = Array.FindIndex(
+            args,
+            arg => arg.Equals(option, StringComparison.OrdinalIgnoreCase));
+        if (optionIndex < 0 || optionIndex + 1 >= args.Length)
+        {
+            return false;
+        }
+
+        reportPath = Path.GetFullPath(args[optionIndex + 1]);
+        return true;
+    }
+
+    private void WriteReleaseConfigReport(string reportPath)
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? string.Empty;
+        WriteReleaseReport(reportPath, new
+        {
+            success = BuildConfig.IsAuthConfigured && BuildConfig.AuthBackendsAgree,
+            version,
+            auth_web_url = BuildConfig.AuthWebUrl,
+            profile_api_origin = BuildConfig.SupabaseUrl,
+            auth_configured = BuildConfig.IsAuthConfigured,
+            auth_backends_agree = BuildConfig.AuthBackendsAgree
+        });
+        Shutdown(BuildConfig.IsAuthConfigured && BuildConfig.AuthBackendsAgree ? 0 : 1);
+    }
+
+    private async Task WriteReleaseAuthReportAsync(string reportPath)
+    {
+        var accessToken = Environment.GetEnvironmentVariable("AIDICTATION_RELEASE_ACCESS_TOKEN") ?? string.Empty;
+        var refreshToken = Environment.GetEnvironmentVariable("AIDICTATION_RELEASE_REFRESH_TOKEN") ?? string.Empty;
+        var expectedTier = Environment.GetEnvironmentVariable("AIDICTATION_RELEASE_EXPECTED_TIER") ?? string.Empty;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(accessToken))
+            {
+                throw new InvalidOperationException("Release validation access token is missing.");
+            }
+
+            var callback = new Uri(
+                "aidictation://auth-callback#access_token=" + Uri.EscapeDataString(accessToken) +
+                "&refresh_token=" + Uri.EscapeDataString(refreshToken));
+            var authenticated = await AuthService.Instance.HandleOAuthCallbackAsync(callback);
+            var user = AuthService.Instance.CurrentUser;
+            if (!authenticated || user == null)
+            {
+                throw new InvalidOperationException("The packaged app could not load the authenticated profile.");
+            }
+
+            var tier = user.SubscriptionTier;
+            if (!string.IsNullOrWhiteSpace(expectedTier) &&
+                !tier.ToString().Equals(expectedTier, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Expected {expectedTier} access but the packaged app loaded {tier} access.");
+            }
+
+            var wordLimit = tier.GetWordLimit();
+            WriteReleaseReport(reportPath, new
+            {
+                success = true,
+                tier = tier.ToString(),
+                monthly_words = user.MonthlyWordCount,
+                word_limit = wordLimit,
+                words_remaining = user.WordsRemaining,
+                has_reached_limit = user.HasReachedLimit,
+                profile_record_loaded = user.Id != Guid.Empty,
+                auth_host = new Uri(BuildConfig.AuthWebUrl).Host,
+                profile_api_host = new Uri(BuildConfig.SupabaseUrl).Host
+            });
+            await AuthService.Instance.SignOutAsync();
+            Shutdown(0);
+        }
+        catch (Exception exception)
+        {
+            await AuthService.Instance.SignOutAsync();
+            WriteReleaseReport(reportPath, new
+            {
+                success = false,
+                error = exception.Message
+            });
+            Shutdown(1);
+        }
+    }
+
+    private static void WriteReleaseReport(string reportPath, object report)
+    {
+        var directory = Path.GetDirectoryName(reportPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.WriteAllText(reportPath, JsonConvert.SerializeObject(report));
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/AIDictation.Windows/scripts/build-installer.ps1
+++ b/AIDictation.Windows/scripts/build-installer.ps1
@@ -41,6 +41,7 @@ dotnet publish $ProjectPath `
     --runtime $Runtime `
     --self-contained true `
     --output $PublishDir `
+    -p:Version=$Version `
     -p:PublishSingleFile=true `
     -p:IncludeNativeLibrariesForSelfExtract=true `
     -p:EnableCompressionInSingleFile=true

--- a/AIDictation.Windows/scripts/validate-release-auth.ps1
+++ b/AIDictation.Windows/scripts/validate-release-auth.ps1
@@ -1,0 +1,371 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedVersion,
+    [string]$ReportDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $ReportDir) {
+    $ReportDir = Join-Path $env:RUNNER_TEMP "aidictation-windows-release-validation"
+}
+New-Item -ItemType Directory -Force -Path $ReportDir | Out-Null
+
+function Get-ThreePartVersion {
+    param([Parameter(Mandatory = $true)] [string]$Version)
+
+    $match = [regex]::Match($Version, '^\d+\.\d+\.\d+')
+    if (-not $match.Success) {
+        throw "Could not read a three-part product version from '$Version'."
+    }
+    return $match.Value
+}
+
+function Invoke-WebDriverJson {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Uri,
+        [string]$Method = "GET",
+        [object]$Body = $null
+    )
+
+    $parameters = @{
+        Uri = $Uri
+        Method = $Method
+        TimeoutSec = 15
+    }
+    if ($null -ne $Body) {
+        $parameters.ContentType = "application/json"
+        $parameters.Body = ($Body | ConvertTo-Json -Depth 8 -Compress)
+    }
+    return Invoke-RestMethod @parameters
+}
+
+function Get-WebDriverElement {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SessionUrl,
+        [Parameter(Mandatory = $true)] [string]$Selector
+    )
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds(20)
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        try {
+            $found = Invoke-WebDriverJson `
+                -Uri "$SessionUrl/element" `
+                -Method POST `
+                -Body @{ using = "css selector"; value = $Selector }
+            $id = $found.value.PSObject.Properties.Value | Select-Object -First 1
+            if ($id) { return $id }
+        } catch {
+            Start-Sleep -Milliseconds 300
+        }
+    }
+    throw "The public sign-in page did not expose $Selector."
+}
+
+function ConvertFrom-Fragment {
+    param([Parameter(Mandatory = $true)] [string]$Fragment)
+
+    $result = @{}
+    foreach ($pair in $Fragment.TrimStart('#').Split('&')) {
+        if (-not $pair) { continue }
+        $parts = $pair.Split('=', 2)
+        $name = [System.Net.WebUtility]::UrlDecode($parts[0])
+        $value = if ($parts.Length -gt 1) {
+            [System.Net.WebUtility]::UrlDecode($parts[1])
+        } else {
+            ""
+        }
+        $result[$name] = $value
+    }
+    return $result
+}
+
+function Start-PackagedValidation {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Mode,
+        [Parameter(Mandatory = $true)] [string]$ReportPath
+    )
+
+    if (Test-Path $ReportPath) {
+        Remove-Item -Force $ReportPath
+    }
+    $process = Start-Process `
+        -FilePath $AppPath `
+        -ArgumentList @($Mode, $ReportPath) `
+        -PassThru `
+        -Wait
+    if (-not (Test-Path $ReportPath)) {
+        throw "The packaged app did not write its release-validation report."
+    }
+    $report = Get-Content -Raw $ReportPath | ConvertFrom-Json
+    if ($process.ExitCode -ne 0 -or -not $report.success) {
+        $reason = if ($report.error) { $report.error } else { "unknown validation failure" }
+        throw "Packaged app release validation failed: $reason"
+    }
+    return $report
+}
+
+function Get-BrowserSessionTokens {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Email,
+        [Parameter(Mandatory = $true)] [string]$Password
+    )
+
+    $driverCommand = Get-Command chromedriver.exe -ErrorAction SilentlyContinue
+    if (-not $driverCommand) {
+        $driverCommand = Get-Command msedgedriver.exe -ErrorAction SilentlyContinue
+    }
+    if (-not $driverCommand) {
+        throw "A supported WebDriver is required to verify the public browser sign-in flow."
+    }
+
+    $port = 9515
+    $driverLog = Join-Path $ReportDir "webdriver.out.log"
+    $driverErrorLog = Join-Path $ReportDir "webdriver.err.log"
+    $driver = Start-Process `
+        -FilePath $driverCommand.Source `
+        -ArgumentList @("--port=$port") `
+        -RedirectStandardOutput $driverLog `
+        -RedirectStandardError $driverErrorLog `
+        -PassThru
+    $sessionUrl = $null
+
+    try {
+        $statusUrl = "http://127.0.0.1:$port/status"
+        $readyDeadline = [DateTimeOffset]::UtcNow.AddSeconds(15)
+        while ([DateTimeOffset]::UtcNow -lt $readyDeadline) {
+            try {
+                $status = Invoke-WebDriverJson -Uri $statusUrl
+                if ($status.value.ready) { break }
+            } catch {
+                Start-Sleep -Milliseconds 300
+            }
+        }
+
+        $browserName = if ($driverCommand.Name -like "msedge*") { "MicrosoftEdge" } else { "chrome" }
+        $optionsName = if ($browserName -eq "MicrosoftEdge") { "ms:edgeOptions" } else { "goog:chromeOptions" }
+        $alwaysMatch = @{ browserName = $browserName }
+        $alwaysMatch[$optionsName] = @{
+            args = @("--headless=new", "--disable-gpu", "--no-sandbox", "--window-size=1280,900")
+        }
+        $session = Invoke-WebDriverJson `
+            -Uri "http://127.0.0.1:$port/session" `
+            -Method POST `
+            -Body @{ capabilities = @{ alwaysMatch = $alwaysMatch } }
+        $sessionId = $session.value.sessionId
+        if (-not $sessionId) { $sessionId = $session.sessionId }
+        if (-not $sessionId) { throw "WebDriver did not create a browser session." }
+        $sessionUrl = "http://127.0.0.1:$port/session/$sessionId"
+
+        $callbackUrl = "https://aidictation.com/release-validation"
+        $encodedCallback = [Uri]::EscapeDataString($callbackUrl)
+        $authUrl = "https://aidictation.com/auth?redirect_to=$encodedCallback"
+        Invoke-WebDriverJson -Uri "$sessionUrl/url" -Method POST -Body @{ url = $authUrl } | Out-Null
+
+        $emailElement = Get-WebDriverElement -SessionUrl $sessionUrl -Selector "#email"
+        $passwordElement = Get-WebDriverElement -SessionUrl $sessionUrl -Selector "#password"
+        $submitElement = Get-WebDriverElement -SessionUrl $sessionUrl -Selector "button[type='submit']"
+        Invoke-WebDriverJson `
+            -Uri "$sessionUrl/element/$emailElement/value" `
+            -Method POST `
+            -Body @{ text = $Email } | Out-Null
+        Invoke-WebDriverJson `
+            -Uri "$sessionUrl/element/$passwordElement/value" `
+            -Method POST `
+            -Body @{ text = $Password } | Out-Null
+        Invoke-WebDriverJson `
+            -Uri "$sessionUrl/element/$submitElement/click" `
+            -Method POST `
+            -Body @{} | Out-Null
+
+        $callback = $null
+        $callbackDeadline = [DateTimeOffset]::UtcNow.AddSeconds(30)
+        while ([DateTimeOffset]::UtcNow -lt $callbackDeadline) {
+            $current = Invoke-WebDriverJson -Uri "$sessionUrl/url"
+            if ($current.value -and $current.value.StartsWith("$callbackUrl#")) {
+                $callback = [Uri]$current.value
+                break
+            }
+            Start-Sleep -Milliseconds 500
+        }
+        if (-not $callback) {
+            throw "The public browser sign-in did not return an app session."
+        }
+
+        $tokens = ConvertFrom-Fragment -Fragment $callback.Fragment
+        if (-not $tokens.access_token -or -not $tokens.refresh_token) {
+            throw "The public browser sign-in callback omitted session tokens."
+        }
+        return @{
+            access_token = $tokens.access_token
+            refresh_token = $tokens.refresh_token
+        }
+    } finally {
+        if ($sessionUrl) {
+            try { Invoke-WebDriverJson -Uri $sessionUrl -Method DELETE | Out-Null } catch { }
+        }
+        if ($driver -and -not $driver.HasExited) {
+            Stop-Process -Id $driver.Id -Force
+        }
+        Remove-Item -Force -ErrorAction SilentlyContinue $driverLog, $driverErrorLog
+    }
+}
+
+function ConvertTo-Base64Url {
+    param([Parameter(Mandatory = $true)] [string]$Value)
+    return [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Value)).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Start-LifetimeStub {
+    param([Parameter(Mandatory = $true)] [int]$Port)
+
+    return Start-Job -ScriptBlock {
+        param($ListenPort)
+        $listener = [System.Net.HttpListener]::new()
+        $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
+        $listener.Start()
+        try {
+            for ($requestIndex = 0; $requestIndex -lt 2; $requestIndex++) {
+                $context = $listener.GetContext()
+                $path = $context.Request.Url.AbsolutePath
+                if ($path -eq "/auth/v1/user") {
+                    $json = '{"id":"11111111-1111-1111-1111-111111111111","email":"release-lifetime@example.test"}'
+                } elseif ($path -eq "/rest/v1/profiles") {
+                    $json = '[{"id":"22222222-2222-2222-2222-222222222222","user_id":"11111111-1111-1111-1111-111111111111","email":"release-lifetime@example.test","monthly_word_count":321,"subscription_status":"lifetime"}]'
+                } else {
+                    $context.Response.StatusCode = 404
+                    $json = '{"error":"not found"}'
+                }
+                $bytes = [Text.Encoding]::UTF8.GetBytes($json)
+                $context.Response.ContentType = "application/json"
+                $context.Response.ContentLength64 = $bytes.Length
+                $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+                $context.Response.Close()
+            }
+        } finally {
+            $listener.Stop()
+            $listener.Close()
+        }
+    } -ArgumentList $Port
+}
+
+$app = Get-Item $AppPath
+$productVersion = Get-ThreePartVersion -Version $app.VersionInfo.ProductVersion
+if ($productVersion -ne $ExpectedVersion) {
+    throw "Packaged app reports $productVersion; expected $ExpectedVersion."
+}
+
+$releaseSupabaseUrl = $env:SUPABASE_URL
+$releaseSupabaseAnonKey = $env:SUPABASE_ANON_KEY
+$releaseAuthWebUrl = $env:AUTH_WEB_URL
+if ($releaseSupabaseUrl.TrimEnd('/') -ne "https://aidictation.com" -or
+    $releaseAuthWebUrl.TrimEnd('/') -ne "https://aidictation.com/auth") {
+    throw "Windows release endpoints must both use aidictation.com."
+}
+
+try {
+    $env:SUPABASE_URL = $null
+    $env:SUPABASE_ANON_KEY = $null
+    $env:AUTH_WEB_URL = $null
+    $configReportPath = Join-Path $ReportDir "packaged-config.json"
+    $config = Start-PackagedValidation `
+        -Mode "--validate-release-config" `
+        -ReportPath $configReportPath
+    if ($config.version -ne $ExpectedVersion -or
+        $config.auth_web_url.TrimEnd('/') -ne "https://aidictation.com/auth" -or
+        $config.profile_api_origin.TrimEnd('/') -ne "https://aidictation.com" -or
+        -not $config.auth_backends_agree) {
+        throw "The packaged app did not retain the release version and account-service configuration."
+    }
+} finally {
+    $env:SUPABASE_URL = $releaseSupabaseUrl
+    $env:SUPABASE_ANON_KEY = $releaseSupabaseAnonKey
+    $env:AUTH_WEB_URL = $releaseAuthWebUrl
+}
+
+$testEmail = $env:AIDICTATION_RELEASE_TEST_EMAIL
+$testPassword = $env:AIDICTATION_RELEASE_TEST_PASSWORD
+if (-not $testEmail -or -not $testPassword) {
+    throw "Authenticated browser release-test credentials are required."
+}
+
+$sessionTokens = Get-BrowserSessionTokens -Email $testEmail -Password $testPassword
+try {
+    $env:SUPABASE_URL = $null
+    $env:SUPABASE_ANON_KEY = $null
+    $env:AUTH_WEB_URL = $null
+    $env:AIDICTATION_RELEASE_ACCESS_TOKEN = $sessionTokens.access_token
+    $env:AIDICTATION_RELEASE_REFRESH_TOKEN = $sessionTokens.refresh_token
+    $env:AIDICTATION_RELEASE_EXPECTED_TIER = ""
+    $liveReportPath = Join-Path $ReportDir "live-account.json"
+    $live = Start-PackagedValidation `
+        -Mode "--validate-release-auth" `
+        -ReportPath $liveReportPath
+    if ($live.auth_host -ne "aidictation.com" -or
+        $live.profile_api_host -ne "aidictation.com" -or
+        -not $live.profile_record_loaded -or
+        $live.tier -notin @("Free", "Pro", "Lifetime")) {
+        throw "The packaged app did not load the live account, limits, and access tier."
+    }
+    if ($live.tier -eq "Free" -and $live.word_limit -ne 2000) {
+        throw "The packaged app loaded the wrong free account limit."
+    }
+    if ($live.tier -in @("Pro", "Lifetime") -and $live.word_limit -ne [int]::MaxValue) {
+        throw "The packaged app loaded a finite paid account limit."
+    }
+    $protocolCommand = (Get-Item `
+        -Path "Registry::HKEY_CURRENT_USER\Software\Classes\aidictation\shell\open\command").GetValue("")
+    if (-not $protocolCommand -or -not $protocolCommand.Contains((Get-Item $AppPath).FullName)) {
+        throw "The packaged app did not register its browser callback to the installed executable."
+    }
+    Write-Host "Live packaged account validated: tier=$($live.tier), monthly_words=$($live.monthly_words), word_limit=$($live.word_limit)"
+} finally {
+    $env:AIDICTATION_RELEASE_ACCESS_TOKEN = $null
+    $env:AIDICTATION_RELEASE_REFRESH_TOKEN = $null
+    $env:AIDICTATION_RELEASE_EXPECTED_TIER = $null
+    $env:SUPABASE_URL = $releaseSupabaseUrl
+    $env:SUPABASE_ANON_KEY = $releaseSupabaseAnonKey
+    $env:AUTH_WEB_URL = $releaseAuthWebUrl
+}
+
+$stubPort = 18765
+$stubJob = Start-LifetimeStub -Port $stubPort
+try {
+    Start-Sleep -Milliseconds 800
+    $header = ConvertTo-Base64Url -Value '{"alg":"none","typ":"JWT"}'
+    $expiresAt = [DateTimeOffset]::UtcNow.AddHours(1).ToUnixTimeSeconds()
+    $payload = ConvertTo-Base64Url -Value ("{\"exp\":$expiresAt}")
+    $env:SUPABASE_URL = "http://127.0.0.1:$stubPort"
+    $env:SUPABASE_ANON_KEY = "release-validation"
+    $env:AUTH_WEB_URL = "http://127.0.0.1:$stubPort/auth"
+    $env:AIDICTATION_RELEASE_ACCESS_TOKEN = "$header.$payload.release-validation"
+    $env:AIDICTATION_RELEASE_REFRESH_TOKEN = "release-validation"
+    $env:AIDICTATION_RELEASE_EXPECTED_TIER = "Lifetime"
+    $lifetimeReportPath = Join-Path $ReportDir "lifetime-account.json"
+    $lifetime = Start-PackagedValidation `
+        -Mode "--validate-release-auth" `
+        -ReportPath $lifetimeReportPath
+    if ($lifetime.tier -ne "Lifetime" -or
+        -not $lifetime.profile_record_loaded -or
+        $lifetime.word_limit -ne [int]::MaxValue -or
+        $lifetime.words_remaining -ne [int]::MaxValue -or
+        $lifetime.has_reached_limit) {
+        throw "The packaged app did not preserve lifetime access and unlimited limits."
+    }
+    Write-Host "Lifetime packaged account validated: tier=$($lifetime.tier), word_limit=unlimited"
+} finally {
+    $env:AIDICTATION_RELEASE_ACCESS_TOKEN = $null
+    $env:AIDICTATION_RELEASE_REFRESH_TOKEN = $null
+    $env:AIDICTATION_RELEASE_EXPECTED_TIER = $null
+    $env:SUPABASE_URL = $releaseSupabaseUrl
+    $env:SUPABASE_ANON_KEY = $releaseSupabaseAnonKey
+    $env:AUTH_WEB_URL = $releaseAuthWebUrl
+    if ($stubJob) {
+        Stop-Job -Job $stubJob -ErrorAction SilentlyContinue
+        Remove-Job -Job $stubJob -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "PASS: published-path browser sign-in, packaged profile/limits, and lifetime access validated"


### PR DESCRIPTION
Fixes the Windows packaged-account configuration and version mismatch, then prevents customer-visible publication until the exact installer passes release validation.

Release gates cover:
- canonical browser/profile account service
- public browser sign-in and packaged profile/limit loading
- lifetime entitlement mapping
- installer/app version consistency
- SHA-256 integrity and public download selection

The Windows release is staged as a draft and becomes public only after all gates pass.