### PR TITLE
Register the macOS release app before auth verification

### DIFF
--- a/.github/workflows/apple-audio-recovery.yml
+++ b/.github/workflows/apple-audio-recovery.yml
@@ -14,6 +14,9 @@ on:
       - 'scripts/validate_macos_recording_recovery.swift'
       - 'scripts/validate_macos_transcription_attempt_snapshot.swift'
       - 'scripts/validate_macos_vad_recovery.swift'
+      - 'scripts/validate_macos_url_handler_registration.sh'
+      - 'scripts/verify_macos_url_handler.swift'
+      - 'scripts/verify_macos_release_auth.sh'
       - 'scripts/validate_parakeet_runtime_recovery.swift'
       - 'scripts/validate_transcription_prompt_routing.py'
       - 'scripts/validate_transcription_cleanup_prompt.swift'
@@ -35,6 +38,9 @@ on:
       - 'scripts/validate_macos_recording_recovery.swift'
       - 'scripts/validate_macos_transcription_attempt_snapshot.swift'
       - 'scripts/validate_macos_vad_recovery.swift'
+      - 'scripts/validate_macos_url_handler_registration.sh'
+      - 'scripts/verify_macos_url_handler.swift'
+      - 'scripts/verify_macos_release_auth.sh'
       - 'scripts/validate_parakeet_runtime_recovery.swift'
       - 'scripts/validate_transcription_prompt_routing.py'
       - 'scripts/validate_transcription_cleanup_prompt.swift'
@@ -70,6 +76,9 @@ jobs:
             echo "Recovery contracts checked out $actual_sha instead of event commit $GITHUB_SHA." >&2
             exit 1
           fi
+
+      - name: Validate macOS callback registration
+        run: bash scripts/validate_macos_url_handler_registration.sh
 
       - name: Run deterministic recovery matrix
         run: bash scripts/validate_apple_audio_recovery.sh

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -184,6 +184,9 @@ jobs:
             -o /tmp/validate_macos_history_row_refresh
           /tmp/validate_macos_history_row_refresh
 
+      - name: Validate macOS callback registration
+        run: bash scripts/validate_macos_url_handler_registration.sh
+
       - name: Resolve Swift package dependencies
         run: |
           xcodebuild -resolvePackageDependencies \
@@ -302,6 +305,23 @@ jobs:
             echo "Packaged app is $packaged_version ($packaged_build), expected $VERSION ($BUILD)." >&2
             exit 1
           fi
+          python3 - "$INFO_PLIST" <<'PYEOF'
+          import plistlib
+          import sys
+
+          with open(sys.argv[1], "rb") as plist_file:
+              info = plistlib.load(plist_file)
+          schemes = [
+              scheme
+              for url_type in info.get("CFBundleURLTypes", [])
+              for scheme in url_type.get("CFBundleURLSchemes", [])
+          ]
+          if schemes != ["aidictation"]:
+              raise SystemExit(
+                  "exported release app does not declare exactly the aidictation callback scheme"
+              )
+          print("verified exact exported aidictation callback scheme")
+          PYEOF
           scripts/validate_macos_universal_app.sh "$APP"
           python3 scripts/validate_release_transcription_config.py \
             --secrets "$APP/Contents/Resources/Secrets.plist" \

