### PR TITLE
Preserve macOS release auth callback session

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -336,6 +336,7 @@ jobs:
           npm install --prefix /tmp/aidictation-release-browser playwright@1.55.0
           /tmp/aidictation-release-browser/node_modules/.bin/playwright install chromium
           cp scripts/capture_release_auth_callback.mjs /tmp/aidictation-release-browser/
+          node /tmp/aidictation-release-browser/capture_release_auth_callback.mjs --self-test
 
       - name: Verify release app browser sign-in and lifetime access
         env:

--- a/scripts/capture_release_auth_callback.mjs
+++ b/scripts/capture_release_auth_callback.mjs
@@ -4,8 +4,10 @@ import { chromium } from "playwright";
 const email = process.env.AIDICTATION_RELEASE_TEST_EMAIL?.trim();
 const password = process.env.AIDICTATION_RELEASE_TEST_PASSWORD?.trim();
 const outputPath = process.env.AIDICTATION_RELEASE_AUTH_CALLBACK_PATH?.trim();
+const browserExecutable = process.env.AIDICTATION_RELEASE_AUTH_BROWSER_EXECUTABLE?.trim();
+const isSelfTest = process.argv.includes("--self-test");
 
-if (!email || !password || !outputPath) {
+if (!isSelfTest && (!email || !password || !outputPath)) {
   throw new Error(
     "AIDICTATION_RELEASE_TEST_EMAIL, AIDICTATION_RELEASE_TEST_PASSWORD, and " +
       "AIDICTATION_RELEASE_AUTH_CALLBACK_PATH are required",
@@ -17,9 +19,14 @@ const authURL = new URL("https://aidictation.com/auth");
 authURL.searchParams.set("redirect_to", callbackScheme);
 authURL.searchParams.set("as_web_authentication_session", "1");
 
-const browser = await chromium.launch({ headless: true });
+const browser = await chromium.launch({
+  headless: true,
+  ...(browserExecutable ? { executablePath: browserExecutable } : {}),
+});
 const context = await browser.newContext();
 const page = await context.newPage();
+const cdpSession = await context.newCDPSession(page);
+await cdpSession.send("Page.enable");
 
 let resolveCallback;
 let rejectCallback;
@@ -28,15 +35,32 @@ const callbackPromise = new Promise((resolve, reject) => {
   rejectCallback = reject;
 });
 
-const timeout = setTimeout(() => {
-  rejectCallback(new Error("Live browser sign-in did not produce an app callback"));
-}, 45_000);
+const timeout = setTimeout(
+  () => {
+    rejectCallback(new Error("Live browser sign-in did not produce a complete app callback"));
+  },
+  isSelfTest ? 10_000 : 45_000,
+);
+
+const callbackParams = (candidate) => {
+  const parsed = new URL(candidate);
+  const params = new URLSearchParams(parsed.search);
+  const hashParams = new URLSearchParams(parsed.hash.replace(/^#/, ""));
+  hashParams.forEach((value, key) => params.set(key, value));
+  return params;
+};
 
 const captureCallback = (candidate) => {
   if (!candidate.startsWith(callbackScheme)) return;
+  const params = callbackParams(candidate);
+  if (!params.get("access_token") || !params.get("refresh_token")) return;
   resolveCallback(candidate);
 };
 
+// Network request URLs omit fragments. Capture the browser's requested navigation
+// before the custom-protocol request loses the auth session fragment.
+cdpSession.on("Page.frameScheduledNavigation", ({ url }) => captureCallback(url));
+cdpSession.on("Page.frameRequestedNavigation", ({ url }) => captureCallback(url));
 page.on("request", (request) => captureCallback(request.url()));
 page.on("framenavigated", (frame) => captureCallback(frame.url()));
 await page.route("aidictation://**", async (route) => {
@@ -45,22 +69,34 @@ await page.route("aidictation://**", async (route) => {
 });
 
 try {
-  await page.goto(authURL.toString(), { waitUntil: "domcontentloaded" });
-  await page.locator("#email").fill(email);
-  await page.locator("#password").fill(password);
-  await page
-    .getByRole("button", { name: "Sign In", exact: true })
-    .click({ noWaitAfter: true });
+  if (isSelfTest) {
+    await page.goto("about:blank");
+    await page
+      .evaluate((url) => {
+        window.location.href = url;
+      }, `${callbackScheme}#access_token=synthetic-access&refresh_token=synthetic-refresh`)
+      .catch(() => {});
+  } else {
+    await page.goto(authURL.toString(), { waitUntil: "domcontentloaded" });
+    await page.locator("#email").fill(email);
+    await page.locator("#password").fill(password);
+    await page
+      .getByRole("button", { name: "Sign In", exact: true })
+      .click({ noWaitAfter: true });
+  }
 
   const callbackURL = await callbackPromise;
-  const parsed = new URL(callbackURL);
-  const callbackParams = new URLSearchParams(parsed.hash.replace(/^#/, ""));
-  if (!callbackParams.get("access_token") || !callbackParams.get("refresh_token")) {
+  const params = callbackParams(callbackURL);
+  if (!params.get("access_token") || !params.get("refresh_token")) {
     throw new Error("Live browser callback did not contain a complete auth session");
   }
 
-  await writeFile(outputPath, callbackURL, { encoding: "utf8", mode: 0o600 });
-  console.log("Live browser sign-in produced an AIDictation app callback.");
+  if (isSelfTest) {
+    console.log("Verified complete custom-protocol callback capture.");
+  } else {
+    await writeFile(outputPath, callbackURL, { encoding: "utf8", mode: 0o600 });
+    console.log("Live browser sign-in produced an AIDictation app callback.");
+  }
 } finally {
   clearTimeout(timeout);
   await browser.close();

--- a/scripts/capture_release_auth_callback.mjs
+++ b/scripts/capture_release_auth_callback.mjs
@@ -94,7 +94,7 @@ try {
   if (isSelfTest) {
     await page.goto("about:blank");
     captureCallback(
-      "aidictation://auth-callback%zz#access_token=synthetic-access&refresh_token=synthetic-refresh",
+      "aidictation://auth-callback[#access_token=synthetic-access&refresh_token=synthetic-refresh",
     );
     if (capturedCallback) {
       throw new Error("Custom-protocol callback capture accepted a malformed callback");

--- a/scripts/capture_release_auth_callback.mjs
+++ b/scripts/capture_release_auth_callback.mjs
@@ -30,6 +30,7 @@ await cdpSession.send("Page.enable");
 
 let resolveCallback;
 let rejectCallback;
+let capturedCallback = null;
 const callbackPromise = new Promise((resolve, reject) => {
   resolveCallback = resolve;
   rejectCallback = reject;
@@ -42,8 +43,27 @@ const timeout = setTimeout(
   isSelfTest ? 10_000 : 45_000,
 );
 
-const callbackParams = (candidate) => {
-  const parsed = new URL(candidate);
+const exactCallbackURL = (candidate) => {
+  let parsed;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (
+    parsed.protocol !== "aidictation:" ||
+    parsed.hostname !== "auth-callback" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    (parsed.pathname && parsed.pathname !== "/")
+  ) {
+    return null;
+  }
+  return parsed;
+};
+
+const callbackParams = (parsed) => {
   const params = new URLSearchParams(parsed.search);
   const hashParams = new URLSearchParams(parsed.hash.replace(/^#/, ""));
   hashParams.forEach((value, key) => params.set(key, value));
@@ -51,9 +71,11 @@ const callbackParams = (candidate) => {
 };
 
 const captureCallback = (candidate) => {
-  if (!candidate.startsWith(callbackScheme)) return;
-  const params = callbackParams(candidate);
+  const parsed = exactCallbackURL(candidate);
+  if (!parsed) return;
+  const params = callbackParams(parsed);
   if (!params.get("access_token") || !params.get("refresh_token")) return;
+  capturedCallback = candidate;
   resolveCallback(candidate);
 };
 
@@ -71,11 +93,38 @@ await page.route("aidictation://**", async (route) => {
 try {
   if (isSelfTest) {
     await page.goto("about:blank");
-    await page
-      .evaluate((url) => {
-        window.location.href = url;
-      }, `${callbackScheme}#access_token=synthetic-access&refresh_token=synthetic-refresh`)
-      .catch(() => {});
+    captureCallback(
+      "aidictation://auth-callback%zz#access_token=synthetic-access&refresh_token=synthetic-refresh",
+    );
+    if (capturedCallback) {
+      throw new Error("Custom-protocol callback capture accepted a malformed callback");
+    }
+    const navigate = async (url) => {
+      await page
+        .evaluate((target) => {
+          setTimeout(() => {
+            window.location.href = target;
+          }, 0);
+        }, url)
+        .catch(() => {});
+      await page.waitForTimeout(100);
+    };
+    const rejectedCallbacks = [
+      `${callbackScheme}#access_token=synthetic-access`,
+      "aidictation://auth-callback.evil#access_token=synthetic-access&refresh_token=synthetic-refresh",
+      "aidictation://user@auth-callback#access_token=synthetic-access&refresh_token=synthetic-refresh",
+      "aidictation://auth-callback:123#access_token=synthetic-access&refresh_token=synthetic-refresh",
+      "aidictation://auth-callback/unexpected#access_token=synthetic-access&refresh_token=synthetic-refresh",
+    ];
+    for (const rejectedCallback of rejectedCallbacks) {
+      await navigate(rejectedCallback);
+      if (capturedCallback) {
+        throw new Error("Custom-protocol callback capture accepted a mismatched callback");
+      }
+    }
+    await navigate(
+      `${callbackScheme}#access_token=synthetic-access&refresh_token=synthetic-refresh`,
+    );
   } else {
     await page.goto(authURL.toString(), { waitUntil: "domcontentloaded" });
     await page.locator("#email").fill(email);
@@ -86,7 +135,8 @@ try {
   }
 
   const callbackURL = await callbackPromise;
-  const params = callbackParams(callbackURL);
+  const parsed = exactCallbackURL(callbackURL);
+  const params = parsed ? callbackParams(parsed) : new URLSearchParams();
   if (!params.get("access_token") || !params.get("refresh_token")) {
     throw new Error("Live browser callback did not contain a complete auth session");
   }


### PR DESCRIPTION
The protected macOS release preflight reached the live browser sign-in gate after signing and notarization, but Playwright request interception discarded the callback fragment before verification. Capture the pre-network Chromium navigation, ignore incomplete candidates, and run a synthetic custom-protocol self-test before the live account flow. No product authentication behavior or release artifact is changed.