### PR TITLE
Gate macOS releases on the published account flow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -259,7 +259,8 @@ jobs:
           scripts/validate_macos_universal_app.sh "$APP"
           python3 scripts/validate_release_transcription_config.py \
             --secrets "$APP/Contents/Resources/Secrets.plist" \
-            --require-auth
+            --require-auth \
+            --require-lifetime
           swiftc \
             Whishpermate/Whispermate/Services/TextInsertionFormatter.swift \
             scripts/validate_text_insertion_formatter.swift \
@@ -283,6 +284,21 @@ jobs:
             --wait
           xcrun stapler staple /tmp/AIDictation-export/AIDictation.app
           rm /tmp/AIDictation-notarize.zip
+
+      - name: Install live browser verifier
+        run: |
+          npm install --prefix /tmp/aidictation-release-browser playwright@1.55.0
+          /tmp/aidictation-release-browser/node_modules/.bin/playwright install chromium
+          cp scripts/capture_release_auth_callback.mjs /tmp/aidictation-release-browser/
+
+      - name: Verify release app browser sign-in and lifetime access
+        env:
+          AIDICTATION_RELEASE_TEST_EMAIL: ${{ secrets.AIDICTATION_RELEASE_TEST_EMAIL }}
+          AIDICTATION_RELEASE_TEST_PASSWORD: ${{ secrets.AIDICTATION_RELEASE_TEST_PASSWORD }}
+        run: |
+          bash scripts/verify_macos_release_auth.sh \
+            /tmp/AIDictation-export/AIDictation.app \
+            "${{ steps.version.outputs.version }}"
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -342,6 +358,73 @@ jobs:
               --generate-notes \
               --repo "${{ github.repository }}"
           fi
+
+      - name: Verify public release asset
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          LOCAL_DMG="/tmp/AIDictation-v${VERSION}.dmg"
+          PUBLIC_DMG="/tmp/AIDictation-v${VERSION}-public.dmg"
+          PUBLIC_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/AIDictation-v${VERSION}.dmg"
+
+          for attempt in {1..12}; do
+            if curl --fail --location --silent --show-error "$PUBLIC_URL" --output "$PUBLIC_DMG"; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "Published DMG did not become available at $PUBLIC_URL." >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
+          local_sha="$(shasum -a 256 "$LOCAL_DMG" | awk '{print $1}')"
+          public_sha="$(shasum -a 256 "$PUBLIC_DMG" | awk '{print $1}')"
+          if [ "$local_sha" != "$public_sha" ]; then
+            echo "Published DMG checksum does not match the notarized release artifact." >&2
+            exit 1
+          fi
+
+          xcrun stapler validate "$PUBLIC_DMG"
+          hdiutil verify "$PUBLIC_DMG"
+
+          MOUNT_POINT="/tmp/AIDictation-v${VERSION}-mount"
+          PUBLISHED_APP="/tmp/AIDictation-published.app"
+          mkdir -p "$MOUNT_POINT"
+          cleanup_mount() {
+            hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+          }
+          trap cleanup_mount EXIT
+          hdiutil attach -nobrowse -readonly -mountpoint "$MOUNT_POINT" "$PUBLIC_DMG"
+          ditto "$MOUNT_POINT/AIDictation.app" "$PUBLISHED_APP"
+          cleanup_mount
+          trap - EXIT
+
+          codesign --verify --deep --strict --verbose=2 "$PUBLISHED_APP"
+          spctl --assess --type execute --verbose=4 "$PUBLISHED_APP"
+          scripts/validate_macos_universal_app.sh "$PUBLISHED_APP"
+
+          INFO_PLIST="$PUBLISHED_APP/Contents/Info.plist"
+          packaged_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+          packaged_build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+          callback_scheme="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleURLTypes:0:CFBundleURLSchemes:0' "$INFO_PLIST")"
+          if [ "$packaged_version" != "$VERSION" ] || [ "$packaged_build" != "${{ steps.version.outputs.build }}" ]; then
+            echo "Published app is $packaged_version ($packaged_build), expected $VERSION (${{ steps.version.outputs.build }})." >&2
+            exit 1
+          fi
+          if [ "$callback_scheme" != "aidictation" ]; then
+            echo "Published app does not register the aidictation browser callback scheme." >&2
+            exit 1
+          fi
+          echo "Verified published AIDictation v${VERSION} asset with SHA-256 ${public_sha}."
+
+      - name: Verify published browser sign-in and lifetime access
+        env:
+          AIDICTATION_RELEASE_TEST_EMAIL: ${{ secrets.AIDICTATION_RELEASE_TEST_EMAIL }}
+          AIDICTATION_RELEASE_TEST_PASSWORD: ${{ secrets.AIDICTATION_RELEASE_TEST_PASSWORD }}
+        run: |
+          bash scripts/verify_macos_release_auth.sh \
+            /tmp/AIDictation-published.app \
+            "${{ steps.version.outputs.version }}"
 
       - name: Update appcast
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,6 +1,12 @@
 name: Release macOS
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semver to validate without publishing (for example, 0.0.98)
+        required: true
+        type: string
   push:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
