### PR TITLE
Fix intermittent hotkey failure after sleep/wake cycles

### DIFF
--- a/Whishpermate/Whispermate/Services/FnKeyMonitor.swift
+++ b/Whishpermate/Whispermate/Services/FnKeyMonitor.swift
@@ -14,10 +14,17 @@ class FnKeyMonitor {
     private var resolver = FnKeyGestureResolver()
     private var suppressUntil: Date?
     private(set) var consumePureFnEvents = false
+    private var screenWakeObserver: NSObjectProtocol?
+    private var systemWakeObserver: NSObjectProtocol?
+    private var wakeRecoveryGeneration = 0
+    private var wakeRecoveryWorkItem: DispatchWorkItem?
+    private var lastTapCreationTime: Date?
 
     private enum Constants {
         static let suppressionDuration: TimeInterval = 0.5
         static let eventTapHealthInterval: TimeInterval = 5.0
+        static let wakeRecoveryDelays: [TimeInterval] = [0.5, 1.5, 3.0, 5.0, 8.0]
+        static let tapRecreationCooldown: TimeInterval = 2.0
     }
 
     var onFnPressed: (() -> Void)?
@@ -58,8 +65,100 @@ class FnKeyMonitor {
             return event
         }
 
+        setupWakeObservers()
         startEventTapHealthTimer()
         DebugLog.info("Fn key monitors registered", context: "FnKeyMonitor")
+    }
+
+    private func setupWakeObservers() {
+        removeWakeObservers()
+
+        screenWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleWakeRecovery(reason: "screens did wake")
+        }
+
+        systemWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleWakeRecovery(reason: "system did wake")
+        }
+    }
+
+    private func removeWakeObservers() {
+        if let observer = screenWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            screenWakeObserver = nil
+        }
+        if let observer = systemWakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            systemWakeObserver = nil
+        }
+    }
+
+    private func scheduleWakeRecovery(reason: String) {
+        guard consumePureFnEvents else { return }
+
+        wakeRecoveryGeneration += 1
+        wakeRecoveryWorkItem?.cancel()
+        DebugLog.info("Scheduling Fn event tap wake recovery: \(reason)", context: "FnKeyMonitor")
+
+        runWakeRecoveryAttempt(reason: reason, generation: wakeRecoveryGeneration, attempt: 0)
+    }
+
+    private func runWakeRecoveryAttempt(reason: String, generation: Int, attempt: Int) {
+        guard attempt < Constants.wakeRecoveryDelays.count else {
+            DebugLog.info("Fn event tap wake recovery exhausted after \(attempt) attempts", context: "FnKeyMonitor")
+            return
+        }
+
+        let delay = Constants.wakeRecoveryDelays[attempt]
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, generation == self.wakeRecoveryGeneration else { return }
+
+            interruptGesture(reason: "wake recovery attempt \(attempt + 1)")
+            forceRecreateTap(reason: "wake recovery (\(reason))")
+
+            if self.eventTap != nil, let tap = self.eventTap, CGEvent.tapIsEnabled(tap: tap) {
+                DebugLog.info("Fn event tap wake recovery succeeded on attempt \(attempt + 1)", context: "FnKeyMonitor")
+            } else {
+                DebugLog.info("Fn event tap wake recovery attempt \(attempt + 1) failed, scheduling retry", context: "FnKeyMonitor")
+                self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
+            }
+        }
+        wakeRecoveryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    /// Tears down and recreates the event tap from scratch. Used for wake recovery
+    /// and when the tap appears non-functional despite being "enabled".
+    private func forceRecreateTap(reason: String) {
+        guard consumePureFnEvents else { return }
+
+        if let cooldownStart = lastTapCreationTime,
+           Date().timeIntervalSince(cooldownStart) < Constants.tapRecreationCooldown
+        {
+            DebugLog.info("Skipping tap recreation due to cooldown", context: "FnKeyMonitor")
+            return
+        }
+
+        DebugLog.info("Force recreating Fn event tap: \(reason)", context: "FnKeyMonitor")
+
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source = eventTapRunLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+                eventTapRunLoopSource = nil
+            }
+            eventTap = nil
+        }
+
+        setupConsumingEventTap()
     }
 
     /// Stop monitoring the Fn key
