### PR TITLE
Verify macOS auth backend origin parity

### DIFF
--- a/scripts/validate_macos_callback_token.py
+++ b/scripts/validate_macos_callback_token.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import base64
+import json
+import platform
 import plistlib
 import sys
 import urllib.error
@@ -18,6 +21,21 @@ class VerificationError(Exception):
 class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, request, file_pointer, code, message, headers, new_url):
         return None
+
+
+# Match the shipped app's browser-like URLSession transport and the headers
+# added by the pinned Supabase Swift 2.46.0 Auth client.
+NATIVE_TRANSPORT_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "AIDictation-macOS-Release-Verification/1.0",
+}
+NATIVE_SDK_HEADERS = {
+    "X-Client-Info": "supabase-swift/2.46.0",
+    "X-Supabase-Api-Version": "2024-01-01",
+    "X-Supabase-Client-Platform": "macOS",
+}
+if macos_version := platform.mac_ver()[0]:
+    NATIVE_SDK_HEADERS["X-Supabase-Client-Platform-Version"] = macos_version
 
 
 def is_safe_header_value(value: str) -> bool:
@@ -65,15 +83,38 @@ def callback_params(callback_url: str) -> dict[str, str]:
     return params
 
 
-def auth_user_endpoint(secrets_path: Path) -> tuple[str, str]:
+def https_origin(value: str) -> tuple[str, str, int] | None:
+    parsed = urllib.parse.urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+    ):
+        return None
+    return "https", parsed.hostname.lower(), port if port is not None else 443
+
+
+def auth_backend_origins_match(auth_web_url: str, supabase_url: str) -> bool:
+    auth_origin = https_origin(auth_web_url)
+    return auth_origin is not None and auth_origin == https_origin(supabase_url)
+
+
+def auth_user_endpoint(secrets_path: Path) -> tuple[str, str, bool]:
     with secrets_path.open("rb") as plist_file:
         secrets = plistlib.load(plist_file)
 
     base_value = secrets.get("SUPABASE_URL")
     anon_key = secrets.get("SUPABASE_ANON_KEY")
+    auth_web_value = secrets.get("AUTH_WEB_URL")
     if (
         not isinstance(base_value, str)
         or not isinstance(anon_key, str)
+        or not isinstance(auth_web_value, str)
         or not anon_key
     ):
         raise VerificationError("The packaged authentication configuration is incomplete.")
@@ -99,43 +140,118 @@ def auth_user_endpoint(secrets_path: Path) -> tuple[str, str]:
         raise VerificationError("The packaged authentication service URL is invalid.")
 
     path = f"{parsed.path.rstrip('/')}/auth/v1/user"
-    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", "")), anon_key
+    endpoint = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+    return endpoint, anon_key, auth_backend_origins_match(auth_web_value, base_value)
 
 
-def verify(callback_path: Path, secrets_path: Path) -> None:
-    callback_url = callback_path.read_text(encoding="utf-8").strip()
-    params = callback_params(callback_url)
-    endpoint, anon_key = auth_user_endpoint(secrets_path)
+def request_headers(
+    params: dict[str, str],
+    anon_key: str,
+) -> dict[str, str]:
+    return {
+        "Authorization": f"{params['token_type']} {params['access_token']}",
+        "apikey": anon_key,
+    }
 
+
+def has_native_request_contract(headers: dict[str, str]) -> bool:
+    required = {**NATIVE_TRANSPORT_HEADERS, **NATIVE_SDK_HEADERS}
+    return (
+        all(headers.get(name) == value for name, value in required.items())
+        and headers.get("Authorization", "").lower().startswith("bearer ")
+        and bool(headers.get("apikey"))
+    )
+
+
+def request_status(endpoint: str, headers: dict[str, str]) -> int | None:
     try:
-        request = urllib.request.Request(
-            endpoint,
-            headers={
-                "Authorization": f"{params['token_type']} {params['access_token']}",
-                "apikey": anon_key,
-            },
-            method="GET",
-        )
+        request = urllib.request.Request(endpoint, headers=headers, method="GET")
         opener = urllib.request.build_opener(NoRedirectHandler())
         with opener.open(request, timeout=20) as response:
-            status = response.status
+            return response.status
     except urllib.error.HTTPError as error:
         status = error.code
+        error.close()
+        return status
     except (urllib.error.URLError, TimeoutError):