@@ -21,17 +27,34 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Verify release commit is on main
+        env:
+          PREFLIGHT_VERSION: ${{ inputs.version }}
         run: |
           actual_sha="$(git rev-parse HEAD)"
-          tag_sha="$(git rev-list -n 1 "refs/tags/$GITHUB_REF_NAME")"
-          if [ "$actual_sha" != "$GITHUB_SHA" ] || [ "$tag_sha" != "$GITHUB_SHA" ]; then
-            echo "Release checkout ($actual_sha) or tag ($tag_sha) does not match event commit $GITHUB_SHA." >&2
+          if [ "$actual_sha" != "$GITHUB_SHA" ]; then
+            echo "Release checkout $actual_sha does not match event commit $GITHUB_SHA." >&2
             exit 1
           fi
           git fetch origin main --prune
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            tag_sha="$(git rev-list -n 1 "refs/tags/$GITHUB_REF_NAME")"
+            if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+              echo "Release tag $GITHUB_REF_NAME does not match event commit $GITHUB_SHA." >&2
+              exit 1
+            fi
+          else
+            if [[ ! "$PREFLIGHT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Preflight version must match <major>.<minor>.<patch>; got $PREFLIGHT_VERSION." >&2
+              exit 1
+            fi
+            main_sha="$(git rev-parse origin/main)"
+            if [ "$GITHUB_SHA" != "$main_sha" ]; then
+              echo "Preflight must run from current origin/main ($main_sha), got $GITHUB_SHA." >&2
+              exit 1
+            fi
+          fi
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "Release tag ${GITHUB_REF_NAME} is not based on origin/main." >&2
-            echo "Merge the release commit to main before tagging it." >&2
+            echo "Release source $GITHUB_SHA is not based on origin/main." >&2
             exit 1
           fi
 
@@ -50,6 +73,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Verify tagged source checkout
+        if: github.event_name == 'push'
         run: |
           actual_sha="$(git rev-parse HEAD)"
           tag_sha="$(git rev-list -n 1 "refs/tags/$GITHUB_REF_NAME")"
@@ -60,16 +84,26 @@ jobs:
 
       - name: Extract version info
         id: version
+        env:
+          PREFLIGHT_VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            echo "Release tags must match v<major>.<minor>.<patch>; got $GITHUB_REF_NAME." >&2
-            exit 1
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            if [[ ! "$GITHUB_REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              echo "Release tags must match v<major>.<minor>.<patch>; got $GITHUB_REF_NAME." >&2
+              exit 1
+            fi
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            if [[ ! "$PREFLIGHT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Preflight version must match <major>.<minor>.<patch>; got $PREFLIGHT_VERSION." >&2
+              exit 1
+            fi
+            VERSION="$PREFLIGHT_VERSION"
           fi
-          TAG="${BASH_REMATCH[1]}"
-          BUILD="${TAG##*.}"
-          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          BUILD="${VERSION##*.}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD" >> "$GITHUB_OUTPUT"
-          echo "tag=v$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Cache SPM packages
         uses: actions/cache@v4
@@ -301,9 +335,11 @@ jobs:
             "${{ steps.version.outputs.version }}"
 
       - name: Install create-dmg
+        if: github.event_name == 'push'
         run: brew install create-dmg
 
       - name: Create DMG
+        if: github.event_name == 'push'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           create-dmg \
@@ -319,6 +355,7 @@ jobs:
             /tmp/AIDictation-export/AIDictation.app
 
       - name: Notarize and staple DMG
+        if: github.event_name == 'push'
         env:
           NOTARIZE_APPLE_ID: ${{ secrets.NOTARIZE_APPLE_ID }}
           NOTARIZE_PASSWORD: ${{ secrets.NOTARIZE_PASSWORD }}
@@ -335,6 +372,7 @@ jobs:
           hdiutil verify /tmp/AIDictation-v${VERSION}.dmg
 
       - name: Create GitHub Release
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -360,6 +398,7 @@ jobs:
           fi
 
       - name: Verify public release asset
+        if: github.event_name == 'push'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           LOCAL_DMG="/tmp/AIDictation-v${VERSION}.dmg"
@@ -418,6 +457,7 @@ jobs:
           echo "Verified published AIDictation v${VERSION} asset with SHA-256 ${public_sha}."
 
       - name: Verify published browser sign-in and lifetime access
+        if: github.event_name == 'push'
         env:
           AIDICTATION_RELEASE_TEST_EMAIL: ${{ secrets.AIDICTATION_RELEASE_TEST_EMAIL }}
           AIDICTATION_RELEASE_TEST_PASSWORD: ${{ secrets.AIDICTATION_RELEASE_TEST_PASSWORD }}
@@ -427,6 +467,7 @@ jobs:
             "${{ steps.version.outputs.version }}"
 
       - name: Update appcast
+        if: github.event_name == 'push'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BUILD="${{ steps.version.outputs.build }}"
@@ -493,6 +534,7 @@ jobs:
           fi
 
       - name: Commit appcast to main
+        if: github.event_name == 'push'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           cp appcast.xml /tmp/appcast.xml

--- a/Whishpermate/Whispermate/WhispermateApp.swift
+++ b/Whishpermate/Whispermate/WhispermateApp.swift
@@ -77,6 +77,53 @@ private enum MainSettingsWindowOpenState {
     }
 }
 
+/// Emits a sanitized account-state snapshot only when the release workflow
+/// explicitly enables it. This lets the hosted gate observe the signed app
+/// after Launch Services delivers the real browser callback without exposing
+/// account identifiers or auth tokens.
+private final class ReleaseAuthVerificationReporter {
+    static let shared = ReleaseAuthVerificationReporter()
+
+    private var outputURL: URL?
+
+    private init() {}
+
+    func startIfRequested() {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["AIDICTATION_RELEASE_AUTH_SMOKE"] == "1",
+              let outputPath = environment["AIDICTATION_RELEASE_AUTH_RESULT"],
+              !outputPath.isEmpty
+        else {
+            return
+        }
+
+        outputURL = URL(fileURLWithPath: outputPath)
+    }
+
+    func report(_ authManager: AuthManager) {
+        guard let outputURL else { return }
+
+        let user = authManager.currentUser
+        let payload: [String: Any] = [
+            "version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+            "authenticated": authManager.isAuthenticated,
+            "profile_loaded": user != nil,
+            "subscription_status": user?.subscriptionStatus ?? "missing",
+            "subscription_tier": user?.subscriptionTier.rawValue ?? "missing",
+            "has_reached_limit": user?.hasReachedLimit ?? true,
+            "words_remaining_unlimited": user?.effectiveWordLimit == Int.max,
+            "auth_error_present": authManager.error != nil,
+        ]
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            try data.write(to: outputURL, options: .atomic)
+        } catch {
+            DebugLog.error("Could not write the release authentication result", context: "ReleaseVerification")
+        }
+    }
+}
+
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var statusBarManager = StatusBarManager()
     var mainWindow: NSWindow?
@@ -90,6 +137,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private let terminationReplyGuard = MacTerminationReplyGuard()
 
     func applicationDidFinishLaunching(_: Notification) {
+        ReleaseAuthVerificationReporter.shared.startIfRequested()
         SentryTelemetry.start()
         DockIconManager.shared.applySavedPreference()
         statusBarManager.setupMenuBar()
@@ -211,6 +259,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             DebugLog.info("Processing auth callback...", context: "AppDelegate")
             Task {
                 await authManager.handleAuthCallback(url: url)
+                await MainActor.run {
+                    ReleaseAuthVerificationReporter.shared.report(authManager)
+                }
             }
         }
         // Handle payment success callback

--- a/scripts/capture_release_auth_callback.mjs
+++ b/scripts/capture_release_auth_callback.mjs
@@ -1,0 +1,67 @@
+import { writeFile } from "node:fs/promises";
+import { chromium } from "playwright";
+
+const email = process.env.AIDICTATION_RELEASE_TEST_EMAIL?.trim();
+const password = process.env.AIDICTATION_RELEASE_TEST_PASSWORD?.trim();
+const outputPath = process.env.AIDICTATION_RELEASE_AUTH_CALLBACK_PATH?.trim();
+
+if (!email || !password || !outputPath) {
+  throw new Error(
+    "AIDICTATION_RELEASE_TEST_EMAIL, AIDICTATION_RELEASE_TEST_PASSWORD, and " +
+      "AIDICTATION_RELEASE_AUTH_CALLBACK_PATH are required",
+  );
+}
+
+const callbackScheme = "aidictation://auth-callback";
+const authURL = new URL("https://aidictation.com/auth");
+authURL.searchParams.set("redirect_to", callbackScheme);
+authURL.searchParams.set("as_web_authentication_session", "1");
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext();
+const page = await context.newPage();
+
+let resolveCallback;
+let rejectCallback;
+const callbackPromise = new Promise((resolve, reject) => {
+  resolveCallback = resolve;
+  rejectCallback = reject;
+});
+
+const timeout = setTimeout(() => {
+  rejectCallback(new Error("Live browser sign-in did not produce an app callback"));
+}, 45_000);
+
+const captureCallback = (candidate) => {
+  if (!candidate.startsWith(callbackScheme)) return;
+  resolveCallback(candidate);
+};
+
+page.on("request", (request) => captureCallback(request.url()));
+page.on("framenavigated", (frame) => captureCallback(frame.url()));
+await page.route("aidictation://**", async (route) => {
+  captureCallback(route.request().url());
+  await route.abort();
+});
+
+try {
+  await page.goto(authURL.toString(), { waitUntil: "domcontentloaded" });
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(password);
+  await page
+    .getByRole("button", { name: "Sign In", exact: true })
+    .click({ noWaitAfter: true });
+
+  const callbackURL = await callbackPromise;
+  const parsed = new URL(callbackURL);
+  const callbackParams = new URLSearchParams(parsed.hash.replace(/^#/, ""));
+  if (!callbackParams.get("access_token") || !callbackParams.get("refresh_token")) {
+    throw new Error("Live browser callback did not contain a complete auth session");
+  }
+
+  await writeFile(outputPath, callbackURL, { encoding: "utf8", mode: 0o600 });
+  console.log("Live browser sign-in produced an AIDictation app callback.");
+} finally {
+  clearTimeout(timeout);
+  await browser.close();
+}

--- a/scripts/validate_release_transcription_config.py
+++ b/scripts/validate_release_transcription_config.py
@@ -213,7 +213,14 @@ def transcribe(endpoint: str, api_key: str, model: str, audio: Path, label: str)
     return text
 
 
-def validate_authenticated_user(config: dict[str, Any], endpoint: str, api_key: str, model: str, audio: Path) -> None:
+def validate_authenticated_user(
+    config: dict[str, Any],
+    endpoint: str,
+    api_key: str,
+    model: str,
+    audio: Path,
+    require_lifetime: bool,
+) -> None:
     email = os.environ.get("AIDICTATION_RELEASE_TEST_EMAIL", "").strip()
     password = os.environ.get("AIDICTATION_RELEASE_TEST_PASSWORD", "").strip()
     if not email or not password:
@@ -234,14 +241,13 @@ def validate_authenticated_user(config: dict[str, Any], endpoint: str, api_key: 
     if not access_token or not user_id:
         fail("Supabase test login did not return an access token and user id")
 
-    # Query the way the shipped app does. Foundation's UUID.uuidString is
-    # upper-cased, so filtering with the server's lower-cased id would pass here
-    # while every real macOS/iOS client got an empty result and fell back to the
-    # free tier.
+    # Query the way the corrected Apple clients do. Foundation's UUID.uuidString
+    # is upper-cased, while the account backend stores ids as lower-case text.
+    # The release client canonicalizes the value before querying.
     query = parse.urlencode(
         {
             "select": "user_id,email,monthly_word_count,subscription_status",
-            "user_id": f"eq.{user_id.upper()}",
+            "user_id": f"eq.{user_id.lower()}",
         }
     )
     profile_url = f"{supabase_url}/rest/v1/profiles?{query}"
@@ -253,14 +259,16 @@ def validate_authenticated_user(config: dict[str, Any], endpoint: str, api_key: 
         },
     )
     if not isinstance(profiles, list) or not profiles:
-        fail(
-            "authenticated release test user has no profile row for the "
-            "upper-cased user id the Apple clients send"
-        )
+        fail("authenticated release test user has no profile row for the canonical lower-case user id")
 
     profile = profiles[0]
     monthly_count = int(profile.get("monthly_word_count") or 0)
     subscription_status = str(profile.get("subscription_status") or "free")
+    if require_lifetime and subscription_status != "lifetime":
+        fail(
+            "authenticated release test user must have lifetime access for the "
+            f"release entitlement gate, got {subscription_status!r}"
+        )
     if subscription_status not in {"pro", "lifetime"} and monthly_count >= 10_000:
         fail("authenticated release test user is at or above the free word limit")
 
@@ -273,7 +281,10 @@ def main() -> None:
     parser.add_argument("--secrets", required=True, type=Path)
     parser.add_argument("--config-only", action="store_true")
     parser.add_argument("--require-auth", action="store_true")
+    parser.add_argument("--require-lifetime", action="store_true")
     args = parser.parse_args()
+    if args.require_lifetime and not args.require_auth:
+        fail("--require-lifetime requires --require-auth")
 
     config = load_plist(args.secrets)
     endpoint = required_string(config, "CustomTranscriptionEndpoint")
@@ -295,7 +306,14 @@ def main() -> None:
         generate_speech_sample(audio)
         transcribe(endpoint, api_key, model, audio, "non-auth cloud")
         if args.require_auth:
-            validate_authenticated_user(config, endpoint, api_key, model, audio)
+            validate_authenticated_user(
+                config,
+                endpoint,
+                api_key,
+                model,
+                audio,
+                require_lifetime=args.require_lifetime,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_macos_release_auth.sh
+++ b/scripts/verify_macos_release_auth.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:-}"
+EXPECTED_VERSION="${2:-}"
+BROWSER_SCRIPT="${AIDICTATION_RELEASE_AUTH_BROWSER_SCRIPT:-/tmp/aidictation-release-browser/capture_release_auth_callback.mjs}"
+CALLBACK_PATH="${AIDICTATION_RELEASE_AUTH_CALLBACK_PATH:-/tmp/aidictation-release-auth-callback}"
+RESULT_PATH="${AIDICTATION_RELEASE_AUTH_RESULT_PATH:-/tmp/aidictation-release-auth-result.json}"
+
+if [[ -z "$APP_PATH" || ! -d "$APP_PATH" ]]; then
+  echo "A signed AIDictation.app path is required." >&2
+  exit 1
+fi
+if [[ -z "$EXPECTED_VERSION" ]]; then
+  echo "The expected release version is required." >&2
+  exit 1
+fi
+if [[ ! -f "$BROWSER_SCRIPT" ]]; then
+  echo "The live browser verifier is not installed at $BROWSER_SCRIPT." >&2
+  exit 1
+fi
+
+cleanup() {
+  launchctl unsetenv AIDICTATION_RELEASE_AUTH_SMOKE >/dev/null 2>&1 || true
+  launchctl unsetenv AIDICTATION_RELEASE_AUTH_RESULT >/dev/null 2>&1 || true
+  pkill -x AIDictation >/dev/null 2>&1 || true
+  rm -f "$CALLBACK_PATH" "$RESULT_PATH"
+}
+trap cleanup EXIT
+
+export AIDICTATION_RELEASE_AUTH_CALLBACK_PATH="$CALLBACK_PATH"
+node "$BROWSER_SCRIPT"
+test -s "$CALLBACK_PATH"
+
+rm -f "$RESULT_PATH"
+launchctl setenv AIDICTATION_RELEASE_AUTH_SMOKE 1
+launchctl setenv AIDICTATION_RELEASE_AUTH_RESULT "$RESULT_PATH"
+open -na "$APP_PATH"
+
+for attempt in {1..20}; do
+  if pgrep -x AIDictation >/dev/null; then
+    break
+  fi
+  if [[ "$attempt" -eq 20 ]]; then
+    echo "AIDictation did not launch for release authentication verification." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+CALLBACK_URL="$(<"$CALLBACK_PATH")"
+open "$CALLBACK_URL"
+unset CALLBACK_URL
+rm -f "$CALLBACK_PATH"
+
+for attempt in {1..60}; do
+  if [[ -s "$RESULT_PATH" ]]; then
+    break
+  fi
+  if [[ "$attempt" -eq 60 ]]; then
+    echo "AIDictation did not report account state after the live browser callback." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+python3 - "$RESULT_PATH" "$EXPECTED_VERSION" <<'PYEOF'
+import json
+import sys
+
+result_path, expected_version = sys.argv[1:]
+with open(result_path, encoding="utf-8") as result_file:
+    result = json.load(result_file)
+
+expected = {
+    "version": expected_version,
+    "authenticated": True,
+    "profile_loaded": True,
+    "subscription_status": "lifetime",
+    "subscription_tier": "lifetime",
+    "has_reached_limit": False,
+    "words_remaining_unlimited": True,
+    "auth_error_present": False,
+}
+mismatches = {
+    key: {"expected": value, "actual": result.get(key)}
+    for key, value in expected.items()
+    if result.get(key) != value
+}
+if mismatches:
+    raise SystemExit(f"release app account verification failed: {mismatches}")
+print(
+    "Live browser callback loaded the lifetime profile with unlimited access "
+    f"in AIDictation v{expected_version}."
+)
+PYEOF


### PR DESCRIPTION
Adds a non-publishing macOS preflight plus release gates for the live browser callback, profile loading, lifetime entitlement, unlimited limits, public DMG identity, version, signing, and notarization. Customer notifications remain blocked unless these gates pass.