@@ -67,6 +166,9 @@ class FnKeyMonitor {
         DebugLog.info("Stopping Fn key monitoring", context: "FnKeyMonitor")
 
         stopEventTapHealthTimer()
+        removeWakeObservers()
+        wakeRecoveryWorkItem?.cancel()
+        wakeRecoveryWorkItem = nil
 
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
@@ -114,7 +216,7 @@ class FnKeyMonitor {
 
                 if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
                     monitor.interruptGesture(reason: "tap disabled event \(type.rawValue)")
-                    monitor.enableEventTap(reason: "callback disabled event \(type.rawValue)")
+                    monitor.forceRecreateTap(reason: "callback disabled event \(type.rawValue)")
                     return Unmanaged.passUnretained(event)
                 }
 
@@ -140,6 +242,7 @@ class FnKeyMonitor {
             CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
+        lastTapCreationTime = Date()
         DebugLog.info("Consuming Fn event tap created and enabled", context: "FnKeyMonitor")
     }
 
@@ -168,12 +271,12 @@ class FnKeyMonitor {
 
         guard let tap = eventTap else {
             DebugLog.info("Fn event tap missing during health check; recreating", context: "FnKeyMonitor")
-            setupConsumingEventTap()
+            forceRecreateTap(reason: "health check (nil tap)")
             return
         }
 
         if !CGEvent.tapIsEnabled(tap: tap) {
-            enableEventTap(reason: "health check")
+            forceRecreateTap(reason: "health check (tap disabled)")
         }
     }
 
@@ -229,5 +332,6 @@ class FnKeyMonitor {
 
     deinit {
         stopMonitoring()
+        removeWakeObservers()
     }
 }

--- a/Whishpermate/Whispermate/Services/FnKeyMonitor.swift
+++ b/Whishpermate/Whispermate/Services/FnKeyMonitor.swift
@@ -16,6 +16,7 @@ class FnKeyMonitor {
     private(set) var consumePureFnEvents = false
     private var screenWakeObserver: NSObjectProtocol?
     private var systemWakeObserver: NSObjectProtocol?
+    private var sessionActiveObserver: NSObjectProtocol?
     private var wakeRecoveryGeneration = 0
     private var wakeRecoveryWorkItem: DispatchWorkItem?
     private var lastTapCreationTime: Date?
@@ -88,6 +89,14 @@ class FnKeyMonitor {
         ) { [weak self] _ in
             self?.scheduleWakeRecovery(reason: "system did wake")
         }
+
+        sessionActiveObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleWakeRecovery(reason: "session did become active (unlock)")
+        }
     }
 
     private func removeWakeObservers() {
@@ -98,6 +107,10 @@ class FnKeyMonitor {
         if let observer = systemWakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             systemWakeObserver = nil
+        }
+        if let observer = sessionActiveObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            sessionActiveObserver = nil
         }
     }
 
@@ -113,7 +126,7 @@ class FnKeyMonitor {
 
     private func runWakeRecoveryAttempt(reason: String, generation: Int, attempt: Int) {
         guard attempt < Constants.wakeRecoveryDelays.count else {
-            DebugLog.info("Fn event tap wake recovery exhausted after \(attempt) attempts", context: "FnKeyMonitor")
+            DebugLog.info("Fn event tap wake recovery series complete after \(attempt) attempts", context: "FnKeyMonitor")
             return
         }
 
@@ -124,12 +137,8 @@ class FnKeyMonitor {
             interruptGesture(reason: "wake recovery attempt \(attempt + 1)")
             forceRecreateTap(reason: "wake recovery (\(reason))")
 
-            if self.eventTap != nil, let tap = self.eventTap, CGEvent.tapIsEnabled(tap: tap) {
-                DebugLog.info("Fn event tap wake recovery succeeded on attempt \(attempt + 1)", context: "FnKeyMonitor")
-            } else {
-                DebugLog.info("Fn event tap wake recovery attempt \(attempt + 1) failed, scheduling retry", context: "FnKeyMonitor")
-                self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
-            }
+            DebugLog.info("Fn event tap wake recovery attempt \(attempt + 1) done, scheduling next", context: "FnKeyMonitor")
+            self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
         }
         wakeRecoveryWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
@@ -149,16 +158,22 @@ class FnKeyMonitor {
 
         DebugLog.info("Force recreating Fn event tap: \(reason)", context: "FnKeyMonitor")
 
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            if let source = eventTapRunLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-                eventTapRunLoopSource = nil
-            }
-            eventTap = nil
-        }
-
+        invalidateAndClearTap()
         setupConsumingEventTap()
+    }
+
+    /// Invalidates the Mach port and clears all tap references. Karabiner #4508
+    /// found that not invalidating leaves disabled taps in WindowServer.
+    private func invalidateAndClearTap() {
+        guard let tap = eventTap else { return }
+
+        CGEvent.tapEnable(tap: tap, enable: false)
+        if let source = eventTapRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            eventTapRunLoopSource = nil
+        }
+        CFMachPortInvalidate(tap)
+        eventTap = nil
     }
 
     /// Stop monitoring the Fn key
