### PR TITLE
Use protected environment for macOS releases

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -61,6 +61,7 @@ jobs:
   release:
     needs: provenance
     runs-on: macos-26
+    environment: release
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- connect the macOS release job to the established protected `release` environment
- restore access to the migrated signing, notarization, product configuration, and release-test secrets

## Verification
- workflow YAML parsed successfully
- `git diff --check` passed
- the non-publishing 0.0.98 preflight reproduced the missing-environment failure before this change (run 30754524965); no tag or artifact was published

## Release safety
This change does not publish a release. After merge, the workflow-dispatch preflight must pass signing, notarization, browser sign-in, account-profile loading, and lifetime-access verification before any tag is created.
