### PR TITLE
Make macOS auth callback verification support-safe

### DIFF
--- a/.github/workflows/apple-audio-recovery.yml
+++ b/.github/workflows/apple-audio-recovery.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/validate_macos_transcription_attempt_snapshot.swift'
       - 'scripts/validate_macos_vad_recovery.swift'
       - 'scripts/validate_macos_url_handler_registration.sh'
+      - 'scripts/validate_macos_callback_token.py'
       - 'scripts/verify_macos_url_handler.swift'
       - 'scripts/verify_macos_release_auth.sh'
       - 'scripts/validate_parakeet_runtime_recovery.swift'
@@ -39,6 +40,7 @@ on:
       - 'scripts/validate_macos_transcription_attempt_snapshot.swift'
       - 'scripts/validate_macos_vad_recovery.swift'
       - 'scripts/validate_macos_url_handler_registration.sh'
+      - 'scripts/validate_macos_callback_token.py'
       - 'scripts/verify_macos_url_handler.swift'
       - 'scripts/verify_macos_release_auth.sh'
       - 'scripts/validate_parakeet_runtime_recovery.swift'
@@ -78,7 +80,9 @@ jobs:
           fi
 
       - name: Validate macOS callback registration
-        run: bash scripts/validate_macos_url_handler_registration.sh
+        run: |
+          python3 scripts/validate_macos_callback_token.py --self-test
+          bash scripts/validate_macos_url_handler_registration.sh
 
       - name: Run deterministic recovery matrix
         run: bash scripts/validate_apple_audio_recovery.sh

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -185,7 +185,9 @@ jobs:
           /tmp/validate_macos_history_row_refresh
 
       - name: Validate macOS callback registration
-        run: bash scripts/validate_macos_url_handler_registration.sh
+        run: |
+          python3 scripts/validate_macos_callback_token.py --self-test
+          bash scripts/validate_macos_url_handler_registration.sh
 
       - name: Resolve Swift package dependencies
         run: |

--- a/Whishpermate/WhisperMateShared/Services/AuthManager.swift
+++ b/Whishpermate/WhisperMateShared/Services/AuthManager.swift
@@ -11,6 +11,45 @@ import Supabase
     import UIKit
 #endif
 