@@ -170,14 +185,7 @@ class FnKeyMonitor {
         wakeRecoveryWorkItem?.cancel()
         wakeRecoveryWorkItem = nil
 
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            if let source = eventTapRunLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
-                eventTapRunLoopSource = nil
-            }
-            eventTap = nil
-        }
+        invalidateAndClearTap()
 
         if let monitor = globalMonitor {
             NSEvent.removeMonitor(monitor)
@@ -216,7 +224,7 @@ class FnKeyMonitor {
 
                 if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
                     monitor.interruptGesture(reason: "tap disabled event \(type.rawValue)")
-                    monitor.forceRecreateTap(reason: "callback disabled event \(type.rawValue)")
+                    monitor.handleTapDisabledInCallback(type: type)
                     return Unmanaged.passUnretained(event)
                 }
 
@@ -275,6 +283,12 @@ class FnKeyMonitor {
             return
         }
 
+        if !CFMachPortIsValid(tap) {
+            DebugLog.info("Fn event tap invalid during health check; recreating", context: "FnKeyMonitor")
+            forceRecreateTap(reason: "health check (invalid port)")
+            return
+        }
+
         if !CGEvent.tapIsEnabled(tap: tap) {
             forceRecreateTap(reason: "health check (tap disabled)")
         }
@@ -286,6 +300,47 @@ class FnKeyMonitor {
         interruptGesture(reason: reason)
         CGEvent.tapEnable(tap: tap, enable: true)
         DebugLog.info("Re-enabled Fn event tap after \(reason)", context: "FnKeyMonitor")
+    }
+
+    /// Called from the tap callback when macOS disables the tap. Apple and
+    /// libuiohook #184 found that tapEnable is the reliable recovery from the
+    /// callback; recreating from inside the callback is racy. We enable here,
+    /// then hop to the main queue and only recreate if enable didn't stick.
+    private func handleTapDisabledInCallback(type: CGEventType) {
+        guard let tap = eventTap else { return }
+
+        CGEvent.tapEnable(tap: tap, enable: true)
+        DebugLog.info("Re-enabled Fn event tap in callback for disabled event \(type.rawValue)", context: "FnKeyMonitor")
+
+        DispatchQueue.main.async { [weak self] in
+            self?.recreateTapIfStillBroken(reason: "callback disabled event \(type.rawValue)")
+        }
+    }
+
+    /// After re-enabling in the callback, check if the tap is truly functional.
+    /// Recreate only if still missing, invalid, or disabled.
+    private func recreateTapIfStillBroken(reason: String) {
+        guard consumePureFnEvents else { return }
+
+        guard let tap = eventTap else {
+            DebugLog.info("Fn event tap nil after callback enable; recreating", context: "FnKeyMonitor")
+            forceRecreateTap(reason: reason)
+            return
+        }
+
+        if !CFMachPortIsValid(tap) {
+            DebugLog.info("Fn event tap invalid after callback enable; recreating", context: "FnKeyMonitor")
+            forceRecreateTap(reason: reason)
+            return
+        }
+
+        if !CGEvent.tapIsEnabled(tap: tap) {
+            DebugLog.info("Fn event tap still disabled after callback enable; recreating", context: "FnKeyMonitor")
+            forceRecreateTap(reason: reason)
+            return
+        }
+
+        DebugLog.info("Fn event tap recovered via callback enable", context: "FnKeyMonitor")
     }
 
     /// Ends an in-flight gesture and tells the app about it. Without the callback a

--- a/Whishpermate/Whispermate/Services/HotkeyManager.swift
+++ b/Whishpermate/Whispermate/Services/HotkeyManager.swift
@@ -79,6 +79,7 @@ class HotkeyManager: ObservableObject {
     private var flagsMonitor: Any?
     private var screenWakeObserver: NSObjectProtocol?
     private var systemWakeObserver: NSObjectProtocol?
+    private var sessionActiveObserver: NSObjectProtocol?
     private var appActivationObserver: NSObjectProtocol?
     private var eventTapHealthTimer: Timer?
     private var accessibilityRetryScheduled = false
@@ -122,6 +123,14 @@ class HotkeyManager: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             self?.scheduleHotkeyReregistrationAfterWake(reason: "system did wake")
+        }
+
+        sessionActiveObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.sessionDidBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleHotkeyReregistrationAfterWake(reason: "session did become active (unlock)")
         }
 
         // Granting Accessibility happens in System Settings, so the app is