-        raise VerificationError(
-            "The packaged authentication service could not be reached."
-        ) from None
+        return None
     except Exception:
         raise VerificationError(
             "The packaged authentication request could not be completed safely."
         ) from None
 
-    if status != 200:
+
+def report_status(label: str, status: int | None) -> None:
+    if status is None:
+        print(f"{label}: unavailable.")
+    else:
+        print(f"{label}: HTTP {status}.")
+
+
+def jwt_issuer_matches_auth_service(access_token: str, endpoint: str) -> bool:
+    try:
+        segments = access_token.split(".")
+        if len(segments) != 3 or not segments[1] or len(segments[1]) > 32_768:
+            return False
+        payload_segment = segments[1]
+        payload_segment += "=" * (-len(payload_segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_segment))
+        issuer = payload.get("iss") if isinstance(payload, dict) else None
+        expected_issuer = endpoint.removesuffix("/user").rstrip("/")
+        return isinstance(issuer, str) and issuer.rstrip("/") == expected_issuer
+    except Exception:
+        return False
+
+
+def verify(callback_path: Path, secrets_path: Path) -> None:
+    callback_url = callback_path.read_text(encoding="utf-8").strip()
+    params = callback_params(callback_url)
+    endpoint, anon_key, origins_match = auth_user_endpoint(secrets_path)
+
+    print(
+        "Browser and packaged authentication service origins match: "
+        f"{'true' if origins_match else 'false'}."
+    )
+    if not origins_match:
         raise VerificationError(
-            f"The callback token was rejected by the packaged authentication service "
-            f"(HTTP {status})."
+            "The browser and packaged authentication services do not share an origin."
         )
-    print("Callback token accepted by the packaged authentication service (HTTP 200).")
+
+    issuer_matches = jwt_issuer_matches_auth_service(params["access_token"], endpoint)
+    print(
+        "Callback JWT issuer matches packaged authentication service: "
+        f"{'true' if issuer_matches else 'false'}."
+    )
+
+    baseline_headers = request_headers(params, anon_key)
+    transport_headers = {**baseline_headers, **NATIVE_TRANSPORT_HEADERS}
+    native_headers = {**transport_headers, **NATIVE_SDK_HEADERS}
+    if not has_native_request_contract(native_headers):
+        raise VerificationError(
+            "The native-parity authentication request contract is incomplete."
+        )
+
+    baseline_status = request_status(endpoint, baseline_headers)
+    transport_status = request_status(endpoint, transport_headers)
+    native_status = request_status(endpoint, native_headers)
+
+    report_status("Baseline packaged authentication request", baseline_status)
+    report_status("App-like transport authentication request", transport_status)
+    report_status("Native-parity packaged authentication request", native_status)
+
+    if native_status is None:
+        raise VerificationError(
+            "The packaged authentication service could not be reached."
+        )
+    if native_status != 200:
+        raise VerificationError(
+            "The callback token was rejected by the native-parity packaged "
+            f"authentication request (HTTP {native_status})."
+        )
+    print(
+        "Callback token accepted by the native-parity packaged authentication "
+        "request (HTTP 200)."
+    )
 
 
 def self_test() -> None:
@@ -169,6 +285,40 @@ def self_test() -> None:
         except VerificationError:
             continue
         raise AssertionError("A malformed synthetic callback was accepted.")
+
+    baseline_headers = request_headers(params, "synthetic-anon-key")
+    native_headers = {
+        **baseline_headers,
+        **NATIVE_TRANSPORT_HEADERS,
+        **NATIVE_SDK_HEADERS,
+    }
+    assert has_native_request_contract(native_headers)
+    for required_name in (*NATIVE_TRANSPORT_HEADERS, *NATIVE_SDK_HEADERS):
+        incomplete_headers = native_headers.copy()
+        incomplete_headers.pop(required_name)
+        assert not has_native_request_contract(incomplete_headers)
+
+    def synthetic_jwt(issuer: str) -> str:
+        encoded_payload = base64.urlsafe_b64encode(
+            json.dumps({"iss": issuer}).encode("utf-8")
+        ).decode("ascii").rstrip("=")
+        return f"synthetic.{encoded_payload}.signature"
+
+    endpoint = "https://aidictation.example/auth/v1/user"
+    assert jwt_issuer_matches_auth_service(
+        synthetic_jwt("https://aidictation.example/auth/v1"), endpoint
+    )
+    assert not jwt_issuer_matches_auth_service(
+        synthetic_jwt("https://other.example/auth/v1"), endpoint
+    )
+    assert auth_backend_origins_match(
+        "https://aidictation.example/auth",
+        "https://aidictation.example",
+    )
+    assert not auth_backend_origins_match(
+        "https://login.aidictation.example/auth",
+        "https://aidictation.example",
+    )
     print("Verified support-safe callback token validation inputs.")
 
 