+public enum AuthCallbackFailurePhase: String, Sendable {
+    case none
+    case callbackShape = "callback_shape"
+    case sessionValidation = "session_validation"
+    case profileFetch = "profile_fetch"
+}
+
+public enum AuthCallbackFailureCategory: String, Sendable {
+    case none
+    case missingRequiredFields = "missing_required_fields"
+    case noncanonicalFields = "noncanonical_fields"
+    case configurationUnavailable = "configuration_unavailable"
+    case implicitGrantRejected = "implicit_grant_rejected"
+    case jwtRejected = "jwt_rejected"
+    case sessionMissing = "session_missing"
+    case apiUnauthorized = "api_401"
+    case apiForbidden = "api_403"
+    case apiNotFound = "api_404"
+    case apiClientRejected = "api_client_rejected"
+    case apiServerRejected = "api_server_rejected"
+    case apiOtherRejected = "api_other_rejected"
+    case authOther = "auth_other"
+    case sessionUnavailableAfterCallback = "session_unavailable_after_callback"
+    case profileRequestRejected = "profile_request_rejected"
+    case unknown
+}
+
+public struct AuthCallbackOutcome: Sendable {
+    public let hasAccessToken: Bool
+    public let hasRefreshToken: Bool
+    public let hasTokenType: Bool
+    public let hasExpiresIn: Bool
+    public let sessionEstablished: Bool
+    public let profileRequestStarted: Bool
+    public let profileLoaded: Bool
+    public let failurePhase: AuthCallbackFailurePhase
+    public let failureCategory: AuthCallbackFailureCategory
+}
+
 /// Manages user authentication state and session lifecycle via Supabase
 public class AuthManager: ObservableObject {
     public static let shared = AuthManager()
@@ -40,6 +79,69 @@ public class AuthManager: ObservableObject {
         private var authSession: ASWebAuthenticationSession?
     #endif
 
+    private struct CallbackShape {
+        let hasAccessToken: Bool
+        let hasRefreshToken: Bool
+        let hasTokenType: Bool
+        let hasExpiresIn: Bool
+        let hasAuthFieldsInQuery: Bool
+        let tokenTypeIsBearer: Bool
+
+        init(url: URL) {
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                hasAccessToken = false
+                hasRefreshToken = false
+                hasTokenType = false
+                hasExpiresIn = false
+                hasAuthFieldsInQuery = false
+                tokenTypeIsBearer = false
+                return
+            }
+
+            let requiredNames = Set([
+                "access_token",
+                "refresh_token",
+                "token_type",
+                "expires_in",
+            ])
+            hasAuthFieldsInQuery = (components.queryItems ?? []).contains {
+                requiredNames.contains($0.name)
+            }
+
+            var items: [URLQueryItem] = []
+            if let fragment = components.fragment,
+               let fragmentItems = URLComponents(string: "?\(fragment)")?.queryItems
+            {
+                items.append(contentsOf: fragmentItems)
+            }
+
+            func hasValue(_ name: String) -> Bool {
+                items.contains { $0.name == name && !($0.value ?? "").isEmpty }
+            }
+
+            hasAccessToken = hasValue("access_token")
+            hasRefreshToken = hasValue("refresh_token")
+            hasTokenType = hasValue("token_type")
+            hasExpiresIn = hasValue("expires_in")
+            tokenTypeIsBearer = items.last(where: { $0.name == "token_type" })?
+                .value?.lowercased() == "bearer"
+        }
+
+        var isComplete: Bool {
+            hasAccessToken && hasRefreshToken && hasTokenType && hasExpiresIn
+        }
+
+        var isCanonical: Bool {
+            !hasAuthFieldsInQuery && tokenTypeIsBearer
+        }
+    }
+
+    private enum UserRefreshOutcome {
+        case sessionUnavailable
+        case profileLoaded
+        case profileRequestRejected
+    }
+
     // MARK: - Initialization
 
     private init() {
@@ -67,13 +169,13 @@ public class AuthManager: ObservableObject {
             await startAutoRefreshIfNeeded()
             return true
         } catch {
-            DebugLog.info("No active session, attempting refresh: \(error.localizedDescription)", context: "AuthManager")
+            DebugLog.info("No active session; attempting refresh", context: "AuthManager")
             do {
                 _ = try await client.auth.refreshSession()
                 await startAutoRefreshIfNeeded()
                 return true
             } catch {
-                DebugLog.info("Session refresh failed: \(error.localizedDescription)", context: "AuthManager")
+                DebugLog.info("Session refresh failed", context: "AuthManager")
                 return false
             }
         }
@@ -165,9 +267,9 @@ public class AuthManager: ObservableObject {
                         return
                     }
 
-                    if let error {
-                        DebugLog.warning("Auth popup failed: \(error.localizedDescription)", context: "AuthManager")
-                        self.error = "Authentication failed: \(error.localizedDescription)"
+                    if error != nil {
+                        DebugLog.warning("Authentication popup failed", context: "AuthManager")
+                        self.error = "Authentication failed. Please try again or contact support."
                     }
                 }
             }
@@ -252,23 +354,99 @@ public class AuthManager: ObservableObject {
         }
     }
 