--- a/scripts/validate_macos_url_handler_registration.sh
+++ b/scripts/validate_macos_url_handler_registration.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HANDLER_VERIFIER="$SCRIPT_DIR/verify_macos_url_handler.swift"
+LSREGISTER_PATH="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+USER_APPLICATIONS_DIR="${HOME}/Applications"
+WORK_PREFIX="${TMPDIR:-/tmp}/aidictation-url-handler-contract."
+INSTALL_PREFIX="$USER_APPLICATIONS_DIR/AIDictationURLHandlerContract."
+WORK_DIR=""
+INSTALL_ROOT=""
+INSTALLED_APP=""
+
+cleanup() {
+  if [[ -n "$INSTALL_ROOT" \
+      && "$INSTALL_ROOT" == "$INSTALL_PREFIX"* \
+      && "$(dirname "$INSTALL_ROOT")" == "$USER_APPLICATIONS_DIR" \
+      && "$INSTALLED_APP" == "$INSTALL_ROOT/CallbackProbe.app" ]]; then
+    "$LSREGISTER_PATH" -u "$INSTALLED_APP" >/dev/null 2>&1 || true
+    if [[ -d "$INSTALL_ROOT" ]]; then
+      rm -rf -- "$INSTALL_ROOT"
+    fi
+  fi
+  if [[ -n "$WORK_DIR" && "$WORK_DIR" == "$WORK_PREFIX"* && -d "$WORK_DIR" ]]; then
+    rm -rf -- "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+test -x "$LSREGISTER_PATH"
+test -f "$HANDLER_VERIFIER"
+mkdir -p "$USER_APPLICATIONS_DIR"
+
+WORK_DIR="$(mktemp -d "${WORK_PREFIX}XXXXXX")"
+INSTALL_ROOT="$(mktemp -d "${INSTALL_PREFIX}XXXXXX")"
+SOURCE_APP="$WORK_DIR/CallbackProbe.app"
+INSTALLED_APP="$INSTALL_ROOT/CallbackProbe.app"
+SCHEME="aidictationhandlercontract${RANDOM}${RANDOM}"
+
+mkdir -p "$SOURCE_APP/Contents/MacOS"
+cat > "$WORK_DIR/CallbackProbe.swift" <<'SWIFT'
+import AppKit
+import Foundation
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func application(_ application: NSApplication, open urls: [URL]) {
+        let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes")
+            as? [[String: Any]]
+        let expectedScheme = (urlTypes?.first?["CFBundleURLSchemes"] as? [String])?.first
+        guard urls.contains(where: {
+            $0.scheme == expectedScheme && $0.host == "auth-callback"
+        }) else {
+            return
+        }
+
+        let sentinel = Bundle.main.bundleURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("callback-received")
+        try? Data("received\n".utf8).write(to: sentinel, options: .atomic)
+        application.terminate(nil)
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            NSApplication.shared.terminate(nil)
+        }
+    }
+}
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.prohibited)
+app.run()
+SWIFT
+
+cat > "$SOURCE_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>CallbackProbe</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.writingmate.aidictation.release-handler-contract</string>
+  <key>CFBundleName</key>
+  <string>CallbackProbe</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>$SCHEME</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>
+PLIST
+
+swiftc "$WORK_DIR/CallbackProbe.swift" -o "$SOURCE_APP/Contents/MacOS/CallbackProbe"
+codesign --force --deep --sign - "$SOURCE_APP" >/dev/null
+
+if swift "$HANDLER_VERIFIER" "$SOURCE_APP" "$SCHEME" 0.25 >/dev/null 2>&1; then
+  echo "Synthetic callback unexpectedly resolved to the uninstalled source app." >&2
+  exit 1
+fi
+
+ditto "$SOURCE_APP" "$INSTALLED_APP"
+codesign --verify --deep --strict "$INSTALLED_APP"
+"$LSREGISTER_PATH" -f "$INSTALLED_APP"
+swift "$HANDLER_VERIFIER" "$INSTALLED_APP" "$SCHEME"
+if ! open "$SCHEME://auth-callback" >/dev/null 2>&1; then
+  echo "macOS could not deliver the synthetic callback to the registered app." >&2
+  exit 1
+fi
+for attempt in {1..20}; do
+  if [[ -s "$INSTALL_ROOT/callback-received" ]]; then
+    break
+  fi
+  if [[ "$attempt" -eq 20 ]]; then
+    echo "The registered synthetic app did not receive the callback." >&2
+    exit 1
+  fi
+  sleep 0.25
+done
+
+cleanup
+trap - EXIT
+if [[ -e "$INSTALL_ROOT" || -e "$WORK_DIR" ]]; then
+  echo "Synthetic callback verification did not clean up its temporary apps." >&2
+  exit 1
+fi
+
+echo "Verified exact LaunchServices registration, app callback receipt, and cleanup."

