### PR TITLE
Run the Windows release validator before tagging

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -106,6 +106,23 @@ jobs:
         -p:IncludeNativeLibrariesForSelfExtract=true
         -p:EnableCompressionInSingleFile=true
 
+    - name: Validate release script and packaged configuration
+      shell: pwsh
+      env:
+        SUPABASE_URL: https://aidictation.com
+        SUPABASE_ANON_KEY: public-anon-key
+        AUTH_WEB_URL: https://aidictation.com/auth
+      run: |
+        $appPath = Join-Path "${{ env.PUBLISH_DIR }}" "AIDictation.exe"
+        $version = [regex]::Match(
+          (Get-Item $appPath).VersionInfo.ProductVersion,
+          '^\d+\.\d+\.\d+'
+        ).Value
+        AIDictation.Windows/scripts/validate-release-auth.ps1 `
+          -AppPath $appPath `
+          -ExpectedVersion $version `
+          -StructureOnly
+
     - name: Smoke test published app
       shell: pwsh
       run: |

--- a/AIDictation.Windows/scripts/validate-release-auth.ps1
+++ b/AIDictation.Windows/scripts/validate-release-auth.ps1
@@ -3,7 +3,8 @@ param(
     [string]$AppPath,
     [Parameter(Mandatory = $true)]
     [string]$ExpectedVersion,
-    [string]$ReportDir = ""
+    [string]$ReportDir = "",
+    [switch]$StructureOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -285,6 +286,11 @@ try {
     $env:AUTH_WEB_URL = $releaseAuthWebUrl
 }
 
+if ($StructureOnly) {
+    Write-Host "PASS: packaged version and account-service configuration validated"
+    return
+}
+
 $testEmail = $env:AIDICTATION_RELEASE_TEST_EMAIL
 $testPassword = $env:AIDICTATION_RELEASE_TEST_PASSWORD
 if (-not $testEmail -or -not $testPassword) {
@@ -336,7 +342,8 @@ try {
     Start-Sleep -Milliseconds 800
     $header = ConvertTo-Base64Url -Value '{"alg":"none","typ":"JWT"}'
     $expiresAt = [DateTimeOffset]::UtcNow.AddHours(1).ToUnixTimeSeconds()
-    $payload = ConvertTo-Base64Url -Value ("{\"exp\":$expiresAt}")
+    $payloadJson = @{ exp = $expiresAt } | ConvertTo-Json -Compress
+    $payload = ConvertTo-Base64Url -Value $payloadJson
     $env:SUPABASE_URL = "http://127.0.0.1:$stubPort"
     $env:SUPABASE_ANON_KEY = "release-validation"
     $env:AUTH_WEB_URL = "http://127.0.0.1:$stubPort/auth"


### PR DESCRIPTION
Fixes the exact PowerShell parser failure caught by the Windows 0.0.6 release gate.

Also runs the full script parser plus non-secret packaged version/account-service configuration checks in normal Windows PR CI, so structural validator errors cannot wait until a release tag.

No release artifacts were created by the failed 0.0.6 run. A new release tag must wait until the required authenticated test-account secrets are available.