@@ -558,7 +567,7 @@ class HotkeyManager: ObservableObject {
 
     private func runWakeRecoveryAttempt(reason: String, generation: Int, attempt: Int) {
         guard attempt < Constants.wakeRecoveryDelays.count else {
-            DebugLog.info("Hotkey wake recovery exhausted after \(attempt) attempts", context: "HotkeyManager LOG")
+            DebugLog.info("Hotkey wake recovery series complete after \(attempt) attempts", context: "HotkeyManager LOG")
             return
         }
 
@@ -570,23 +579,11 @@ class HotkeyManager: ObservableObject {
             self.releaseHeldHotkeys(reason: "wake recovery attempt \(attempt + 1)")
             self.registerHotkey()
 
-            let tapWorking = self.verifyEventTapFunctional()
-            let fnWorking = self.fnKeyMonitor == nil || self.fnKeyMonitor?.consumePureFnEvents == true
-
-            if tapWorking && fnWorking {
-                DebugLog.info("Hotkey wake recovery succeeded on attempt \(attempt + 1)", context: "HotkeyManager LOG")
-            } else {
-                DebugLog.info("Hotkey wake recovery attempt \(attempt + 1) incomplete (tap=\(tapWorking), fn=\(fnWorking)), scheduling retry", context: "HotkeyManager LOG")
-                self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
-            }
+            DebugLog.info("Hotkey wake recovery attempt \(attempt + 1) done, scheduling next", context: "HotkeyManager LOG")
+            self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
         }
         wakeRecoveryWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
-    }
-
-    private func verifyEventTapFunctional() -> Bool {
-        guard let tap = eventTap else { return true }
-        return CGEvent.tapIsEnabled(tap: tap)
     }
 
     private func startEventTapHealthTimer() {
@@ -607,6 +604,12 @@ class HotkeyManager: ObservableObject {
     private func validateEventTapHealth() {
         guard let tap = eventTap else { return }
 
+        if !CFMachPortIsValid(tap) {
+            DebugLog.info("Hotkey event tap invalid during health check; recreating", context: "HotkeyManager LOG")
+            forceRecreateEventTap(reason: "health check (invalid port)")
+            return
+        }
+
         if !CGEvent.tapIsEnabled(tap: tap) {
             forceRecreateEventTap(reason: "health check (tap disabled)")
         }
@@ -619,6 +622,46 @@ class HotkeyManager: ObservableObject {
         releaseHeldHotkeys(reason: reason)
         CGEvent.tapEnable(tap: tap, enable: true)
         logFunctionKeyDiagnostic("Re-enabled hotkey event tap after \(reason)")
+    }
+
+    /// Called from the tap callback when macOS disables the tap. Apple and
+    /// libuiohook #184 found that tapEnable is the reliable recovery from the
+    /// callback; recreating from inside the callback is racy. We enable here,
+    /// then hop to the main queue and only recreate if enable didn't stick.
+    private func handleTapDisabledInCallback(type: CGEventType) {
+        guard let tap = eventTap else { return }
+
+        releaseHeldHotkeys(reason: "tap disabled in callback \(type.rawValue)")
+        CGEvent.tapEnable(tap: tap, enable: true)
+        DebugLog.info("Re-enabled hotkey event tap in callback for disabled event \(type.rawValue)", context: "HotkeyManager LOG")
+
+        DispatchQueue.main.async { [weak self] in
+            self?.recreateTapIfStillBroken(reason: "callback disabled event \(type.rawValue)")
+        }
+    }
+
+    /// After re-enabling in the callback, check if the tap is truly functional.
+    /// Recreate only if still missing, invalid, or disabled.
+    private func recreateTapIfStillBroken(reason: String) {
+        guard let tap = eventTap else {
+            DebugLog.info("Hotkey event tap nil after callback enable; recreating", context: "HotkeyManager LOG")
+            forceRecreateEventTap(reason: reason)
+            return
+        }
+
+        if !CFMachPortIsValid(tap) {
+            DebugLog.info("Hotkey event tap invalid after callback enable; recreating", context: "HotkeyManager LOG")
+            forceRecreateEventTap(reason: reason)
+            return
+        }
+
+        if !CGEvent.tapIsEnabled(tap: tap) {
+            DebugLog.info("Hotkey event tap still disabled after callback enable; recreating", context: "HotkeyManager LOG")
+            forceRecreateEventTap(reason: reason)
+            return
+        }
+
+        DebugLog.info("Hotkey event tap recovered via callback enable", context: "HotkeyManager LOG")
     }
 
     /// Tears down and recreates the event tap from scratch. Used when the tap
@@ -634,15 +677,7 @@ class HotkeyManager: ObservableObject {
         DebugLog.info("Force recreating hotkey event tap: \(reason)", context: "HotkeyManager LOG")
 
         releaseHeldHotkeys(reason: reason)
-
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            if let source = eventTapRunLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-                eventTapRunLoopSource = nil
-            }
-            eventTap = nil
-        }
+        invalidateAndClearTap()
 
         let dictationHotkey = currentHotkey
         let cmdHotkey = commandHotkey
@@ -656,6 +691,20 @@ class HotkeyManager: ObservableObject {
         } else if needsKeyTap {
             setupEventTap()
         }
+    }
+
+    /// Invalidates the Mach port and clears all tap references. Karabiner #4508
+    /// found that not invalidating leaves disabled taps in WindowServer.
+    private func invalidateAndClearTap() {
+        guard let tap = eventTap else { return }
+
+        CGEvent.tapEnable(tap: tap, enable: false)
+        if let source = eventTapRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            eventTapRunLoopSource = nil
+        }
+        CFMachPortInvalidate(tap)
+        eventTap = nil
     }
 
     /// Ends any push-to-talk hold that was in flight when the tap went away.
@@ -798,7 +847,7 @@ class HotkeyManager: ObservableObject {
 
     private func handleCGEvent(proxy _: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            forceRecreateEventTap(reason: "callback disabled event \(type.rawValue)")
+            handleTapDisabledInCallback(type: type)
             return Unmanaged.passUnretained(event)
         }
 
@@ -872,16 +921,7 @@ class HotkeyManager: ObservableObject {
         wakeRecoveryWorkItem?.cancel()
         wakeRecoveryWorkItem = nil
 
-        // Disable and remove event tap
-        if let tap = eventTap {
-            DebugLog.info("Disabling event tap", context: "HotkeyManager LOG")
-            CGEvent.tapEnable(tap: tap, enable: false)
-            if let source = eventTapRunLoopSource {
-                CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-                eventTapRunLoopSource = nil
-            }
-            eventTap = nil
-        }
+        invalidateAndClearTap()
 
         if let monitor = globalMonitor {
             DebugLog.info("Removing global monitor", context: "HotkeyManager LOG")
@@ -985,6 +1025,9 @@ class HotkeyManager: ObservableObject {
         }
         if let systemWakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(systemWakeObserver)
+        }
+        if let sessionActiveObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(sessionActiveObserver)
         }
         if let appActivationObserver {
             NotificationCenter.default.removeObserver(appActivationObserver)

--- a/Whishpermate/Whispermate/Services/HotkeyManager.swift
+++ b/Whishpermate/Whispermate/Services/HotkeyManager.swift
@@ -22,6 +22,10 @@ class HotkeyManager: ObservableObject {
         }
     }
 
+    /// Indicates the Fn hotkey is configured but not fully functional due to
+    /// missing Accessibility permission.
+    @Published private(set) var isFnHotkeyDegraded: Bool = false
+
     // MARK: - Public Callbacks
 
     var onHotkeyPressed: (() -> Void)?
@@ -48,6 +52,9 @@ class HotkeyManager: ObservableObject {
         // Command mode has not been shipped publicly yet. Keep any saved value
         // untouched, but do not register it until the feature is enabled.
         static let commandHotkeyEnabled = false
+        static let wakeRecoveryDelays: [TimeInterval] = [0.5, 1.5, 3.0, 5.0, 8.0]
+        static let accessibilityPollInterval: TimeInterval = 30.0
+        static let tapRecreationCooldown: TimeInterval = 2.0
     }
 
     private enum Diagnostics {
@@ -76,6 +83,10 @@ class HotkeyManager: ObservableObject {
     private var eventTapHealthTimer: Timer?
     private var accessibilityRetryScheduled = false
     private var accessibilityRetryAttempts = 0
+    private var wakeRecoveryGeneration = 0
+    private var wakeRecoveryWorkItem: DispatchWorkItem?
+    private var accessibilityPollingTimer: Timer?
+    private var lastTapCreationTime: Date?
 
     // All press/release/double-tap/toggle state lives in these two resolvers, one
     // per channel. See HotkeyGestureResolver — it is covered by unit tests, this
@@ -136,6 +147,7 @@ class HotkeyManager: ObservableObject {
             "Accessibility permission restored while the app was away; re-registering Fn hotkey",
             context: "HotkeyManager LOG"
         )
+        isFnHotkeyDegraded = false
         accessibilityRetryScheduled = false
         accessibilityRetryAttempts = 0
         registerHotkey()
@@ -378,13 +390,56 @@ class HotkeyManager: ObservableObject {
                 "Fn dictation hotkey needs Accessibility permission; waiting for the user to grant it",
                 context: "HotkeyManager LOG"
             )
+            isFnHotkeyDegraded = true
             scheduleAccessibilityRetryForFnHotkey()
+            startAccessibilityPollingTimer()
         } else {
+            isFnHotkeyDegraded = false
             accessibilityRetryScheduled = false
             accessibilityRetryAttempts = 0
+            stopAccessibilityPollingTimer()
         }
 
         fnKeyMonitor?.startMonitoring(consumePureFnEvents: accessibilityTrusted)
+    }
+
+    private func startAccessibilityPollingTimer() {
+        stopAccessibilityPollingTimer()
+
+        let timer = Timer(timeInterval: Constants.accessibilityPollInterval, repeats: true) { [weak self] _ in
+            self?.checkAccessibilityAndRecoverIfNeeded()
+        }
+        accessibilityPollingTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+        DebugLog.info("Started accessibility polling timer", context: "HotkeyManager LOG")
+    }
+
+    private func stopAccessibilityPollingTimer() {
+        accessibilityPollingTimer?.invalidate()
+        accessibilityPollingTimer = nil
+    }
+
+    private func checkAccessibilityAndRecoverIfNeeded() {
+        guard let hotkey = currentHotkey, isFnOnlyHotkey(hotkey), !deferRegistration else {
+            stopAccessibilityPollingTimer()
+            isFnHotkeyDegraded = false
+            return
+        }
+
+        guard fnKeyMonitor?.consumePureFnEvents == false else {
+            stopAccessibilityPollingTimer()
+            isFnHotkeyDegraded = false
+            return
+        }
+
+        if AXIsProcessTrusted() {
+            DebugLog.info("Accessibility permission restored; re-registering Fn hotkey from polling timer", context: "HotkeyManager LOG")
+            stopAccessibilityPollingTimer()
+            isFnHotkeyDegraded = false
+            accessibilityRetryScheduled = false
+            accessibilityRetryAttempts = 0
+            registerHotkey()
+        }
     }
 
     private func scheduleAccessibilityRetryForFnHotkey() {
@@ -454,6 +509,7 @@ class HotkeyManager: ObservableObject {
         eventTapRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), eventTapRunLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        lastTapCreationTime = Date()
         startEventTapHealthTimer()
 
         DebugLog.info("Event tap created and enabled (includes flagsChanged for modifier keys)", context: "HotkeyManager LOG")
@@ -484,6 +540,7 @@ class HotkeyManager: ObservableObject {
         eventTapRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), eventTapRunLoopSource, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
+        lastTapCreationTime = Date()
         startEventTapHealthTimer()
 
         DebugLog.info("Mouse event tap created and enabled", context: "HotkeyManager LOG")
@@ -493,12 +550,43 @@ class HotkeyManager: ObservableObject {
         DebugLog.info("Wake notification (\(reason)) - scheduling hotkey re-registration", context: "HotkeyManager LOG")
         guard !deferRegistration, currentHotkey != nil || commandHotkey != nil else { return }
 
-        // Small delay to let macOS finish rebuilding input devices/event taps after wake.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            guard let self else { return }
-            guard !self.deferRegistration, self.currentHotkey != nil || self.commandHotkey != nil else { return }
-            self.registerHotkey()
+        wakeRecoveryGeneration += 1
+        wakeRecoveryWorkItem?.cancel()
+
+        runWakeRecoveryAttempt(reason: reason, generation: wakeRecoveryGeneration, attempt: 0)
+    }
+
+    private func runWakeRecoveryAttempt(reason: String, generation: Int, attempt: Int) {
+        guard attempt < Constants.wakeRecoveryDelays.count else {
+            DebugLog.info("Hotkey wake recovery exhausted after \(attempt) attempts", context: "HotkeyManager LOG")
+            return
         }
+
+        let delay = Constants.wakeRecoveryDelays[attempt]
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, generation == self.wakeRecoveryGeneration else { return }
+            guard !self.deferRegistration, self.currentHotkey != nil || self.commandHotkey != nil else { return }
+
+            self.releaseHeldHotkeys(reason: "wake recovery attempt \(attempt + 1)")
+            self.registerHotkey()
+
+            let tapWorking = self.verifyEventTapFunctional()
+            let fnWorking = self.fnKeyMonitor == nil || self.fnKeyMonitor?.consumePureFnEvents == true
+
+            if tapWorking && fnWorking {
+                DebugLog.info("Hotkey wake recovery succeeded on attempt \(attempt + 1)", context: "HotkeyManager LOG")
+            } else {
+                DebugLog.info("Hotkey wake recovery attempt \(attempt + 1) incomplete (tap=\(tapWorking), fn=\(fnWorking)), scheduling retry", context: "HotkeyManager LOG")
+                self.runWakeRecoveryAttempt(reason: reason, generation: generation, attempt: attempt + 1)
+            }
+        }
+        wakeRecoveryWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func verifyEventTapFunctional() -> Bool {
+        guard let tap = eventTap else { return true }
+        return CGEvent.tapIsEnabled(tap: tap)
     }
 
     private func startEventTapHealthTimer() {
@@ -520,7 +608,7 @@ class HotkeyManager: ObservableObject {
         guard let tap = eventTap else { return }
 
         if !CGEvent.tapIsEnabled(tap: tap) {
-            enableEventTap(reason: "health check")
+            forceRecreateEventTap(reason: "health check (tap disabled)")
         }
     }
 
@@ -531,6 +619,43 @@ class HotkeyManager: ObservableObject {
         releaseHeldHotkeys(reason: reason)
         CGEvent.tapEnable(tap: tap, enable: true)
         logFunctionKeyDiagnostic("Re-enabled hotkey event tap after \(reason)")
+    }
+
+    /// Tears down and recreates the event tap from scratch. Used when the tap
+    /// becomes non-functional after wake or timeout.
+    private func forceRecreateEventTap(reason: String) {
+        if let cooldownStart = lastTapCreationTime,
+           Date().timeIntervalSince(cooldownStart) < Constants.tapRecreationCooldown
+        {
+            DebugLog.info("Skipping tap recreation due to cooldown", context: "HotkeyManager LOG")
+            return
+        }
+
+        DebugLog.info("Force recreating hotkey event tap: \(reason)", context: "HotkeyManager LOG")
+
+        releaseHeldHotkeys(reason: reason)
+
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source = eventTapRunLoopSource {
+                CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+                eventTapRunLoopSource = nil
+            }
+            eventTap = nil
+        }
+
+        let dictationHotkey = currentHotkey
+        let cmdHotkey = commandHotkey
+        let needsDictationFnMonitor = dictationHotkey.map(isFnOnlyHotkey) ?? false
+        let needsMouseTap = (dictationHotkey?.isMouseButton == true) || (cmdHotkey?.isMouseButton == true)
+        let needsKeyTap = (dictationHotkey != nil && dictationHotkey?.isMouseButton != true && !needsDictationFnMonitor) ||
+            (cmdHotkey != nil && cmdHotkey?.isMouseButton != true)
+
+        if needsMouseTap {
+            setupMouseEventTap()
+        } else if needsKeyTap {
+            setupEventTap()
+        }
     }
 
     /// Ends any push-to-talk hold that was in flight when the tap went away.
@@ -673,7 +798,7 @@ class HotkeyManager: ObservableObject {
 
     private func handleCGEvent(proxy _: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            enableEventTap(reason: "callback disabled event \(type.rawValue)")
+            forceRecreateEventTap(reason: "callback disabled event \(type.rawValue)")
             return Unmanaged.passUnretained(event)
         }
 
@@ -743,6 +868,9 @@ class HotkeyManager: ObservableObject {
         DebugLog.info("unregisterHotkey called", context: "HotkeyManager LOG")
 
         stopEventTapHealthTimer()
+        stopAccessibilityPollingTimer()
+        wakeRecoveryWorkItem?.cancel()
+        wakeRecoveryWorkItem = nil
 
         // Disable and remove event tap
         if let tap = eventTap {
@@ -850,11 +978,16 @@ class HotkeyManager: ObservableObject {
 
     deinit {
         unregisterHotkey()
+        stopAccessibilityPollingTimer()
+        wakeRecoveryWorkItem?.cancel()
         if let screenWakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(screenWakeObserver)
         }
         if let systemWakeObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(systemWakeObserver)
+        }
+        if let appActivationObserver {
+            NotificationCenter.default.removeObserver(appActivationObserver)
         }
     }
 }

--- a/Whishpermate/Whispermate/Views/SettingsView.swift
+++ b/Whishpermate/Whispermate/Views/SettingsView.swift
@@ -749,6 +749,22 @@ struct SettingsView: View {
                     }
                     .padding(.vertical, 2)
 
+                    if hotkeyManager.isFnHotkeyDegraded {
+                        HStack(spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(Color.orange)
+                            Text("Fn hotkey requires Accessibility permission to work. Grant access in Permissions below.")
+                                .dsFont(.label)
+                                .foregroundStyle(Color.dsMutedForeground)
+                            Spacer()
+                        }
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                        .background(Color.orange.opacity(0.1))
+                        .cornerRadius(6)
+                        .padding(.top, 4)
+                    }
+
                     Divider()
                         .padding(.vertical, 6)
 

--- a/scripts/validate_macos_hotkey_options.swift
+++ b/scripts/validate_macos_hotkey_options.swift
@@ -30,6 +30,12 @@ private func run() throws {
         ),
         encoding: .utf8
     )
+    let resolverSource = try String(
+        contentsOf: root.appendingPathComponent(
+            "Whishpermate/Whispermate/Services/HotkeyGestureResolver.swift"
+        ),
+        encoding: .utf8
+    )
 
     try requireContains(
         pickerSource,
@@ -66,11 +72,34 @@ private func run() throws {
         )
     }
 
+    // Modifier-only hotkey logic now lives in HotkeyGestureResolver
     try requireContains(
-        managerSource,
-        "let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63, 179]",
-        "the event path does not recognize all left modifier-only keycodes"
+        resolverSource,
+        "static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63, 179]",
+        "the resolver does not recognize all left modifier-only keycodes"
     )
+    try requireContains(
+        resolverSource,
+        "private func flagsChangedKeyMatches(_ eventKeyCode: UInt16, binding: Binding) -> Bool",
+        "modifier-only events are not matched by their physical keycode"
+    )
+    try requireContains(
+        resolverSource,
+        "return eventKeyCode == binding.keyCode",
+        "left and right modifier keys are no longer distinguished"
+    )
+    try requireContains(
+        resolverSource,
+        "mutating func flagsChanged(keyCode: UInt16, modifiers: NSEvent.ModifierFlags, at time: TimeInterval) -> Outcome",
+        "modifier press and release state is no longer derived from flagsChanged events"
+    )
+    try requireContains(
+        resolverSource,
+        "let isPressed = modifiers.intersection(required) == required",
+        "modifier pressed state is no longer computed from event flags"
+    )
+
+    // HotkeyManager still observes flagsChanged via the global event tap
     try requireContains(
         managerSource,
         "(1 << CGEventType.flagsChanged.rawValue)",
@@ -78,23 +107,8 @@ private func run() throws {
     )
     try requireContains(
         managerSource,
-        "flagsChangedKeyMatchesHotkey(eventKeyCode: keyCode, hotkey: hotkey)",
-        "modifier-only events are not matched by their physical keycode"
-    )
-    try requireContains(
-        managerSource,
-        "return eventKeyCode == hotkey.keyCode",
-        "left and right modifier keys are no longer distinguished"
-    )
-    try requireContains(
-        managerSource,
-        "let isModifierPressed = isRequiredModifierPressed(for: hotkey, eventModifiers: modifiers)",
-        "modifier press and release state is no longer derived from event flags"
-    )
-    try requireContains(
-        managerSource,
-        "handled = handleModifierFlagsStateChange(isModifierPressed: isModifierPressed, isDictation: true) || handled",
-        "modifier-only dictation no longer reaches the press/release state machine"
+        "handleFlagsChangedEvent(_ event: NSEvent)",
+        "modifier-only events are no longer dispatched to the resolver"
     )
 
     let existingCombinationContracts = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Customer reported (info@loiaconoluca.com) that the global hotkey stops working intermittently:
- 14 Aug: Global hotkey stopped starting dictation. Tried new hotkey, update, restart, permissions. Still dead.
- Support had them remove+readd the app in System Settings › Accessibility. That temporarily fixed it.
- 22 Aug: Worked last night, dead again this morning. Permissions still look granted. Handy and Wispr Flow still work on the same Mac.

This is a confirmed intermittent bug: TCC reset revives the hotkey, then it dies overnight / after sleep without the user changing anything.

## Root Cause Analysis

1. **Event taps become silently non-functional after sleep**: Even if `CGEvent.tapIsEnabled(tap:)` returns `true`, the tap might not actually receive events after macOS wakes from sleep. This is a known macOS quirk.

2. **Single-shot wake recovery was insufficient**: The previous code used a single 1-second delay after wake, which isn't enough on all systems.

3. **FnKeyMonitor had its own wake issues**: The Fn-only hotkey path didn't have wake observers, and when AX permission was lost/regained, the monitor stayed in passive mode.

4. **No AX permission recovery after onboarding**: If AX permission was lost and regained (e.g., after TCC reset), the app only checked for 30 seconds at startup, not continuously.

## Changes (First Commit)

### FnKeyMonitor.swift
- Add wake notification observers (`screensDidWakeNotification`, `didWakeNotification`)
- Implement progressive wake recovery with 5 retry attempts (0.5s, 1.5s, 3s, 5s, 8s)
- Force tap recreation instead of just re-enabling on wake/timeout
- Add cooldown to prevent rapid tap recreation thrashing

### HotkeyManager.swift
- Replace single-shot 1s delay with progressive wake recovery (same retry delays)
- Add `forceRecreateEventTap()` method for more robust tap recovery
- Add periodic AX permission polling (every 30s) to recover degraded Fn hotkey
- Add `isFnHotkeyDegraded` published property to surface state in UI
- Clean up wake recovery work items and timers properly

### SettingsView.swift
- Show warning banner when Fn hotkey is configured but AX permission is missing
- Directs user to grant Accessibility permission in Permissions section

## Changes (Second Commit) - OSS-Learned Gaps

After comparing with solutions in UnnaturalScrollWheels #119, SwiftShift #169, Karabiner-Elements #4508, libuiohook #184, Ghostty #11819, and LinearMouse:

### 1. Invalidate the Mach port on every teardown (Karabiner #4508)
- Add `CFMachPortInvalidate` before dropping tap references
- Extract `invalidateAndClearTap()` helper for consistent teardown
- Without this, disabled taps leak in WindowServer (Karabiner saw 1100+ leaked taps overnight)

### 2. Do not recreate tap from inside its own CGEvent callback (libuiohook #184)
- On `.tapDisabledByTimeout`/`.tapDisabledByUserInput`, call `tapEnable` first
- Hop to main queue, only recreate if enable didn't stick
- Check tap is nil, `!CFMachPortIsValid`, or still `!tapIsEnabled`
- Recreating from callback was racy; enable is the reliable recovery

### 3. Wake recovery must not short-circuit on tapIsEnabled == true (Ghostty #11819)
- A tap can report enabled yet deliver zero events after sleep/lock
- Always run the full retry series (0.5/1.5/3/5/8s) on wake
- Add `NSWorkspace.sessionDidBecomeActiveNotification` for lock/unlock recovery
- Health check: also recreate if `!CFMachPortIsValid`, not just `!tapIsEnabled`

## How the Fix Works

The fix ensures hotkeys self-heal after sleep/wake cycles by:
1. Listening for screen wake, system wake, and session unlock notifications in both `HotkeyManager` and `FnKeyMonitor`
2. Running all 5 progressive retry attempts (0.5s, 1.5s, 3s, 5s, 8s) regardless of apparent tap state
3. Invalidating the Mach port on every teardown to avoid WindowServer tap leaks
4. In callbacks: enabling first, then hopping off the tap thread to check and recreate if needed
5. Health check (every 5s) now also catches invalid ports, not just disabled taps
6. Continuously polling for AX permission recovery when Fn hotkey is degraded (every 30s)
7. Surfacing the degraded state in the Settings UI so users know to check permissions

## How to Verify

1. **Sleep/wake test**:
   - Set Fn key as dictation hotkey
   - Verify hotkey works
   - Close MacBook lid or put Mac to sleep
   - Wait at least a few seconds, then wake
   - Press hotkey - should work without needing to restart app or toggle permissions

2. **Overnight test**:
   - Set Fn key as dictation hotkey
   - Leave Mac overnight (will go through multiple sleep cycles)
   - Next morning, press hotkey - should work

3. **Lock/unlock test**:
   - Set Fn key as dictation hotkey
   - Lock screen (Ctrl+Cmd+Q) or let it auto-lock
   - Unlock
   - Press hotkey - should work

4. **Permission recovery test**:
   - Set Fn key as dictation hotkey
   - Remove app from System Settings › Privacy & Security › Accessibility
   - Settings should show warning banner about degraded hotkey
   - Re-add app to Accessibility
   - Hotkey should recover within 30 seconds without app restart
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ad05eca-f1c0-43e7-9ba7-8205efcedd38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad05eca-f1c0-43e7-9ba7-8205efcedd38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790050891&installation_model_id=432087&pr_number=97&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F97&signature=7f29c54f6af5e69fee2a11fff70fe2342308e43adb28b672efbb18b5c4c76248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->