### PR TITLE
Set up Cloud Agent Android build environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,11 @@
 - Retry transient transport failures only under the shared bounded policy. Do not retry permanent `4xx` responses or fully received malformed responses. Split rejected `413` leaves sequentially without replaying completed chunks.
 - Treat cleanup as optional after complete raw recognition. Cleanup failure or empty output keeps the raw transcript.
 - Delete and Clear must either refuse active work or win durably over it. Never submit audio known to be truncated or unfinalized, and never delete the only recoverable source.
+
+## Cursor Cloud specific instructions
+
+- Cloud Agents run on Linux (x86_64). Only the Android client (`AIDictationAndroid/`) is buildable here; the macOS/iOS (Xcode) and Windows (.NET desktop) targets require their own operating systems.
+- Prepare the machine with `scripts/cloud-agent-android-setup.sh`. It is idempotent and installs JDK 17 plus the Android SDK, pins Gradle to JDK 17, and generates the git-ignored `AIDictationAndroid/local.properties`.
+- Build and test the same way CI does (`.github/workflows/android-build.yml`), from `AIDictationAndroid/`: `./gradlew lint`, `./gradlew testDebugUnitTest`, and `./gradlew assembleDebug`. Config validation: `python3 scripts/validate_client_config.py --allow-missing`.
+- Without transcription/auth secrets the debug build uses public defaults and is unconfigured but valid; supply `TRANSCRIPTION_API_KEY`, `AIDICTATION_POST_PROCESSING_KEY`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `AUTH_WEB_URL` (see `AIDictationAndroid/CI.md`) for a fully configured build.
+- The Android emulator does not run here: the host rejects nested hardware virtualization (`kernel BUG ... arch/x86/kvm/x86.c`), so validate via unit tests plus APK inspection (`aapt dump badging`) rather than an emulator.