-    public func handleAuthCallback(url: URL) async {
-        DebugLog.info("Handling auth callback: \(url.absoluteString)", context: "AuthManager")
+    @discardableResult
+    public func handleAuthCallback(url: URL) async -> AuthCallbackOutcome {
+        DebugLog.info("Handling authentication callback", context: "AuthManager")
+        let shape = CallbackShape(url: url)
+
+        guard shape.isComplete else {
+            DebugLog.warning(
+                "Authentication callback is missing required session fields",
+                context: "AuthManager"
+            )
+            await setSupportSafeCallbackError()
+            return callbackOutcome(
+                shape: shape,
+                failurePhase: .callbackShape,
+                failureCategory: .missingRequiredFields
+            )
+        }
+        guard shape.isCanonical else {
+            DebugLog.warning(
+                "Authentication callback session fields are not canonical",
+                context: "AuthManager"
+            )
+            await setSupportSafeCallbackError()
+            return callbackOutcome(
+                shape: shape,
+                failurePhase: .callbackShape,
+                failureCategory: .noncanonicalFields
+            )
+        }
 
         do {
-            guard let client = supabase.client else { return }
-            let session = try await client.auth.session(from: url)
-            DebugLog.info("Session established for user: \(session.user.id)", context: "AuthManager")
-            await refreshUser()
-        } catch {
-            DebugLog.info("Auth callback failed: \(error.localizedDescription)", context: "AuthManager")
-            await MainActor.run {
-                self.error = "Authentication failed: \(error.localizedDescription)"
+            guard let client = supabase.client else {
+                await setSupportSafeCallbackError()
+                return callbackOutcome(
+                    shape: shape,
+                    failurePhase: .sessionValidation,
+                    failureCategory: .configurationUnavailable
+                )
             }
+            _ = try await client.auth.session(from: url)
+            DebugLog.info("Authentication callback established a session", context: "AuthManager")
+
+            switch await refreshUserWithOutcome() {
+            case .profileLoaded:
+                return callbackOutcome(
+                    shape: shape,
+                    sessionEstablished: true,
+                    profileRequestStarted: true,
+                    profileLoaded: true
+                )
+            case .sessionUnavailable:
+                await setSupportSafeCallbackError()
+                return callbackOutcome(
+                    shape: shape,
+                    sessionEstablished: true,
+                    failurePhase: .sessionValidation,
+                    failureCategory: .sessionUnavailableAfterCallback
+                )
+            case .profileRequestRejected:
+                return callbackOutcome(
+                    shape: shape,
+                    sessionEstablished: true,
+                    profileRequestStarted: true,
+                    failurePhase: .profileFetch,
+                    failureCategory: .profileRequestRejected
+                )
+            }
+        } catch {
+            let category = callbackFailureCategory(error)
+            DebugLog.warning(
+                "Authentication callback session validation failed (\(category.rawValue))",
+                context: "AuthManager"
+            )
+            await setSupportSafeCallbackError()
+            return callbackOutcome(
+                shape: shape,
+                failurePhase: .sessionValidation,
+                failureCategory: category
+            )
         }
     }
 
-    public func refreshUser() async {
+    @discardableResult
+    public func refreshUser() async -> Bool {
+        switch await refreshUserWithOutcome() {
+        case .profileLoaded:
+            return true
+        case .sessionUnavailable, .profileRequestRejected:
+            return false
+        }
+    }
+
+    private func refreshUserWithOutcome() async -> UserRefreshOutcome {
         DebugLog.info("Fetching user data...", context: "AuthManager")
         await MainActor.run {
             self.isLoading = true
@@ -282,7 +460,7 @@ public class AuthManager: ObservableObject {
                 self.isAuthenticated = false
                 self.isLoading = false
             }
-            return
+            return .sessionUnavailable
         }
 
         await MainActor.run {
@@ -301,12 +479,75 @@ public class AuthManager: ObservableObject {
                 NotificationCenter.default.post(name: NSNotification.Name(Constants.userAuthChangedNotification), object: nil)
             }
             DebugLog.info("Auth state updated - isAuthenticated: true", context: "AuthManager")
+            return .profileLoaded
         } catch {
-            DebugLog.info("Failed to fetch user: \(error.localizedDescription)", context: "AuthManager")
+            DebugLog.warning("Failed to fetch authenticated profile", context: "AuthManager")
             await MainActor.run {
-                self.error = error.localizedDescription
+                self.error = "We could not load your account. Please try again."
                 self.isLoading = false
             }
+            return .profileRequestRejected
+        }
+    }
+
+    private func callbackOutcome(
+        shape: CallbackShape,
+        sessionEstablished: Bool = false,
+        profileRequestStarted: Bool = false,
+        profileLoaded: Bool = false,
+        failurePhase: AuthCallbackFailurePhase = .none,
+        failureCategory: AuthCallbackFailureCategory = .none
+    ) -> AuthCallbackOutcome {
+        AuthCallbackOutcome(
+            hasAccessToken: shape.hasAccessToken,
+            hasRefreshToken: shape.hasRefreshToken,
+            hasTokenType: shape.hasTokenType,
+            hasExpiresIn: shape.hasExpiresIn,
+            sessionEstablished: sessionEstablished,
+            profileRequestStarted: profileRequestStarted,
+            profileLoaded: profileLoaded,
+            failurePhase: failurePhase,
+            failureCategory: failureCategory
+        )
+    }
+
+    private func callbackFailureCategory(_ error: Error) -> AuthCallbackFailureCategory {
+        guard let authError = error as? AuthError else {
+            return .unknown
+        }
+
+        switch authError {
+        case .implicitGrantRedirect:
+            return .implicitGrantRejected
+        case .jwtVerificationFailed:
+            return .jwtRejected
+        case .sessionMissing:
+            return .sessionMissing
+        case let .api(_, _, _, response):
+            switch response.statusCode {
+            case 401:
+                return .apiUnauthorized
+            case 403:
+                return .apiForbidden
+            case 404:
+                return .apiNotFound
+            case 400 ... 499:
+                return .apiClientRejected
+            case 500 ... 599:
+                return .apiServerRejected
+            default:
+                return .apiOtherRejected
+            }
+        case .weakPassword, .pkceGrantCodeExchange:
+            return .authOther
+        default:
+            return .authOther
+        }
+    }
+
+    private func setSupportSafeCallbackError() async {
+        await MainActor.run {
+            self.error = "Authentication failed. Please try again or contact support."
         }
     }
 

--- a/Whishpermate/Whispermate/WhispermateApp.swift
+++ b/Whishpermate/Whispermate/WhispermateApp.swift
@@ -100,7 +100,7 @@ private final class ReleaseAuthVerificationReporter {
         outputURL = URL(fileURLWithPath: outputPath)
     }
 
-    func report(_ authManager: AuthManager) {
+    func report(_ authManager: AuthManager, outcome: AuthCallbackOutcome) {
         guard let outputURL else { return }
 
         let user = authManager.currentUser
@@ -113,6 +113,14 @@ private final class ReleaseAuthVerificationReporter {
             "has_reached_limit": user?.hasReachedLimit ?? true,
             "words_remaining_unlimited": user?.effectiveWordLimit == Int.max,
             "auth_error_present": authManager.error != nil,
+            "callback_has_access_token": outcome.hasAccessToken,
+            "callback_has_refresh_token": outcome.hasRefreshToken,
+            "callback_has_token_type": outcome.hasTokenType,
+            "callback_has_expires_in": outcome.hasExpiresIn,
+            "callback_session_established": outcome.sessionEstablished,
+            "profile_request_started": outcome.profileRequestStarted,
+            "callback_failure_phase": outcome.failurePhase.rawValue,
+            "callback_failure_category": outcome.failureCategory.rawValue,
         ]
 
         do {
@@ -244,10 +252,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private func handleURL(_ url: URL) {
-        DebugLog.info("AppDelegate received URL: \(url.absoluteString)", context: "AppDelegate")
-
         // Handle authentication callback (aidictation://auth-callback)
         if isAuthCallbackURL(url) {
+            DebugLog.info("AppDelegate received authentication callback", context: "AppDelegate")
             guard AuthCallbackGate.shouldProcess(url, context: "AppDelegate") else {
                 return
             }
@@ -258,9 +265,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
             DebugLog.info("Processing auth callback...", context: "AppDelegate")
             Task {
-                await authManager.handleAuthCallback(url: url)
+                let outcome = await authManager.handleAuthCallback(url: url)
                 await MainActor.run {
-                    ReleaseAuthVerificationReporter.shared.report(authManager)
+                    ReleaseAuthVerificationReporter.shared.report(authManager, outcome: outcome)
                 }
             }
         }

--- a/scripts/validate_macos_callback_token.py
+++ b/scripts/validate_macos_callback_token.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate a release callback token without printing credentials or response data."""
+
+from __future__ import annotations
+
+import plistlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+class VerificationError(Exception):
+    """A support-safe release verification failure."""
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+def is_safe_header_value(value: str) -> bool:
+    return value.isascii() and all(
+        0x21 <= ord(character) <= 0x7E for character in value
+    )
+
+
+def callback_params(callback_url: str) -> dict[str, str]:
+    parsed = urllib.parse.urlsplit(callback_url)
+    try:
+        port = parsed.port
+    except ValueError:
+        raise VerificationError("The captured callback target is invalid.") from None
+    if (
+        parsed.scheme != "aidictation"
+        or parsed.hostname != "auth-callback"
+        or parsed.username
+        or parsed.password
+        or port
+        or parsed.path not in ("", "/")
+    ):
+        raise VerificationError("The captured callback target is invalid.")
+
+    required = ("access_token", "refresh_token", "token_type", "expires_in")
+    query_items = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    if any(name in required for name, _ in query_items):
+        raise VerificationError(
+            "The captured callback must keep session fields in the fragment only."
+        )
+
+    params: dict[str, str] = {}
+    for name, value in urllib.parse.parse_qsl(
+        parsed.fragment,
+        keep_blank_values=True,
+    ):
+        params[name] = value
+
+    if any(not params.get(name) for name in required):
+        raise VerificationError("The captured callback is missing required session fields.")
+    if not is_safe_header_value(params["access_token"]):
+        raise VerificationError("The captured callback contains an invalid access token.")
+    if params["token_type"].lower() != "bearer":
+        raise VerificationError("The captured callback token type is invalid.")
+    return params
+
+
+def auth_user_endpoint(secrets_path: Path) -> tuple[str, str]:
+    with secrets_path.open("rb") as plist_file:
+        secrets = plistlib.load(plist_file)
+
+    base_value = secrets.get("SUPABASE_URL")
+    anon_key = secrets.get("SUPABASE_ANON_KEY")
+    if (
+        not isinstance(base_value, str)
+        or not isinstance(anon_key, str)
+        or not anon_key
+    ):
+        raise VerificationError("The packaged authentication configuration is incomplete.")
+    if not is_safe_header_value(anon_key):
+        raise VerificationError("The packaged authentication configuration is invalid.")
+
+    parsed = urllib.parse.urlsplit(base_value)
+    try:
+        port = parsed.port
+    except ValueError:
+        raise VerificationError(
+            "The packaged authentication service URL is invalid."
+        ) from None
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or port not in (None, 443)
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise VerificationError("The packaged authentication service URL is invalid.")
+
+    path = f"{parsed.path.rstrip('/')}/auth/v1/user"
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", "")), anon_key
+
+
+def verify(callback_path: Path, secrets_path: Path) -> None:
+    callback_url = callback_path.read_text(encoding="utf-8").strip()
+    params = callback_params(callback_url)
+    endpoint, anon_key = auth_user_endpoint(secrets_path)
+
+    try:
+        request = urllib.request.Request(
+            endpoint,
+            headers={
+                "Authorization": f"{params['token_type']} {params['access_token']}",
+                "apikey": anon_key,
+            },
+            method="GET",
+        )
+        opener = urllib.request.build_opener(NoRedirectHandler())
+        with opener.open(request, timeout=20) as response:
+            status = response.status
+    except urllib.error.HTTPError as error:
+        status = error.code
+    except (urllib.error.URLError, TimeoutError):
+        raise VerificationError(
+            "The packaged authentication service could not be reached."
+        ) from None
+    except Exception:
+        raise VerificationError(
+            "The packaged authentication request could not be completed safely."
+        ) from None
+
+    if status != 200:
+        raise VerificationError(
+            f"The callback token was rejected by the packaged authentication service "
+            f"(HTTP {status})."
+        )
+    print("Callback token accepted by the packaged authentication service (HTTP 200).")
+
+
+def self_test() -> None:
+    params = callback_params(
+        "aidictation://auth-callback#"
+        "access_token=synthetic-access&refresh_token=synthetic-refresh&"
+        "token_type=bearer&expires_in=3600"
+    )
+    assert params == {
+        "access_token": "synthetic-access",
+        "refresh_token": "synthetic-refresh",
+        "token_type": "bearer",
+        "expires_in": "3600",
+    }
+
+    rejected = (
+        "aidictation://auth-callback#access_token=synthetic-access",
+        "aidictation://auth-callback.evil#access_token=synthetic-access&"
+        "refresh_token=synthetic-refresh&token_type=bearer&expires_in=3600",
+        "aidictation://auth-callback#access_token=synthetic%0D%0Asecret&"
+        "refresh_token=synthetic-refresh&token_type=bearer&expires_in=3600",
+        "aidictation://auth-callback?access_token=query-access#"
+        "access_token=synthetic-access&refresh_token=synthetic-refresh&"
+        "token_type=bearer&expires_in=3600",
+        "aidictation://auth-callback#access_token=synthetic-access&"
+        "refresh_token=synthetic-refresh&token_type=unknown&expires_in=3600",
+    )
+    for candidate in rejected:
+        try:
+            callback_params(candidate)
+        except VerificationError:
+            continue
+        raise AssertionError("A malformed synthetic callback was accepted.")
+    print("Verified support-safe callback token validation inputs.")
+
+
+def main() -> int:
+    try:
+        if sys.argv[1:] == ["--self-test"]:
+            self_test()
+            return 0
+        if len(sys.argv) != 3:
+            raise VerificationError(
+                "Usage: validate_macos_callback_token.py <callback-path> <secrets-plist>"
+            )
+        verify(Path(sys.argv[1]), Path(sys.argv[2]))
+        return 0
+    except (OSError, plistlib.InvalidFileException, VerificationError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    except Exception:
+        print("Callback token validation failed safely.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_macos_url_handler_registration.sh
+++ b/scripts/validate_macos_url_handler_registration.sh
@@ -47,8 +47,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes")
             as? [[String: Any]]
         let expectedScheme = (urlTypes?.first?["CFBundleURLSchemes"] as? [String])?.first
-        guard urls.contains(where: {
-            $0.scheme == expectedScheme && $0.host == "auth-callback"
+        guard urls.contains(where: { url in
+            guard let components = URLComponents(
+                url: url,
+                resolvingAgainstBaseURL: false
+            ),
+                components.scheme == expectedScheme,
+                components.host == "auth-callback",
+                components.user == nil,
+                components.password == nil,
+                components.port == nil,
+                components.path.isEmpty,
+                components.query == nil,
+                let fragment = components.fragment,
+                let items = URLComponents(string: "?\(fragment)")?.queryItems
+            else {
+                return false
+            }
+            var params: [String: String] = [:]
+            for item in items {
+                params[item.name] = item.value ?? ""
+            }
+            return params == [
+                "access_token": "synthetic-access",
+                "refresh_token": "synthetic-refresh",
+                "token_type": "bearer",
+                "expires_in": "3600",
+            ]
         }) else {
             return
         }
@@ -114,7 +139,7 @@ ditto "$SOURCE_APP" "$INSTALLED_APP"
 codesign --verify --deep --strict "$INSTALLED_APP"
 "$LSREGISTER_PATH" -f "$INSTALLED_APP"
 swift "$HANDLER_VERIFIER" "$INSTALLED_APP" "$SCHEME"
-if ! open "$SCHEME://auth-callback" >/dev/null 2>&1; then
+if ! open "$SCHEME://auth-callback#access_token=synthetic-access&refresh_token=synthetic-refresh&token_type=bearer&expires_in=3600" >/dev/null 2>&1; then
   echo "macOS could not deliver the synthetic callback to the registered app." >&2
   exit 1
 fi
@@ -136,4 +161,4 @@ if [[ -e "$INSTALL_ROOT" || -e "$WORK_DIR" ]]; then
   exit 1
 fi
 
-echo "Verified exact LaunchServices registration, app callback receipt, and cleanup."
+echo "Verified exact LaunchServices registration, callback fragment receipt, and cleanup."

--- a/scripts/verify_macos_release_auth.sh
+++ b/scripts/verify_macos_release_auth.sh
@@ -7,6 +7,7 @@ BROWSER_SCRIPT="${AIDICTATION_RELEASE_AUTH_BROWSER_SCRIPT:-/tmp/aidictation-rele
 CALLBACK_PATH="${AIDICTATION_RELEASE_AUTH_CALLBACK_PATH:-/tmp/aidictation-release-auth-callback}"
 RESULT_PATH="${AIDICTATION_RELEASE_AUTH_RESULT_PATH:-/tmp/aidictation-release-auth-result.json}"
 HANDLER_VERIFIER="${AIDICTATION_RELEASE_URL_HANDLER_VERIFIER:-scripts/verify_macos_url_handler.swift}"
+TOKEN_VERIFIER="${AIDICTATION_RELEASE_CALLBACK_TOKEN_VERIFIER:-scripts/validate_macos_callback_token.py}"
 LSREGISTER_PATH="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 USER_APPLICATIONS_DIR="${HOME}/Applications"
 INSTALL_PREFIX="$USER_APPLICATIONS_DIR/AIDictationReleaseVerification."
@@ -25,8 +26,8 @@ if [[ ! -f "$BROWSER_SCRIPT" ]]; then
   echo "The live browser verifier is not installed at $BROWSER_SCRIPT." >&2
   exit 1
 fi
-if [[ ! -f "$HANDLER_VERIFIER" || ! -x "$LSREGISTER_PATH" ]]; then
-  echo "The macOS callback-handler verifier is unavailable." >&2
+if [[ ! -f "$HANDLER_VERIFIER" || ! -f "$TOKEN_VERIFIER" || ! -x "$LSREGISTER_PATH" ]]; then
+  echo "A macOS callback verifier is unavailable." >&2
   exit 1
 fi
 
@@ -78,6 +79,9 @@ swift "$HANDLER_VERIFIER" "$INSTALLED_APP" aidictation
 export AIDICTATION_RELEASE_AUTH_CALLBACK_PATH="$CALLBACK_PATH"
 node "$BROWSER_SCRIPT"
 test -s "$CALLBACK_PATH"
+python3 "$TOKEN_VERIFIER" \
+  "$CALLBACK_PATH" \
+  "$APP_PATH/Contents/Resources/Secrets.plist"
 
 rm -f "$RESULT_PATH"
 launchctl setenv AIDICTATION_RELEASE_AUTH_SMOKE 1
@@ -131,6 +135,14 @@ expected = {
     "has_reached_limit": False,
     "words_remaining_unlimited": True,
     "auth_error_present": False,
+    "callback_has_access_token": True,
+    "callback_has_refresh_token": True,
+    "callback_has_token_type": True,
+    "callback_has_expires_in": True,
+    "callback_session_established": True,
+    "profile_request_started": True,
+    "callback_failure_phase": "none",
+    "callback_failure_category": "none",
 }
 mismatches = {
     key: {"expected": value, "actual": result.get(key)}


### PR DESCRIPTION
## Summary
- prove LaunchServices preserves the complete no-secret callback fragment at app level
- remove raw authentication callback URLs and callback error descriptions from app logs/UI
- report only required-field/session/profile booleans and fixed failure phase/category values
- validate the captured access token directly against the packaged auth `/user` endpoint while exposing only HTTP status

## Why
The protected v0.0.98 preflight proved exact callback routing and app receipt, then failed before an authenticated profile was loaded. The previous reporter exposed only a generic error boolean, and two app debug logs could persist the full callback URL. This keeps publication blocked while making the next preflight diagnostic precise and token-safe.

## Verification
- macOS Debug build passed
- iOS simulator + keyboard/shared-code build passed
- callback token validator self-test passed
- exact LaunchServices registration + complete synthetic fragment receipt + cleanup passed
- shell syntax, workflow YAML parse, and `git diff --check` passed
- raw authentication callback URL/error logging pattern check passed

No release tag or artifact is created by this PR.