--- a/scripts/verify_macos_release_auth.sh
+++ b/scripts/verify_macos_release_auth.sh
@@ -6,6 +6,12 @@ EXPECTED_VERSION="${2:-}"
 BROWSER_SCRIPT="${AIDICTATION_RELEASE_AUTH_BROWSER_SCRIPT:-/tmp/aidictation-release-browser/capture_release_auth_callback.mjs}"
 CALLBACK_PATH="${AIDICTATION_RELEASE_AUTH_CALLBACK_PATH:-/tmp/aidictation-release-auth-callback}"
 RESULT_PATH="${AIDICTATION_RELEASE_AUTH_RESULT_PATH:-/tmp/aidictation-release-auth-result.json}"
+HANDLER_VERIFIER="${AIDICTATION_RELEASE_URL_HANDLER_VERIFIER:-scripts/verify_macos_url_handler.swift}"
+LSREGISTER_PATH="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+USER_APPLICATIONS_DIR="${HOME}/Applications"
+INSTALL_PREFIX="$USER_APPLICATIONS_DIR/AIDictationReleaseVerification."
+INSTALL_ROOT=""
+INSTALLED_APP=""
 
 if [[ -z "$APP_PATH" || ! -d "$APP_PATH" ]]; then
   echo "A signed AIDictation.app path is required." >&2
@@ -19,14 +25,55 @@ if [[ ! -f "$BROWSER_SCRIPT" ]]; then
   echo "The live browser verifier is not installed at $BROWSER_SCRIPT." >&2
   exit 1
 fi
+if [[ ! -f "$HANDLER_VERIFIER" || ! -x "$LSREGISTER_PATH" ]]; then
+  echo "The macOS callback-handler verifier is unavailable." >&2
+  exit 1
+fi
 
 cleanup() {
   launchctl unsetenv AIDICTATION_RELEASE_AUTH_SMOKE >/dev/null 2>&1 || true
   launchctl unsetenv AIDICTATION_RELEASE_AUTH_RESULT >/dev/null 2>&1 || true
   pkill -x AIDictation >/dev/null 2>&1 || true
   rm -f "$CALLBACK_PATH" "$RESULT_PATH"
+  if [[ -n "$INSTALL_ROOT" \
+      && "$INSTALL_ROOT" == "$INSTALL_PREFIX"* \
+      && "$(dirname "$INSTALL_ROOT")" == "$USER_APPLICATIONS_DIR" \
+      && "$INSTALLED_APP" == "$INSTALL_ROOT/AIDictation.app" ]]; then
+    "$LSREGISTER_PATH" -u "$INSTALLED_APP" >/dev/null 2>&1 || true
+    if [[ -d "$INSTALL_ROOT" ]]; then
+      rm -rf -- "$INSTALL_ROOT"
+    fi
+  fi
 }
 trap cleanup EXIT
+
+python3 - "$APP_PATH/Contents/Info.plist" <<'PYEOF'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as plist_file:
+    info = plistlib.load(plist_file)
+
+schemes = [
+    scheme
+    for url_type in info.get("CFBundleURLTypes", [])
+    for scheme in url_type.get("CFBundleURLSchemes", [])
+]
+if schemes != ["aidictation"]:
+    raise SystemExit("The release app does not declare exactly the aidictation callback scheme.")
+PYEOF
+
+mkdir -p "$USER_APPLICATIONS_DIR"
+INSTALL_ROOT="$(mktemp -d "${INSTALL_PREFIX}XXXXXX")"
+if [[ "$INSTALL_ROOT" != "$INSTALL_PREFIX"* ]]; then
+  echo "The release verification install path is outside the user Applications directory." >&2
+  exit 1
+fi
+INSTALLED_APP="$INSTALL_ROOT/AIDictation.app"
+ditto "$APP_PATH" "$INSTALLED_APP"
+codesign --verify --deep --strict --verbose=2 "$INSTALLED_APP"
+"$LSREGISTER_PATH" -f "$INSTALLED_APP"
+swift "$HANDLER_VERIFIER" "$INSTALLED_APP" aidictation
 
 export AIDICTATION_RELEASE_AUTH_CALLBACK_PATH="$CALLBACK_PATH"
 node "$BROWSER_SCRIPT"