--- a/scripts/validate_release_transcription_config.py
+++ b/scripts/validate_release_transcription_config.py
@@ -79,18 +79,38 @@ def validate_auth_backend_agreement(config: dict[str, Any], supabase_url: str) -
     another, which rejects it — sign-in silently returns the user to signed-out.
     """
     auth_web_url = required_string(config, "AUTH_WEB_URL")
-    auth_host = parse.urlparse(auth_web_url).netloc.lower()
-    api_host = parse.urlparse(supabase_url).netloc.lower()
-    if not auth_host or not api_host:
-        fail(f"AUTH_WEB_URL and SUPABASE_URL must be absolute URLs, got {auth_web_url!r} and {supabase_url!r}")
-    # The legacy split (a standalone auth page in front of Supabase) is gone:
-    # aidictation.com now serves both the sign-in page and the auth API.
-    if "aidictation.com" in (auth_host, api_host) and auth_host != api_host:
-        fail(
-            f"AUTH_WEB_URL host ({auth_host}) and SUPABASE_URL host ({api_host}) "
-            "point at different backends; sessions minted by one will be rejected by the other"
+    auth_parts = parse.urlparse(auth_web_url)
+    api_parts = parse.urlparse(supabase_url)
+    try:
+        auth_origin = (
+            auth_parts.scheme.lower(),
+            auth_parts.hostname,
+            auth_parts.port if auth_parts.port is not None else 443,
         )
-    print(f"auth backend ok: auth_host={auth_host}, api_host={api_host}")
+        api_origin = (
+            api_parts.scheme.lower(),
+            api_parts.hostname,
+            api_parts.port if api_parts.port is not None else 443,
+        )
+    except ValueError:
+        fail("AUTH_WEB_URL and SUPABASE_URL must use valid HTTPS origins")
+    if (
+        auth_origin[0] != "https"
+        or api_origin[0] != "https"
+        or not auth_origin[1]
+        or not api_origin[1]
+        or auth_parts.username
+        or auth_parts.password
+        or api_parts.username
+        or api_parts.password
+    ):
+        fail("AUTH_WEB_URL and SUPABASE_URL must use valid HTTPS origins")
+    if auth_origin != api_origin:
+        fail(
+            "AUTH_WEB_URL and SUPABASE_URL must share the exact origin so the "
+            "packaged app validates sessions against the service that issued them"
+        )
+    print("auth backend ok: exact origin agreement verified")
 
 
 def generate_speech_sample(output: Path) -> None:
@@ -228,7 +248,6 @@ def validate_authenticated_user(
 
     supabase_url = required_string(config, "SUPABASE_URL").rstrip("/")
     anon_key = required_string(config, "SUPABASE_ANON_KEY")
-    validate_auth_backend_agreement(config, supabase_url)
     token_url = f"{supabase_url}/auth/v1/token?grant_type=password"
     token = http_json(
         token_url,
@@ -292,6 +311,10 @@ def main() -> None:
     api_key = required_string(config, "CustomTranscriptionKey")
 
     validate_model(endpoint, model)
+    validate_auth_backend_agreement(
+        config,
+        required_string(config, "SUPABASE_URL").rstrip("/"),
+    )
     print(
         "config ok: "
         f"endpoint={parse.urlparse(endpoint).netloc}, model={model}, "


### PR DESCRIPTION
Summary

- fail the release config check before archive build when the browser and packaged authentication services do not share the exact HTTPS origin
- compare the callback token with baseline, app-like transport, and pinned native Supabase request contracts without following redirects
- report only origin/issuer booleans and HTTP status codes
- keep callbacks, tokens, URLs, bodies, identities, and provider error messages out of output

Verification

- callback verifier support-safe self-test
- config-only same-origin acceptance and split-origin rejection
- local HTTP transport header assertion
- git diff check

The separately authorized release-environment URL correction is not part of this code diff; no secret value was read or exposed.