### PR TITLE
Prepare Android 0.0.33 internal release

### DIFF
--- a/AIDictationAndroid/app/build.gradle.kts
+++ b/AIDictationAndroid/app/build.gradle.kts
@@ -165,8 +165,8 @@ android {
         applicationId = "com.aidictation.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = configValue("VERSION_CODE", "1029").toInt()
-        versionName = configValue("VERSION_NAME", "0.0.32")
+        versionCode = configValue("VERSION_CODE", "1030").toInt()
+        versionName = configValue("VERSION_NAME", "0.0.33")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## What

- Bump the Android release from 0.0.32 (1029) to 0.0.33 (1030).
- Keep the change limited to the default Android version metadata.

## Why

Version code 1029 is already published. The Android 16 build needs a unique, monotonic version before it can be uploaded to the protected internal Play track.

## Verification

- Android client configuration validation passed.
- Lint passed.
- 74 unit tests passed with no failures.
- Debug APK assembly passed.
- APK metadata reports package `com.aidictation.app`, version `0.0.33` (1030), compile/target API 36, and minimum API 26.
- `git diff --check` passed.

## Release gate

Merging this PR does not create a tag or publish an artifact. The `android-v0.0.33` tag will be created only after the API 36/16 KB device preflight is sufficient to begin the internal release. The tag path is internal-Play-only and GitHub-draft-only.