@@ -35,7 +82,7 @@ test -s "$CALLBACK_PATH"
 rm -f "$RESULT_PATH"
 launchctl setenv AIDICTATION_RELEASE_AUTH_SMOKE 1
 launchctl setenv AIDICTATION_RELEASE_AUTH_RESULT "$RESULT_PATH"
-open -na "$APP_PATH"
+open -na "$INSTALLED_APP"
 
 for attempt in {1..20}; do
   if pgrep -x AIDictation >/dev/null; then
@@ -49,7 +96,10 @@ for attempt in {1..20}; do
 done
 
 CALLBACK_URL="$(<"$CALLBACK_PATH")"
-open "$CALLBACK_URL"
+if ! open "$CALLBACK_URL" >/dev/null 2>&1; then
+  echo "macOS could not deliver the browser callback to the registered release app." >&2
+  exit 1
+fi
 unset CALLBACK_URL
 rm -f "$CALLBACK_PATH"
 

--- a/scripts/verify_macos_url_handler.swift
+++ b/scripts/verify_macos_url_handler.swift
@@ -1,0 +1,45 @@
+import CoreServices
+import Foundation
+
+guard CommandLine.arguments.count == 3 || CommandLine.arguments.count == 4 else {
+    fputs("Usage: verify_macos_url_handler.swift <app-path> <scheme> [timeout-seconds]\n", stderr)
+    exit(2)
+}
+
+let expectedApp = URL(fileURLWithPath: CommandLine.arguments[1])
+    .resolvingSymlinksInPath()
+    .standardizedFileURL
+let scheme = CommandLine.arguments[2]
+let timeout = CommandLine.arguments.count == 4
+    ? (Double(CommandLine.arguments[3]) ?? 10)
+    : 10
+
+guard let callbackURL = URL(string: "\(scheme)://auth-callback") else {
+    fputs("The release callback scheme is invalid.\n", stderr)
+    exit(2)
+}
+
+let deadline = Date().addingTimeInterval(max(timeout, 0))
+repeat {
+    var lookupError: Unmanaged<CFError>?
+    if let unmanagedHandler = LSCopyDefaultApplicationURLForURL(
+        callbackURL as CFURL,
+        .all,
+        &lookupError
+    ) {
+        let actualApp = (unmanagedHandler.takeRetainedValue() as URL)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        if actualApp == expectedApp {
+            print("LaunchServices resolves the callback to the exact release app.")
+            exit(0)
+        }
+    }
+
+    if Date() < deadline {
+        Thread.sleep(forTimeInterval: 0.25)
+    }
+} while Date() < deadline
+
+fputs("LaunchServices does not resolve the callback to the exact release app.\n", stderr)
+exit(1)


### PR DESCRIPTION
## Summary
- copy the signed release app into a dedicated temporary folder under `~/Applications` before browser callback verification
- explicitly register that exact app with LaunchServices and fail closed unless it resolves as the callback handler
- verify the exported package declares exactly the `aidictation` callback scheme
- add a no-secret synthetic LaunchServices regression and run it in recovery and release workflows

## Why
The protected v0.0.98 preflight captured a complete browser callback, but macOS could not deliver it because a temporary exported app was not an installed LaunchServices handler. This changes only the release verifier; product behavior is unchanged.

## Verification
- `bash -n scripts/validate_macos_url_handler_registration.sh scripts/verify_macos_release_auth.sh`
- `swiftc -typecheck scripts/verify_macos_url_handler.swift`
- workflow YAML parse
- `bash scripts/validate_macos_url_handler_registration.sh` (verified no handler before registration, exact handler after registration, callback delivery, and cleanup)
- `git diff --check`