### PR TITLE
Target Android 16 for Play compliance

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          packages: platform-tools platforms;android-36 build-tools;35.0.0
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -356,6 +358,8 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          packages: platform-tools platforms;android-36 build-tools;35.0.0
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -167,6 +167,47 @@ jobs:
       - name: Validate auth configuration
         run: python3 scripts/validate_client_config.py --allow-missing
 
+      - name: Validate Android release gating contract
+        shell: bash
+        run: |
+          python3 - "$GITHUB_WORKSPACE/.github/workflows/android-play-release.yml" "$GITHUB_WORKSPACE/.github/workflows/android-build.yml" <<'PY'
+          from pathlib import Path
+          import sys
+
+          play = Path(sys.argv[1]).read_text()
+          build = Path(sys.argv[2]).read_text()
+          expression_open = "$" + "{{"
+
+          required_play_contract = (
+              f"PLAY_TRACK: {expression_open} github.event_name == 'push' && 'internal' || inputs.play_track }}",
+              f"PLAY_RELEASE_STATUS: {expression_open} github.event_name == 'push' && 'completed' || inputs.release_status }}",
+              f"PLAY_PUBLISH_MODE: {expression_open} github.event_name == 'push' && 'upload' || inputs.publish_mode }}",
+              f"PUBLISH_GITHUB_RELEASE: {expression_open} github.event_name == 'workflow_dispatch' && inputs.publish_github_release || false }}",
+              'if [ "${PLAY_TRACK}" != "internal" ] || [ "${PLAY_RELEASE_STATUS}" != "completed" ] || [ "${PLAY_PUBLISH_MODE}" != "upload" ]; then',
+              'if [ "${PUBLISH_GITHUB_RELEASE}" != "false" ]; then',
+              'if [ "${PLAY_TRACK}" = "production" ] && { [ "${PLAY_PUBLISH_MODE}" != "promote" ] || [ "${PLAY_PROMOTE_FROM_TRACK}" != "internal" ]; }; then',
+              "needs: publish",
+              "inputs.publish_github_release &&",
+              "inputs.release_status == 'completed' &&",
+              'gh release edit "${RELEASE_TAG}"',
+              "--draft=false",
+          )
+          missing = [entry for entry in required_play_contract if entry not in play]
+          if missing:
+              raise SystemExit(f"Android Play release gate is missing: {missing}")
+          if "vars.ANDROID_PLAY_TRACK" in play or "vars.ANDROID_PLAY_RELEASE_STATUS" in play:
+              raise SystemExit("Repository variables must not redirect a tag-triggered Play release")
+
+          release_marker = "- name: Create or update " + "draft GitHub Release"
+          release_block = build.split(release_marker, 1)
+          if len(release_block) != 2 or "gh release create" not in release_block[1] or "--draft" not in release_block[1]:
+              raise SystemExit("Tag release creation must remain draft-only")
+          if "--draft=false" in release_block[1]:
+              raise SystemExit("Tag workflow must not publish a GitHub release")
+
+          print("Android tag releases are internal-only and GitHub draft-only.")
+          PY
+
       - name: Write local.properties
         run: |
           normalize_transcription_model() {
@@ -527,7 +568,7 @@ jobs:
           path: AIDictationAndroid/app/build/outputs/bundle/release/*.aab
           retention-days: 90
 
-      - name: Publish GitHub Release
+      - name: Create or update draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release_meta.outputs.tag }}
@@ -536,10 +577,15 @@ jobs:
         run: |
           actual_sha="$(git rev-parse HEAD)"
           if [ "$actual_sha" != "$GITHUB_SHA" ] || [ "$RELEASE_TAG_SHA" != "$GITHUB_SHA" ]; then
-            echo "Refusing to publish artifacts not built from event commit $GITHUB_SHA." >&2
+            echo "Refusing to stage artifacts not built from event commit $GITHUB_SHA." >&2
             exit 1
           fi
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            is_draft=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+            if [ "$is_draft" != "true" ]; then
+              echo "Refusing to modify already-public release $RELEASE_TAG from a tag build." >&2
+              exit 1
+            fi
             gh release upload "$RELEASE_TAG" release-artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
             gh release edit "$RELEASE_TAG" --title "$RELEASE_TITLE" --repo "$GITHUB_REPOSITORY"
           else
@@ -547,5 +593,11 @@ jobs:
               --target "$RELEASE_TAG_SHA" \
               --title "$RELEASE_TITLE" \
               --generate-notes \
+              --draft \
               --repo "$GITHUB_REPOSITORY"
+          fi
+          is_draft=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          if [ "$is_draft" != "true" ]; then
+            echo "Tag build must leave release $RELEASE_TAG in draft state." >&2
+            exit 1
           fi

--- a/.github/workflows/android-play-listing.yml
+++ b/.github/workflows/android-play-listing.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: platform-tools platforms;android-35 build-tools;35.0.0
+          packages: platform-tools platforms;android-36 build-tools;35.0.0
 
       - name: Decode Google Play credentials
         run: |

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -33,7 +33,7 @@ on:
       publish_mode:
         description: 'Upload a new bundle, or promote an existing version code between tracks'
         required: true
-        default: upload
+        default: promote
         type: choice
         options:
           - upload
@@ -48,6 +48,11 @@ on:
           - alpha
           - beta
           - production
+      publish_github_release:
+        description: 'Publish the existing draft GitHub release after a verified internal-to-production promotion'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -72,10 +77,11 @@ jobs:
         working-directory: ${{ env.ANDROID_PROJECT_DIR }}
 
     env:
-      PLAY_TRACK: ${{ inputs.play_track || vars.ANDROID_PLAY_TRACK || 'production' }}
-      PLAY_RELEASE_STATUS: ${{ inputs.release_status || vars.ANDROID_PLAY_RELEASE_STATUS || 'completed' }}
-      PLAY_PUBLISH_MODE: ${{ inputs.publish_mode || 'upload' }}
-      PLAY_PROMOTE_FROM_TRACK: ${{ inputs.promote_from_track || 'internal' }}
+      PLAY_TRACK: ${{ github.event_name == 'push' && 'internal' || inputs.play_track }}
+      PLAY_RELEASE_STATUS: ${{ github.event_name == 'push' && 'completed' || inputs.release_status }}
+      PLAY_PUBLISH_MODE: ${{ github.event_name == 'push' && 'upload' || inputs.publish_mode }}
+      PLAY_PROMOTE_FROM_TRACK: ${{ github.event_name == 'push' && 'internal' || inputs.promote_from_track }}
+      PUBLISH_GITHUB_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_github_release || false }}
       PLAY_RELEASE_NAME: ''
       PARAKEET_RUNTIME: onnx
 
@@ -120,6 +126,29 @@ jobs:
         id: release_meta
         shell: bash
         run: |
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            if [ "${PLAY_TRACK}" != "internal" ] || [ "${PLAY_RELEASE_STATUS}" != "completed" ] || [ "${PLAY_PUBLISH_MODE}" != "upload" ]; then
+              echo "Tag-triggered releases must upload to the internal track with completed status." >&2
+              exit 1
+            fi
+            if [ "${PUBLISH_GITHUB_RELEASE}" != "false" ]; then
+              echo "Tag-triggered releases cannot publish the draft GitHub release." >&2
+              exit 1
+            fi
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${PLAY_TRACK}" = "production" ] && { [ "${PLAY_PUBLISH_MODE}" != "promote" ] || [ "${PLAY_PROMOTE_FROM_TRACK}" != "internal" ]; }; then
+              echo "Production is promotion-only and must promote the verified internal release." >&2
+              exit 1
+            fi
+            if [ "${PUBLISH_GITHUB_RELEASE}" = "true" ] && { [ "${PLAY_TRACK}" != "production" ] || [ "${PLAY_RELEASE_STATUS}" != "completed" ] || [ "${PLAY_PUBLISH_MODE}" != "promote" ] || [ "${PLAY_PROMOTE_FROM_TRACK}" != "internal" ]; }; then
+              echo "Publishing the GitHub release requires a completed internal-to-production Play promotion." >&2
+              exit 1
+            fi
+          else
+            echo "Unsupported release event ${GITHUB_EVENT_NAME}." >&2
+            exit 1
+          fi
+
           case "${PLAY_TRACK}" in
             internal|alpha|beta|production) ;;
             *)
@@ -419,3 +448,80 @@ jobs:
             args+=(-PPLAY_RELEASE_NAME="${PLAY_RELEASE_NAME}")
           fi
           ./gradlew "${args[@]}"
+
+  publish_github_release:
+    name: Publish verified GitHub release
+    needs: publish
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish_github_release &&
+      inputs.play_track == 'production' &&
+      inputs.release_status == 'completed' &&
+      inputs.publish_mode == 'promote' &&
+      inputs.promote_from_track == 'internal'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout verified release tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: false
+          ref: ${{ format('refs/tags/{0}', inputs.release_tag) }}
+
+      - name: Publish existing draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        shell: bash
+        run: |
+          if [[ ! "${RELEASE_TAG}" =~ ^android-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid Android release tag ${RELEASE_TAG}." >&2
+            exit 1
+          fi
+
+          version_name=$(sed -nE 's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p; s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*configValue\("VERSION_NAME", "([^"]+)".*/\1/p' AIDictationAndroid/app/build.gradle.kts | head -n 1)
+          if [ "${RELEASE_TAG}" != "android-v${version_name}" ]; then
+            echo "Tag ${RELEASE_TAG} does not match Android versionName ${version_name}." >&2
+            exit 1
+          fi
+
+          tag_sha=$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")
+          actual_sha=$(git rev-parse HEAD)
+          git fetch origin main --prune
+          if [ "${actual_sha}" != "${tag_sha}" ] || ! git merge-base --is-ancestor "${tag_sha}" origin/main; then
+            echo "Release tag ${RELEASE_TAG} must be checked out exactly and reachable from origin/main." >&2
+            exit 1
+          fi
+
+          is_draft=$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)
+          if [ "${is_draft}" != "true" ]; then
+            echo "Release ${RELEASE_TAG} must exist as a draft before publication." >&2
+            exit 1
+          fi
+
+          artifact_version="${RELEASE_TAG#android-v}"
+          verification_dir="${RUNNER_TEMP}/github-release-verification"
+          mkdir -p "${verification_dir}"
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --dir "${verification_dir}"
+          test -s "${verification_dir}/AIDictation-Android-${artifact_version}.apk"
+          test -s "${verification_dir}/AIDictation-Android-${artifact_version}.aab"
+          test -s "${verification_dir}/SHA256SUMS.txt"
+          (
+            cd "${verification_dir}"
+            shasum -a 256 -c SHA256SUMS.txt
+          )
+
+          gh release edit "${RELEASE_TAG}" \
+            --draft=false \
+            --latest \
+            --repo "${GITHUB_REPOSITORY}"
+          published_draft_state=$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)
+          if [ "${published_draft_state}" != "false" ]; then
+            echo "Release ${RELEASE_TAG} was not published." >&2
+            exit 1
+          fi

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
-          packages: platform-tools platforms;android-35 build-tools;35.0.0
+          packages: platform-tools platforms;android-36 build-tools;35.0.0
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/AIDictationAndroid/CI.md
+++ b/AIDictationAndroid/CI.md
@@ -15,15 +15,20 @@ on-device transcription, and builds the Play AAB with the `parakeet_v3_pack`
 asset pack.
 
 `.github/workflows/android-play-release.yml` publishes the signed release
