### PR TITLE
Add Windows microphone permission help article

### DIFF
--- a/website-content/README.md
+++ b/website-content/README.md
@@ -1,0 +1,24 @@
+# Website content staging
+
+This directory contains content intended for the aidictation.com website. The website source lives in the private `writingmate/speak-it-fast` submodule.
+
+## Integration instructions
+
+### help/windows-microphone-permission.md
+
+**Target URL:** `/faq/windows-microphone` or `/help/windows-microphone` (match existing routing)
+
+**Steps to integrate:**
+
+1. Open the `speak-it-fast` repository.
+2. Add this help article using the same pattern as the existing FAQ page.
+3. If the site has a `/faq` index, add a link to this new page from there.
+4. Update the website submodule pointer in this repo after deploying.
+
+**SEO metadata:**
+- Title: `Windows Microphone Permission | AI Dictation Help`
+- Description: `Fix microphone access issues on Windows. Enable the three privacy toggles so AI Dictation can hear you.`
+
+**Structured data:** Consider adding FAQPage schema with these questions:
+- "Why can't AI Dictation hear my microphone on Windows?"
+- "How do I enable microphone access for AI Dictation on Windows?"

--- a/website-content/help/windows-microphone-permission.md
+++ b/website-content/help/windows-microphone-permission.md
@@ -1,0 +1,26 @@
+# Windows microphone permission
+
+AI Dictation needs access to your Windows microphone so it can hear you. If the blue overlay appears when you press the shortcut but nothing is recorded, Windows may be blocking microphone access.
+
+## Enable microphone access
+
+1. Open **Start > Settings > Privacy & security > Microphone**.
+2. Turn **Microphone access** to **On**.
+3. Turn **Let apps access your microphone** to **On**.
+4. Turn **Let desktop apps access your microphone** to **On**. AI Dictation is a desktop app, so this toggle is the one that matters.
+
+After changing any of these settings, quit AI Dictation completely and reopen it.
+
+For the official guide, see Microsoft's [Turn on app permissions for your microphone in Windows](https://support.microsoft.com/en-us/windows/privacy/turn-on-app-permissions-for-your-microphone-in-windows).
+
+## Verify your microphone is working
+
+1. Open **Settings > System > Sound > Input**.
+2. Select the correct microphone if you have more than one.
+3. Speak and confirm the level meter moves.
+
+If the meter does not move, the microphone hardware or driver may need attention before AI Dictation can use it.
+
+## Transcript not appearing in the app
+
+If dictation completes successfully but text does not land in the target field, click the field and press **Ctrl+V**. The transcript is copied to your clipboard automatically.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a customer-facing help article for Windows users whose F8 overlay appears but the microphone is blocked by Windows privacy settings. Support needs a shareable URL for this common issue.

## Content

The help article covers:

1. **Enable microphone access** - The three Windows 11 privacy toggles:
   - Microphone access (On)
   - Let apps access your microphone (On)
   - Let desktop apps access your microphone (On) — this is the critical one for desktop apps

2. **Verify microphone is working** - Check Settings > System > Sound > Input and confirm the level meter moves

3. **Clipboard fallback** - If text doesn't appear in the target field, Ctrl+V pastes from clipboard

Tone is direct and short per the request. Links to Microsoft's official [Turn on app permissions for your microphone in Windows](https://support.microsoft.com/en-us/windows/privacy/turn-on-app-permissions-for-your-microphone-in-windows) page.

## Integration required

The website source lives in the private `writingmate/speak-it-fast` submodule, which this agent cannot access. The content is staged in `website-content/help/windows-microphone-permission.md` with integration instructions in `website-content/README.md`.

**To complete this work:**

1. Add the article to the speak-it-fast repo using the site's existing help/FAQ pattern
2. Update the website submodule pointer in this repo after deploying

## Public URL after merge/deploy

Depending on the existing site routing pattern:
- `https://aidictation.com/faq/windows-microphone` (if FAQ has sub-pages)
- `https://aidictation.com/help/windows-microphone` (if a /help section is added)

The live site currently has no `/help` route, so `/faq/windows-microphone` may be the natural fit, or this could be the first page in a new `/help` section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-820157b6-670c-4c6f-afff-4c29a340e219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-820157b6-670c-4c6f-afff-4c29a340e219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790145124&installation_model_id=432087&pr_number=100&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F100&signature=03588fa9bbd60f4f41d4a68c64a54a532ff6b0951e3334b0f0e14eed522cce49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->