### PR TITLE
Restore modifier hotkeys and refresh History rows

### DIFF
--- a/.github/workflows/macos-ui-contracts.yml
+++ b/.github/workflows/macos-ui-contracts.yml
@@ -1,0 +1,29 @@
+name: macOS UI Contracts
+
+on:
+  pull_request:
+    paths:
+      - 'Whishpermate/Whispermate/Services/HotkeyManager.swift'
+      - 'Whishpermate/Whispermate/Views/HotkeyRecorderView.swift'
+      - 'scripts/validate_macos_hotkey_options.swift'
+      - '.github/workflows/macos-ui-contracts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'Whishpermate/Whispermate/Services/HotkeyManager.swift'
+      - 'Whishpermate/Whispermate/Views/HotkeyRecorderView.swift'
+      - 'scripts/validate_macos_hotkey_options.swift'
+      - '.github/workflows/macos-ui-contracts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: macos-15
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate modifier-only hotkey options
+        run: swift scripts/validate_macos_hotkey_options.swift

--- a/.github/workflows/macos-ui-contracts.yml
+++ b/.github/workflows/macos-ui-contracts.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     paths:
       - 'Whishpermate/Whispermate/Services/HotkeyManager.swift'
+      - 'Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift'
+      - 'Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift'
       - 'Whishpermate/Whispermate/Views/HotkeyRecorderView.swift'
+      - 'scripts/validate_macos_history_row_refresh.swift'
       - 'scripts/validate_macos_hotkey_options.swift'
       - '.github/workflows/macos-ui-contracts.yml'
   push:
@@ -12,7 +15,10 @@ on:
       - main
     paths:
       - 'Whishpermate/Whispermate/Services/HotkeyManager.swift'
+      - 'Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift'
+      - 'Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift'
       - 'Whishpermate/Whispermate/Views/HotkeyRecorderView.swift'
+      - 'scripts/validate_macos_history_row_refresh.swift'
       - 'scripts/validate_macos_hotkey_options.swift'
       - '.github/workflows/macos-ui-contracts.yml'
 
@@ -27,3 +33,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate modifier-only hotkey options
         run: swift scripts/validate_macos_hotkey_options.swift
+      - name: Validate History presentation refresh
+        run: |
+          swiftc \
+            Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift \
+            scripts/validate_macos_history_row_refresh.swift \
+            -o "$RUNNER_TEMP/validate_macos_history_row_refresh"
+          "$RUNNER_TEMP/validate_macos_history_row_refresh"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -173,6 +173,11 @@ jobs:
       - name: Validate audio recovery contracts
         run: bash scripts/validate_apple_audio_recovery.sh
 
+      - name: Validate macOS UI contracts
+        run: |
+          swift -module-cache-path /tmp/aidictation-ui-contract-module-cache \
+            scripts/validate_macos_hotkey_options.swift
+
       - name: Resolve Swift package dependencies
         run: |
           xcodebuild -resolvePackageDependencies \

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -177,6 +177,12 @@ jobs:
         run: |
           swift -module-cache-path /tmp/aidictation-ui-contract-module-cache \
             scripts/validate_macos_hotkey_options.swift
+          swiftc \
+            -module-cache-path /tmp/aidictation-ui-contract-module-cache \
+            Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift \
+            scripts/validate_macos_history_row_refresh.swift \
+            -o /tmp/validate_macos_history_row_refresh
+          /tmp/validate_macos_history_row_refresh
 
       - name: Resolve Swift package dependencies
         run: |

--- a/Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift
+++ b/Whishpermate/Whispermate/Models/HistoryPresentationIdentity.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Values that change the History row or detail content for one recording.
+/// Keeping this separate from `Recording` identity preserves list selection
+/// while still refreshing terminal status, transcript, and failure changes.
+struct HistoryPresentationIdentity: Hashable {
+    let recordingID: UUID
+    let status: String
+    let transcription: String?
+    let errorMessage: String?
+}

--- a/Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift
+++ b/Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift
@@ -92,7 +92,7 @@ private struct HistoryDetailPane: View {
                     leadingPadding: 16,
                     onDelete: deleteRecording
                 )