-AAB to Google Play from the same `android-v<versionName>` tag. Tag pushes ship
-to the track selected by repository variable `ANDROID_PLAY_TRACK`, with
-`production` as the workflow fallback and a `completed` release status. The
-repository is currently configured for `production`. Set the variable to
-`internal`, `alpha`, `beta`, or `production` to change the automatic target. Set
-`ANDROID_PLAY_RELEASE_STATUS` to `draft`, `inProgress`, `halted`, or
-`completed` to override the default. The workflow uses the checked-in
+AAB to Google Play from the same `android-v<versionName>` tag. Tag pushes are
+hard-coded to upload a completed release to the `internal` track; repository
+variables cannot redirect a tag to production. The workflow uses the checked-in
 `versionName` and `versionCode`, and rejects tags that do not point at a commit
 reachable from `origin/main`.
+
+The tag-triggered Android build uploads private GitHub Actions artifacts and
+creates or updates only a draft GitHub release. After the internal artifact has
+passed Android 16 device checks and Play pre-launch verification, manually run
+the Play release workflow for the same tag with `publish_mode=promote`,
+`promote_from_track=internal`, and `play_track=production`. Production uploads
+are rejected; production is promotion-only. Set `publish_github_release=true`
+to publish the checksummed draft GitHub release only after the Play promotion
+succeeds.
 
 Google Play version codes are monotonic across every track. Because an earlier
 internal upload used version code `1007`, Android release version codes must be