--- a/scripts/cloud-agent-android-setup.sh
+++ b/scripts/cloud-agent-android-setup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent setup for the AIDictationAndroid Gradle project.
+#
+# Prepares a Linux (x86_64 Debian/Ubuntu) machine to build and test the Android
+# app the same way `.github/workflows/android-build.yml` does: JDK 17, the
+# Android SDK (platform-tools, platforms;android-36, build-tools;35.0.0), and a
+# generated local.properties. Safe to run repeatedly; every step is guarded so a
+# warm snapshot re-runs it as a fast no-op.
+#
+# The macOS/iOS (Xcode) and Windows (.NET desktop) targets cannot be built on
+# Linux, so this environment scopes to the Android client.
+set -euo pipefail
+
+JDK_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+ANDROID_SDK_DIR="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+CMDLINE_TOOLS_VERSION="14742923"
+ANDROID_PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/AIDictationAndroid"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+# 1. JDK 17 (matches the Android CI toolchain; AGP 8.10 requires JDK 17+).
+if [ ! -x "$JDK_HOME/bin/java" ]; then
+  log "Installing JDK 17"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq openjdk-17-jdk-headless unzip wget
+else
+  log "JDK 17 already present"
+fi
+
+# 2. Android SDK command-line tools + required packages.
+if [ ! -x "$ANDROID_SDK_DIR/cmdline-tools/latest/bin/sdkmanager" ]; then
+  log "Installing Android command-line tools"
+  mkdir -p "$ANDROID_SDK_DIR/cmdline-tools"
+  tmp_zip="$(mktemp --suffix=.zip)"
+  wget -q "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip" -O "$tmp_zip"
+  rm -rf "$ANDROID_SDK_DIR/cmdline-tools/latest" "$ANDROID_SDK_DIR/cmdline-tools/cmdline-tools"
+  unzip -q "$tmp_zip" -d "$ANDROID_SDK_DIR/cmdline-tools"
+  mv "$ANDROID_SDK_DIR/cmdline-tools/cmdline-tools" "$ANDROID_SDK_DIR/cmdline-tools/latest"
+  rm -f "$tmp_zip"
+else
+  log "Android command-line tools already present"
+fi
+
+export ANDROID_HOME="$ANDROID_SDK_DIR"
+export ANDROID_SDK_ROOT="$ANDROID_SDK_DIR"
+export JAVA_HOME="$JDK_HOME"
+SDKMANAGER="$ANDROID_SDK_DIR/cmdline-tools/latest/bin/sdkmanager"
+
+log "Accepting SDK licenses and installing SDK packages"
+yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
+"$SDKMANAGER" "platform-tools" "platforms;android-36" "build-tools;35.0.0" >/dev/null
+
+# 3. Point Gradle at JDK 17 regardless of the machine's default `java`.
+mkdir -p "$HOME/.gradle"
+if ! grep -qs "^org.gradle.java.home=" "$HOME/.gradle/gradle.properties" 2>/dev/null; then
+  log "Pinning Gradle to JDK 17"
+  echo "org.gradle.java.home=$JDK_HOME" >> "$HOME/.gradle/gradle.properties"
+fi
+
+# 4. Generate local.properties (git-ignored) from CI-provided env vars when set,
+#    otherwise fall back to the public defaults used for unconfigured debug
+#    builds. Never overwrites an existing developer-provided file.
+LOCAL_PROPS="$ANDROID_PROJECT_DIR/local.properties"
+if [ ! -f "$LOCAL_PROPS" ]; then
+  log "Writing local.properties"
+  cat > "$LOCAL_PROPS" <<EOF
+sdk.dir=$ANDROID_SDK_DIR
+TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY:-}
+TRANSCRIPTION_ENDPOINT=${TRANSCRIPTION_ENDPOINT:-https://writingmate.ai/api/openai/v1/audio/transcriptions}
+TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL:-groq/whisper-large-v3-turbo}
+PARAKEET_RUNTIME=
+PACKAGE_OFFLINE_MODELS=false
+AIDICTATION_POST_PROCESSING_KEY=${AIDICTATION_POST_PROCESSING_KEY:-}
+AIDICTATION_POST_PROCESSING_ENDPOINT=${AIDICTATION_POST_PROCESSING_ENDPOINT:-https://writingmate.ai/api/openai/v1/chat/completions}
+AIDICTATION_POST_PROCESSING_MODEL=${AIDICTATION_POST_PROCESSING_MODEL:-openai/gpt-oss-20b}
+SUPABASE_URL=${SUPABASE_URL:-}
+SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY:-}
+AUTH_WEB_URL=${AUTH_WEB_URL:-https://aidictation.com/auth}
+EOF
+else
+  log "local.properties already present; leaving it untouched"
+fi
+
+# 5. Warm the Gradle wrapper distribution and dependency cache so the first
+#    interactive build is fast. Resolves dependencies without building.
+log "Warming Gradle"
+( cd "$ANDROID_PROJECT_DIR" && chmod +x gradlew && ./gradlew --no-daemon help >/dev/null )
+
+log "Android environment ready"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Sets up a reproducible Cloud Agent development environment for this repository. On Linux (x86_64) the Android client (`AIDictationAndroid/`) is the only buildable target — the macOS/iOS (Xcode) and Windows (.NET desktop) apps require their own operating systems — so this environment scopes to Android and mirrors `.github/workflows/android-build.yml`.

- `scripts/cloud-agent-android-setup.sh`: idempotent setup that installs JDK 17 and the Android SDK (`platform-tools`, `platforms;android-36`, `build-tools;35.0.0`), pins Gradle to JDK 17, and generates the git-ignored `AIDictationAndroid/local.properties` (from CI env vars when present, else public defaults).
- `AGENTS.md`: new "Cursor Cloud specific instructions" section documenting the buildable scope, canonical build/test commands, and the emulator limitation.

## Validation (on this VM)

| Check | Result |
| --- | --- |
| `scripts/validate_client_config.py --allow-missing` + unit test | Passed |
| `./gradlew lint` | BUILD SUCCESSFUL |
| `./gradlew testDebugUnitTest` | BUILD SUCCESSFUL (79 unit tests) |
| `./gradlew assembleDebug` | BUILD SUCCESSFUL — 150 MB `app-debug.apk` |
| APK `aapt dump badging` | `com.aidictation.app` v0.0.37 (1034), launchable `MainActivity` |
| Install idempotence | Setup script + build re-run as no-ops (all `UP-TO-DATE`) |

## Notes

The Android emulator cannot run in this environment: the host rejects nested hardware virtualization (`kernel BUG ... arch/x86/kvm/x86.c`, `kvm_spurious_fault`), so end-to-end validation uses unit tests plus APK inspection instead of an emulator. This is a host-level limitation, not a repository issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4ce8d0e-3eac-4089-a7f8-a1a46b13ecd4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4ce8d0e-3eac-4089-a7f8-a1a46b13ecd4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790123697&installation_model_id=432087&pr_number=99&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F99&signature=f007a2370ba83d4c97ff100c7b9f9cf32a39fbdf76141ec64b6f757dfa4362b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->