-                .id("\(recording.id)-\(recording.status)-\(recording.transcription?.hashValue ?? 0)")
+                .id(recording.historyPresentationIdentity)
             } else {
                 VStack(spacing: 12) {
                     Image(systemName: "mic.circle")
@@ -205,6 +205,7 @@ struct HistorySidebarView: View {
         List(selection: $selectedRecording) {
             ForEach(filteredRecordings) { recording in
                 HistorySidebarRow(recording: recording)
+                    .id(recording.historyPresentationIdentity)
                     .tag(recording)
             }
         }
@@ -287,6 +288,17 @@ struct HistorySidebarView: View {
                 selectedRecording = nextSelection
             }
         }
+    }
+}
+
+private extension Recording {
+    var historyPresentationIdentity: HistoryPresentationIdentity {
+        HistoryPresentationIdentity(
+            recordingID: id,
+            status: status.rawValue,
+            transcription: transcription,
+            errorMessage: errorMessage
+        )
     }
 }
 

--- a/Whishpermate/Whispermate/Views/HotkeyRecorderView.swift
+++ b/Whishpermate/Whispermate/Views/HotkeyRecorderView.swift
@@ -19,6 +19,9 @@ enum HotkeyOption: String, CaseIterable, Identifiable {
     case optionSpace = "opt_space"
     case shiftF9 = "shift_f9"
     case optionF7 = "opt_f7"
+    case leftCommand = "left_cmd"
+    case leftOption = "left_opt"
+    case leftShift = "left_shift"
     case leftControl = "left_ctrl"
     case rightCommand = "right_cmd"
     case rightOption = "right_opt"
@@ -61,6 +64,9 @@ enum HotkeyOption: String, CaseIterable, Identifiable {
         case .optionSpace: return "⌥ + Space"
         case .shiftF9: return "⇧ + F9"
         case .optionF7: return "⌥ + F7"
+        case .leftCommand: return "Left ⌘"
+        case .leftOption: return "Left ⌥"
+        case .leftShift: return "Left ⇧"
         case .leftControl: return "Left ⌃"
         case .rightCommand: return "Right ⌘"
         case .rightOption: return "Right ⌥"
@@ -102,6 +108,15 @@ enum HotkeyOption: String, CaseIterable, Identifiable {
         case .optionF7:
             // F7 key code is 98
             return Hotkey(keyCode: 98, modifiers: .option)
+        case .leftCommand:
+            // Left Command key code is 55
+            return Hotkey(keyCode: 55, modifiers: .command)
+        case .leftOption:
+            // Left Option key code is 58
+            return Hotkey(keyCode: 58, modifiers: .option)
+        case .leftShift:
+            // Left Shift key code is 56
+            return Hotkey(keyCode: 56, modifiers: .shift)
         case .leftControl:
             // Left Control key code is 59
             return Hotkey(keyCode: 59, modifiers: .control)
@@ -194,7 +209,16 @@ enum HotkeyOption: String, CaseIterable, Identifiable {
             return .optionF7
         }
 
-        // Check for left Control (keyCode 59)
+        // Check for left-side modifier keys
+        if hotkey.keyCode == 55, hotkey.modifiers.contains(.command) {
+            return .leftCommand
+        }
+        if hotkey.keyCode == 58, hotkey.modifiers.contains(.option) {
+            return .leftOption
+        }
+        if hotkey.keyCode == 56, hotkey.modifiers.contains(.shift) {
+            return .leftShift
+        }
         if hotkey.keyCode == 59, hotkey.modifiers.contains(.control) {
             return .leftControl
         }

--- a/scripts/validate_macos_history_row_refresh.swift
+++ b/scripts/validate_macos_history_row_refresh.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+private enum ValidationFailure: Error, CustomStringConvertible {
+    case assertion(String)
+
+    var description: String {
+        switch self {
+        case let .assertion(message): return message
+        }
+    }
+}
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    guard condition() else {
+        throw ValidationFailure.assertion(message)
+    }
+}
+
+private func identity(
+    id: UUID,
+    status: String,
+    transcription: String? = nil,
+    errorMessage: String? = nil
+) -> HistoryPresentationIdentity {
+    HistoryPresentationIdentity(
+        recordingID: id,
+        status: status,
+        transcription: transcription,
+        errorMessage: errorMessage
+    )
+}
+
+@main
+private enum HistoryRowRefreshValidator {
+    static func main() throws {
+        let recordingID = UUID(uuidString: "9A3ACCC5-F758-4B3F-B5A6-6CFEC8CE7733")!
+        let processing = identity(id: recordingID, status: "processing")
+        let retrying = identity(id: recordingID, status: "retrying", transcription: "Earlier text")
+        let success = identity(id: recordingID, status: "success", transcription: "Finished text")
+        let failed = identity(
+            id: recordingID,
+            status: "failed",
+            errorMessage: "Transcription stopped"
+        )
+        let cancelled = identity(id: recordingID, status: "cancelled")
+
+        try require(processing != success, "processing to success did not refresh the presentation")
+        try require(processing != failed, "processing to failed did not refresh the presentation")
+        try require(processing != cancelled, "processing to cancelled did not refresh the presentation")
+        try require(retrying != success, "retrying to success did not refresh the presentation")
+        try require(
+            success == identity(id: recordingID, status: "success", transcription: "Finished text"),
+            "an unchanged completed row acquired unrelated identity churn"
+        )
+        try require(
+            failed == identity(
+                id: recordingID,
+                status: "failed",
+                errorMessage: "Transcription stopped"
+            ),
+            "an unchanged failed row acquired unrelated identity churn"
+        )
+        try require(
+            success != identity(id: recordingID, status: "success", transcription: "Corrected text"),
+            "a same-status transcript correction did not refresh the presentation"
+        )
+        try require(
+            failed != identity(id: recordingID, status: "failed", errorMessage: "Network unavailable"),
+            "a same-status failure-message correction did not refresh the presentation"
+        )
+        try require(
+            success != identity(id: UUID(), status: "success", transcription: "Finished text"),
+            "different recordings share a presentation identity"
+        )
+
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let historyViewSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift"
+            ),
+            encoding: .utf8
+        )
+        let integrationCount = historyViewSource
+            .components(separatedBy: ".id(recording.historyPresentationIdentity)")
+            .count - 1
+
+        try require(
+            integrationCount == 2,
+            "the deterministic identity must guard both History sidebar and detail content"
+        )
+        try require(
+            !historyViewSource.contains("hashValue"),
+            "History refresh identity must not depend on process-random string hashes"
+        )
+
+        print("macOS History row refresh contracts passed")
+    }
+}