@@ -77,13 +82,6 @@ runs, matching the local-developer layout described in
 |---|---|
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64` | Preferred. Base64-encoded Google Play service account JSON. |
 | `ANDROID_PUBLISHER_CREDENTIALS` | Optional fallback. Raw Google Play service account JSON used by Gradle Play Publisher. |
-
-Optional repository variables:
-
-| Variable | Purpose |
-|---|---|
-| `ANDROID_PLAY_TRACK` | Automatic tagged release target. Defaults to `production`; supported values are `internal`, `alpha`, `beta`, and `production`. |
-| `ANDROID_PLAY_RELEASE_STATUS` | Automatic tagged release status. Defaults to `completed`; supported values are `draft`, `inProgress`, `halted`, and `completed`. |
 
 Before the workflow can publish, create the app once in Play Console and
 upload the first signed AAB manually if the package has never been uploaded.

--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -150,7 +150,7 @@ val authApiKey = configValue("SUPABASE_ANON_KEY").ifBlank {
 
 android {
     namespace = "com.whispermate.aidictation"
-    compileSdk = 35
+    compileSdk = 36
 
     signingConfigs {
         create("release") {
@@ -164,7 +164,7 @@ android {
     defaultConfig {
         applicationId = "com.aidictation.app"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = configValue("VERSION_CODE", "1029").toInt()
         versionName = configValue("VERSION_NAME", "0.0.32")
 

--- a/AIDictationAndroid/app/src/main/AndroidManifest.xml
+++ b/AIDictationAndroid/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AIDictation"
-        tools:targetApi="35">
+        tools:targetApi="36">
 
         <!-- Main Activity -->
         <activity

--- a/AIDictationAndroid/gradle/libs.versions.toml
+++ b/AIDictationAndroid/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.10.1"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 lifecycleRuntimeKtx = "2.8.7"

--- a/AIDictationAndroid/gradle/wrapper/gradle-wrapper.properties
+++ b/AIDictationAndroid/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/AIDictationAndroid/simple-keyboard/build.gradle.kts
+++ b/AIDictationAndroid/simple-keyboard/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "rkr.simplekeyboard.inputmethod"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
## What

- Target Android 16 (API 36) in the shipped app and keep the optional keyboard module aligned.
- Upgrade Android Gradle Plugin to 8.10.1 and Gradle to 8.11.1, the supported toolchain for API 36.
- Install Android platform 36 in Android build and Play release workflows while retaining the AGP 8.10 default Build Tools 35.0.0.
- Gate every tag-triggered Play upload to the `internal` track with completed status.
- Make tag-triggered GitHub releases draft-only; public GitHub publication is coupled to an explicit, completed internal-to-production Play promotion.
- Add a CI contract assertion and operator documentation for these release gates.

## Why

Google Play requires new apps and updates to target Android 16 (API 36) starting August 31, 2026. The repository still targeted API 35. The former tag path could also publish directly to production and make release assets public before device and Play verification.

## Verification

- Baseline API 35 checkout: lint, unit tests, and debug assembly passed.
- Patched clean remote checkout: lint, 74 unit tests, and debug assembly passed.
- Signed release APK and App Bundle assembled with an ephemeral verification key.
- Bundletool validation passed; bundle configuration reports `PAGE_ALIGNMENT_16K`.
- Universal APK and release APK passed 16 KB zip alignment checks.
- All 14 shipped arm64-v8a/x86_64 native libraries have at least 16 KB LOAD alignment.
- Client configuration validation and the 14-test Android audio recovery suite passed.
- Release-gating contract passes locally: tags are internal-only and GitHub draft-only.
- Workflow YAML and embedded Bash syntax validation passed; `git diff --check` passed.
- Hosted CI is rerunning for the amended head.

## Release sequence enforced by this PR

This PR does **not** bump the Android version, publish to Google Play, or notify users.

1. Merge the reviewed PR.
2. Bump to a unique version and tag the exact `main` commit.
3. The tag builds private Actions artifacts, uploads a completed internal Play release, and creates only a draft GitHub release.
4. Verify the same artifact on Android 16/API 36, including a 16 KB environment: sign-in/account loading, microphone and transcription, offline model delivery, accessibility overlay/text insertion, predictive back, edge-to-edge, and adaptive layouts.
5. Confirm Play accepts target API 36, signing and asset delivery, and passes the pre-launch report.
6. Explicitly promote the existing internal version code to production. Only a completed internal-to-production promotion may publish the checksummed draft GitHub release.
7. Use a staged production rollout and verify the public Play listing/download before notifying users.

Official references:

- https://support.google.com/googleplay/android-developer/answer/11926878
- https://developer.android.com/about/versions/16/setup-sdk
- https://developer.android.com/build/releases/agp-8-10-0-release-notes
- https://developer.android.com/about/versions/16/behavior-changes-16
- https://developer.android.com/guide/practices/page-sizes