--- a/scripts/validate_macos_hotkey_options.swift
+++ b/scripts/validate_macos_hotkey_options.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+private enum ValidationFailure: Error, CustomStringConvertible {
+    case assertion(String)
+
+    var description: String {
+        switch self {
+        case let .assertion(message): return message
+        }
+    }
+}
+
+private func requireContains(_ source: String, _ fragment: String, _ message: String) throws {
+    guard source.contains(fragment) else {
+        throw ValidationFailure.assertion(message)
+    }
+}
+
+private func run() throws {
+    let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    let pickerSource = try String(
+        contentsOf: root.appendingPathComponent(
+            "Whishpermate/Whispermate/Views/HotkeyRecorderView.swift"
+        ),
+        encoding: .utf8
+    )
+    let managerSource = try String(
+        contentsOf: root.appendingPathComponent(
+            "Whishpermate/Whispermate/Services/HotkeyManager.swift"
+        ),
+        encoding: .utf8
+    )
+
+    try requireContains(
+        pickerSource,
+        "ForEach(HotkeyOption.allCases)",
+        "the hotkey picker no longer exposes every declared option"
+    )
+
+    let leftModifierContracts = [
+        ("leftCommand", "left_cmd", "Left ⌘", 55, "command"),
+        ("leftOption", "left_opt", "Left ⌥", 58, "option"),
+        ("leftShift", "left_shift", "Left ⇧", 56, "shift"),
+    ]
+
+    for (name, rawValue, label, keyCode, modifier) in leftModifierContracts {
+        try requireContains(
+            pickerSource,
+            "case \(name) = \"\(rawValue)\"",
+            "missing picker case for \(label)"
+        )
+        try requireContains(
+            pickerSource,
+            "case .\(name): return \"\(label)\"",
+            "missing user-facing label for \(label)"
+        )
+        try requireContains(
+            pickerSource,
+            "return Hotkey(keyCode: \(keyCode), modifiers: .\(modifier))",
+            "\(label) does not map to the expected macOS keycode"
+        )
+        try requireContains(
+            pickerSource,
+            "if hotkey.keyCode == \(keyCode), hotkey.modifiers.contains(.\(modifier)) {\n            return .\(name)\n        }",
+            "\(label) does not round-trip from a saved hotkey"
+        )
+    }
+
+    try requireContains(
+        managerSource,
+        "let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63, 179]",
+        "the event path does not recognize all left modifier-only keycodes"
+    )
+    try requireContains(
+        managerSource,
+        "(1 << CGEventType.flagsChanged.rawValue)",
+        "the global event tap no longer observes modifier-only key changes"
+    )
+    try requireContains(
+        managerSource,
+        "flagsChangedKeyMatchesHotkey(eventKeyCode: keyCode, hotkey: hotkey)",
+        "modifier-only events are not matched by their physical keycode"
+    )
+    try requireContains(
+        managerSource,
+        "return eventKeyCode == hotkey.keyCode",
+        "left and right modifier keys are no longer distinguished"
+    )
+    try requireContains(
+        managerSource,
+        "let isModifierPressed = isRequiredModifierPressed(for: hotkey, eventModifiers: modifiers)",
+        "modifier press and release state is no longer derived from event flags"
+    )
+    try requireContains(
+        managerSource,
+        "handled = handleModifierFlagsStateChange(isModifierPressed: isModifierPressed, isDictation: true) || handled",
+        "modifier-only dictation no longer reaches the press/release state machine"
+    )
+
+    let existingCombinationContracts = [
+        "return Hotkey(keyCode: 49, modifiers: [.option, .command])",
+        "return Hotkey(keyCode: 49, modifiers: [.control, .command])",
+        "return Hotkey(keyCode: 49, modifiers: [.control, .option])",
+        "return Hotkey(keyCode: 49, modifiers: [.shift, .command])",
+        "return Hotkey(keyCode: 49, modifiers: [.option, .shift])",
+        "return Hotkey(keyCode: 49, modifiers: [.control, .shift])",
+        "return Hotkey(keyCode: 15, modifiers: .option)",
+    ]
+
+    for contract in existingCombinationContracts {
+        try requireContains(
+            pickerSource,
+            contract,
+            "an existing hotkey combination mapping was removed"
+        )
+    }
+
+    let existingCombinationRoundTrips = [
+        ("if hotkey.modifiers == [.option, .command]", "return .optionCommand"),
+        ("if hotkey.modifiers == [.control, .command]", "return .controlCommand"),
+        ("if hotkey.modifiers == [.control, .option]", "return .controlOption"),
+        ("if hotkey.modifiers == [.shift, .command]", "return .shiftCommand"),
+        ("if hotkey.modifiers == [.option, .shift]", "return .optionShift"),
+        ("if hotkey.modifiers == [.control, .shift]", "return .controlShift"),
+    ]
+
+    for (condition, result) in existingCombinationRoundTrips {
+        try requireContains(
+            pickerSource,
+            "\(condition) {\n                \(result)",
+            "an existing hotkey combination no longer round-trips from saved settings"
+        )
+    }
+
+    print("macOS hotkey option contracts passed")
+}
+
+do {
+    try run()
+} catch {
+    fputs("macOS hotkey option validation failed: \(error)\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- restore Left Command, Left Option, and Left Shift choices while preserving saved-setting round trips and existing combinations
- refresh History sidebar and detail content when a recording moves from Processing or Retrying to a terminal result
- replace process-random string hashing with a typed, deterministic presentation identity that also covers same-status transcript and error updates
- run focused UI contracts on pull requests and in the macOS release gate

## Verification
- modifier-only hotkey contract passed
- History presentation-transition contract passed
- full Apple audio recovery contract matrix passed
- unsigned Debug macOS build passed for arm64 and x86_64
- universal-app validator confirmed both architectures in all 11 Mach-O binaries

## Release gate
This change does not tag or publish a release. Customer notification remains blocked until a signed, notarized artifact is published and both reported behaviors pass end-to-end checks in that public build.