### PR TITLE
fix(ios-keyboard): Fix keyboard dictation setup screen hidden and app opening issues

### DIFF
--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -208,7 +208,7 @@ struct ContentView: View {
         ZStack {
             historyView
 
-            if inlineRecording.isPanelVisible {
+            if inlineRecording.isPanelVisible, !showKeyboardReturnScreen {
                 GeometryReader { proxy in
                     let sheetBaseHeight = max(proxy.size.height, UIScreen.main.bounds.height)
                     let isCompleting = inlineRecording.state == .completing
@@ -257,25 +257,27 @@ struct ContentView: View {
                     .zIndex(3)
             }
 
-            VStack {
-                Spacer()
-                Button(action: handleInlineRecordingTap) {
-                    AIDictationMicButtonVisual(
-                        state: inlineRecording.visualState,
-                        audioLevel: inlineRecording.audioLevel,
-                        frequencyBands: inlineRecording.frequencyBands,
-                        size: 64
-                    )
-                    .shadow(color: .black.opacity(inlineRecording.isActive ? 0.28 : 0.2), radius: inlineRecording.isActive ? 10 : 4, x: 0, y: inlineRecording.isActive ? 5 : 2)
+            if !showKeyboardReturnScreen {
+                VStack {
+                    Spacer()
+                    Button(action: handleInlineRecordingTap) {
+                        AIDictationMicButtonVisual(
+                            state: inlineRecording.visualState,
+                            audioLevel: inlineRecording.audioLevel,
+                            frequencyBands: inlineRecording.frequencyBands,
+                            size: 64
+                        )
+                        .shadow(color: .black.opacity(inlineRecording.isActive ? 0.28 : 0.2), radius: inlineRecording.isActive ? 10 : 4, x: 0, y: inlineRecording.isActive ? 5 : 2)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(inlineRecording.state == .processing || inlineRecording.state == .completing)
+                    .opacity(inlineRecording.state == .processing || inlineRecording.state == .completing ? 0 : 1)
+                    .scaleEffect(inlineRecording.state == .processing || inlineRecording.state == .completing ? 0.82 : 1)
+                    .accessibilityLabel(inlineRecording.isActive ? "Stop recording" : "Start recording")
+                    .padding(.bottom, 28)
                 }
-                .buttonStyle(.plain)
-                .disabled(inlineRecording.state == .processing || inlineRecording.state == .completing)
-                .opacity(inlineRecording.state == .processing || inlineRecording.state == .completing ? 0 : 1)
-                .scaleEffect(inlineRecording.state == .processing || inlineRecording.state == .completing ? 0.82 : 1)
-                .accessibilityLabel(inlineRecording.isActive ? "Stop recording" : "Start recording")
-                .padding(.bottom, 28)
+                .zIndex(2)
             }
-            .zIndex(2)
         }
         .animation(.spring(response: 0.42, dampingFraction: 0.86, blendDuration: 0.08), value: inlineRecording.state)
         .animation(.easeInOut(duration: 0.2), value: inlineRecording.errorMessage)
@@ -2937,6 +2939,13 @@ private final class InlineRecordingCoordinator: ObservableObject {
                     guard KeyboardDictationHandoff.snapshot(for: keyboardIdentity)?.phase == .preparing else {
                         throw CancellationError()
                     }
+                    guard KeyboardDictationHandoff.publishHostPhase(
+                        .recording,
+                        identity: keyboardIdentity,
+                        recordingID: prepared.recordingID.uuidString
+                    ) else {
+                        throw CancellationError()
+                    }
                 }
 
                 _ = try await IOSAudioProcessingDeadline.run(seconds: recordingStartDeadline) {
@@ -2952,16 +2961,6 @@ private final class InlineRecordingCoordinator: ObservableObject {
                 )
                 guard activeAttempt == prepared, !Task.isCancelled else {
                     throw CancellationError()
-                }
-
-                if let keyboardIdentity {
-                    guard KeyboardDictationHandoff.publishHostPhase(
-                        .recording,
-                        identity: keyboardIdentity,
-                        recordingID: prepared.recordingID.uuidString
-                    ) else {
-                        throw CancellationError()
-                    }
                 }
 
                 recordingStartTime = Date()

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -144,12 +144,14 @@ struct ContentView: View {
     }
 
     private func openRecordingSheet() {
+        guard !showKeyboardReturnScreen else { return }
         guard requireMobileAudioRecoveryReady() else { return }
         recordingSheetID = UUID()
         showRecordingSheet = true
     }
 
     private func openSavedRecording(_ recording: Recording) {
+        guard !showKeyboardReturnScreen else { return }
         guard requireMobileAudioRecoveryReady() else { return }
         selectedRecording = recording
     }
@@ -504,6 +506,7 @@ struct ContentView: View {
                 historySearchField
 
                 Button {
+                    guard !showKeyboardReturnScreen else { return }
                     showSettings = true
                 } label: {
                     Image(systemName: "gearshape")
@@ -1171,9 +1174,19 @@ struct ContentView: View {
 
         activeKeyboardDictationIdentity = identity
         keepKeyboardBridgeAlive()
+        dismissAllSheetsForKeyboardDictation()
         showKeyboardReturnScreen = true
         inlineRecording.setKeyboardAttemptIdentity(identity)
         handleInlineRecordingTap()
+    }
+
+    private func dismissAllSheetsForKeyboardDictation() {
+        showSettings = false
+        showRecordingSheet = false
+        selectedRecording = nil
+        recordingToShare = nil
+        referralShareItem = nil
+        showLoginSheet = false
     }
 
     private func stopKeyboardDictation(identity: KeyboardDictationHandoff.AttemptIdentity) {
@@ -1185,6 +1198,7 @@ struct ContentView: View {
         }
         DebugLog.info("stopKeyboardDictation attemptID=\(identity.attemptID) inlineState=\(inlineRecording.state)", context: "KEYBOARD_DIAG")
         keepKeyboardBridgeAlive()
+        dismissAllSheetsForKeyboardDictation()
         showKeyboardReturnScreen = true
         inlineRecording.setKeyboardAttemptIdentity(identity)
         if inlineRecording.state == .recording || inlineRecording.state == .paused || inlineRecording.state == .processing {
@@ -1288,9 +1302,11 @@ struct ContentView: View {
         guard keyboardHostLaunchReady, keyboardCommandPollTask == nil else { return }
 
         DebugLog.info("start command polling", context: "KEYBOARD_DIAG")
+        armQuickDictation()
         keyboardCommandPollTask = Task { @MainActor in
             while !Task.isCancelled {
                 KeyboardDictationHandoff.publishAppReady()
+                refreshQuickDictationHeartbeat()
                 drainKeyboardDiagnostics()
                 consumePendingKeyboardCommandIfNeeded()
                 tearDownExpiredKeyboardBridge()
@@ -1301,6 +1317,23 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    /// Arms Quick Dictation with a 10-minute window.
+    /// The keyboard checks this availability to decide whether to open the app or dictate in place.
+    private func armQuickDictation() {
+        let availability = KeyboardDictationHandoff.QuickDictationAvailability()
+        KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
+        DebugLog.info("armed Quick Dictation until \(availability.expiresAt)", context: "KEYBOARD_DIAG")
+    }
+
+    /// Refreshes the Quick Dictation heartbeat to indicate the app is still actively listening.
+    private func refreshQuickDictationHeartbeat() {
+        guard let current = KeyboardDictationHandoff.loadQuickDictationAvailability(),
+              current.expiresAt > Date()
+        else { return }
+        let refreshed = current.refreshingHeartbeat()
+        KeyboardDictationHandoff.saveQuickDictationAvailability(refreshed)
     }
 
     /// The keyboard refreshes the bridge while it is in use; once it has been
@@ -1323,6 +1356,7 @@ struct ContentView: View {
         keyboardBridgeAliveUntil = Date().addingTimeInterval(120)
         guard keyboardHostLaunchReady else { return }
         KeyboardDictationHandoff.publishAppReady()
+        refreshQuickDictationHeartbeat()
         startKeyboardCommandPolling()
     }
 
@@ -1337,6 +1371,10 @@ struct ContentView: View {
             return
         }
         KeyboardHostLaunchRecoveryGate.attempted = true
+
+        // Clear any stale Quick Dictation availability from a previous process.
+        // A new app launch means we need to re-arm Quick Dictation fresh.
+        KeyboardDictationHandoff.clearQuickDictationAvailability()
 
         do {
             if let abandonedIdentity = try KeyboardDictationHandoff.normalizeAfterHostLaunch() {
@@ -1390,6 +1428,10 @@ struct ContentView: View {
         DebugLog.info("stop command polling", context: "KEYBOARD_DIAG")
         keyboardCommandPollTask?.cancel()
         keyboardCommandPollTask = nil
+        // Note: We intentionally do NOT clear Quick Dictation availability here.
+        // The heartbeat mechanism will let it expire naturally within 6 seconds,
+        // giving the user a short grace period to start dictation even after
+        // the app goes to background.
     }
 
     private func markRecordingAsNew(_ recording: Recording) {

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -1311,20 +1311,57 @@ struct ContentView: View {
                 consumePendingKeyboardCommandIfNeeded()
                 tearDownExpiredKeyboardBridge()
                 try? await Task.sleep(nanoseconds: 250_000_000)
-                if scenePhase != .active, !shouldKeepKeyboardCommandPolling {
+
+                // Check if we should keep polling
+                let isQuickDictationActive = inlineRecording.audioRecorder.isStandbyActive
+                let hasActiveKeyboardWork = shouldKeepKeyboardCommandPolling
+
+                if scenePhase != .active, !hasActiveKeyboardWork, !isQuickDictationActive {
+                    // App is in background, no active keyboard work, and no Quick Dictation standby
+                    // Stop polling and let iOS suspend the app
+                    DebugLog.info("stopping command polling (background, no standby)", context: "KEYBOARD_DIAG")
+                    clearQuickDictation()
                     keyboardCommandPollTask = nil
                     break
+                }
+
+                // If Quick Dictation is active, check if it has expired
+                if isQuickDictationActive {
+                    if let availability = KeyboardDictationHandoff.loadQuickDictationAvailability(),
+                       availability.expiresAt <= Date() {
+                        // Quick Dictation window expired - stop standby
+                        DebugLog.info("Quick Dictation window expired; stopping standby", context: "KEYBOARD_DIAG")
+                        clearQuickDictation()
+                        if scenePhase != .active, !hasActiveKeyboardWork {
+                            keyboardCommandPollTask = nil
+                            break
+                        }
+                    }
                 }
             }
         }
     }
 
-    /// Arms Quick Dictation with a 10-minute window.
-    /// The keyboard checks this availability to decide whether to open the app or dictate in place.
+    /// Arms Quick Dictation with a 10-minute window using audio standby mode.
+    /// The audio standby keeps iOS from suspending the app, enabling in-place dictation.
     private func armQuickDictation() {
-        let availability = KeyboardDictationHandoff.QuickDictationAvailability()
-        KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
-        DebugLog.info("armed Quick Dictation until \(availability.expiresAt)", context: "KEYBOARD_DIAG")
+        guard !inlineRecording.audioRecorder.isStandbyActive else {
+            // Already in standby - just refresh the availability
+            refreshQuickDictationHeartbeat()
+            return
+        }
+
+        do {
+            try inlineRecording.audioRecorder.startStandby()
+            let availability = KeyboardDictationHandoff.QuickDictationAvailability()
+            KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
+            DebugLog.info("armed Quick Dictation with audio standby until \(availability.expiresAt)", context: "KEYBOARD_DIAG")
+        } catch {
+            DebugLog.info("failed to arm Quick Dictation: \(error)", context: "KEYBOARD_DIAG")
+            // Fall back to non-standby mode - the heartbeat will expire quickly
+            let availability = KeyboardDictationHandoff.QuickDictationAvailability()
+            KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
+        }
     }
 
     /// Refreshes the Quick Dictation heartbeat to indicate the app is still actively listening.
@@ -1334,6 +1371,13 @@ struct ContentView: View {
         else { return }
         let refreshed = current.refreshingHeartbeat()
         KeyboardDictationHandoff.saveQuickDictationAvailability(refreshed)
+    }
+
+    /// Clears Quick Dictation and stops audio standby.
+    private func clearQuickDictation() {
+        inlineRecording.audioRecorder.stopStandby(deactivateAudioSession: true)
+        KeyboardDictationHandoff.clearQuickDictationAvailability()
+        DebugLog.info("cleared Quick Dictation", context: "KEYBOARD_DIAG")
     }
 
     /// The keyboard refreshes the bridge while it is in use; once it has been
@@ -1428,10 +1472,7 @@ struct ContentView: View {
         DebugLog.info("stop command polling", context: "KEYBOARD_DIAG")
         keyboardCommandPollTask?.cancel()
         keyboardCommandPollTask = nil
-        // Note: We intentionally do NOT clear Quick Dictation availability here.
-        // The heartbeat mechanism will let it expire naturally within 6 seconds,
-        // giving the user a short grace period to start dictation even after
-        // the app goes to background.
+        clearQuickDictation()
     }
 
     private func markRecordingAsNew(_ recording: Recording) {
@@ -2381,7 +2422,8 @@ private final class InlineRecordingCoordinator: ObservableObject {
     @Published var completionText: String?
 
     private let audioRecorderSlot = IOSRetirableResourceSlot(factory: AudioRecorder.init)
-    private var audioRecorder: AudioRecorder { audioRecorderSlot.current }
+    /// Public accessor for the audio recorder, needed for Quick Dictation standby mode.
+    var audioRecorder: AudioRecorder { audioRecorderSlot.current }
     private let processingStore = MobileAudioProcessingStore.shared
     private let recordingStatus = RecordingNowPlayingStatus()
     private let subscriptionManager = SubscriptionManager.shared

--- a/Whishpermate/WhisperMateKeyboard/KeyboardRecordingView.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardRecordingView.swift
@@ -217,26 +217,13 @@ struct KeyboardRecordingView: View {
             .frame(width: 190, height: 82)
             .padding(.horizontal, 28)
 
-            HStack(spacing: 12) {
-                Text(recordTitle)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                if showsCancelAction {
-                    Button("Cancel", action: onCancelAction)
-                        .font(.caption.weight(.semibold))
-                        .buttonStyle(.bordered)
-                        .accessibilityHint("Keeps any recording already saved in the app")
-                }
-            }
-
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var recordButton: some View {
-        Button(action: onPrimaryAction) {
+        Button(action: recordButtonAction) {
             AIDictationMicButtonVisual(
                 state: model.state,
                 audioLevel: model.audioLevel,
@@ -248,8 +235,15 @@ struct KeyboardRecordingView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(model.state == .processing)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func recordButtonAction() {
+        if model.state == .processing {
+            onCancelAction()
+        } else {
+            onPrimaryAction()
+        }
     }
 
     private func letterRow(_ keys: [KeyboardTypingKey]) -> some View {
@@ -264,40 +258,6 @@ struct KeyboardRecordingView: View {
                     action: { onKeyPress(key.label(shifted: isShifted)) }
                 )
             }
-        }
-    }
-
-    private var recordTitle: String {
-        switch handoffPhase {
-        case .preparing:
-            return "Starting recording…"
-        case .recording:
-            return "Recording"
-        case .finalizing:
-            return "Finishing recording…"
-        case .processing:
-            return "Transcribing…"
-        case .succeeded:
-            return "Ready"
-        case .failed:
-            return "Couldn't transcribe"
-        case .cancelled:
-            return "Cancelled"
-        case .none:
-            return "AI Dictation"
-        @unknown default:
-            return "AI Dictation"
-        }
-    }
-
-    private var showsCancelAction: Bool {
-        switch handoffPhase {
-        case .preparing, .finalizing, .processing:
-            return true
-        case .recording, .succeeded, .failed, .cancelled, .none:
-            return false
-        @unknown default:
-            return false
         }
     }
 

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -334,8 +334,9 @@ class KeyboardViewController: UIInputViewController {
 
     private func handlePrimaryAction() {
         let buttonState = primaryButtonState
-        DebugLog.info("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue)", context: "KEYBOARD_DIAG")
-        KeyboardDictationHandoff.appendDiagnostic("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue)")
+        let appReady = KeyboardDictationHandoff.isAppReady()
+        DebugLog.info("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) appReady=\(appReady)", context: "KEYBOARD_DIAG")
+        KeyboardDictationHandoff.appendDiagnostic("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) appReady=\(appReady)")
         switch buttonState {
         case .startRequiresApp:
             startRecording(openAppIfNeeded: true)
@@ -353,7 +354,7 @@ class KeyboardViewController: UIInputViewController {
     private var primaryButtonState: PrimaryButtonState {
         switch keyboardState {
         case .idle:
-            return KeyboardDictationHandoff.isAppReady() ? .startViaReadyApp : .startRequiresApp
+            return .startViaReadyApp
         case .recording, .paused:
             return .finishRecording
         case .processing:
@@ -444,6 +445,8 @@ class KeyboardViewController: UIInputViewController {
 
     private func startAppOpenFallbackTimer(identity: KeyboardDictationHandoff.AttemptIdentity) {
         stopStartFallbackTimer()
+        DebugLog.info("starting 3s app-open fallback timer sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
+        KeyboardDictationHandoff.appendDiagnostic("starting 3s app-open fallback timer sessionID=\(identity.sessionID)")
         let timer = Timer(timeInterval: 3.0, repeats: false) { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self,
@@ -703,6 +706,10 @@ class KeyboardViewController: UIInputViewController {
             armDeadline(for: snapshot)
 
         case .recording:
+            if startFallbackTimer != nil {
+                DebugLog.info("app acknowledged recording; cancelling fallback timer sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
+                KeyboardDictationHandoff.appendDiagnostic("app acknowledged recording; cancelling fallback timer sessionID=\(identity.sessionID)")
+            }
             stopStartFallbackTimer()
             stopHandoffDeadlineTimer()
             setHandoffPhase(.recording, animated: handoffPhase != .recording)

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -399,13 +399,42 @@ class KeyboardViewController: UIInputViewController {
         reconcileHandoff()
 
         if !openAppIfNeeded {
-            DebugLog.info("startRecording using ready app bridge sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
-            KeyboardDictationHandoff.appendDiagnostic("startRecording using ready app bridge sessionID=\(identity.sessionID)")
-            startAppOpenFallbackTimer(identity: identity)
+            // Quick Dictation is ready - the app is running in standby mode.
+            // Wait for the app to pick up the command without opening its UI.
+            // Use a longer fallback (8s) because the app should respond quickly from standby.
+            DebugLog.info("startRecording using Quick Dictation sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
+            KeyboardDictationHandoff.appendDiagnostic("startRecording using Quick Dictation sessionID=\(identity.sessionID)")
+            startQuickDictationFallbackTimer(identity: identity)
             return
         }
 
+        // Quick Dictation not ready (cold start or expired) - must open the app
         openAppForRecording(identity: identity)
+    }
+
+    /// Fallback timer for Quick Dictation mode.
+    /// The app should respond quickly from standby, but if it doesn't within 8 seconds,
+    /// we fall back to opening the app.
+    private func startQuickDictationFallbackTimer(identity: KeyboardDictationHandoff.AttemptIdentity) {
+        stopStartFallbackTimer()
+        let fallbackSeconds: TimeInterval = 8.0
+        DebugLog.info("starting \(Int(fallbackSeconds))s Quick Dictation fallback timer sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
+        KeyboardDictationHandoff.appendDiagnostic("starting \(Int(fallbackSeconds))s Quick Dictation fallback timer sessionID=\(identity.sessionID)")
+        let timer = Timer(timeInterval: fallbackSeconds, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async {
+                guard let self,
+                      self.handoffPhase == .preparing,
+                      self.activeHandoffIdentity == identity,
+                      KeyboardDictationHandoff.snapshot(for: identity)?.phase == .preparing
+                else { return }
+
+                DebugLog.info("Quick Dictation fallback: app did not respond; opening app sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
+                KeyboardDictationHandoff.appendDiagnostic("Quick Dictation fallback: app did not respond; opening app sessionID=\(identity.sessionID)")
+                self.openAppForRecording(identity: identity)
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        startFallbackTimer = timer
     }
 
     private func openAppForRecording(identity: KeyboardDictationHandoff.AttemptIdentity) {
@@ -441,27 +470,6 @@ class KeyboardViewController: UIInputViewController {
             // preparing until the host confirms durable source ownership and recorder readiness.
             self.reconcileHandoff()
         }
-    }
-
-    private func startAppOpenFallbackTimer(identity: KeyboardDictationHandoff.AttemptIdentity) {
-        stopStartFallbackTimer()
-        DebugLog.info("starting 3s app-open fallback timer sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
-        KeyboardDictationHandoff.appendDiagnostic("starting 3s app-open fallback timer sessionID=\(identity.sessionID)")
-        let timer = Timer(timeInterval: 3.0, repeats: false) { [weak self] _ in
-            DispatchQueue.main.async {
-                guard let self,
-                      self.handoffPhase == .preparing,
-                      self.activeHandoffIdentity == identity,
-                      KeyboardDictationHandoff.snapshot(for: identity)?.phase == .preparing
-                else { return }
-
-                DebugLog.info("ready app bridge did not acknowledge start; opening app sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
-                KeyboardDictationHandoff.appendDiagnostic("ready app bridge did not acknowledge start; opening app sessionID=\(identity.sessionID)")
-                self.openAppForRecording(identity: identity)
-            }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        startFallbackTimer = timer
     }
 
     private func stopStartFallbackTimer() {

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -444,7 +444,7 @@ class KeyboardViewController: UIInputViewController {
 
     private func startAppOpenFallbackTimer(identity: KeyboardDictationHandoff.AttemptIdentity) {
         stopStartFallbackTimer()
-        let timer = Timer(timeInterval: 1.25, repeats: false) { [weak self] _ in
+        let timer = Timer(timeInterval: 3.0, repeats: false) { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self,
                       self.handoffPhase == .preparing,

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -334,9 +334,9 @@ class KeyboardViewController: UIInputViewController {
 
     private func handlePrimaryAction() {
         let buttonState = primaryButtonState
-        let appReady = KeyboardDictationHandoff.isAppReady()
-        DebugLog.info("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) appReady=\(appReady)", context: "KEYBOARD_DIAG")
-        KeyboardDictationHandoff.appendDiagnostic("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) appReady=\(appReady)")
+        let quickDictationReady = KeyboardDictationHandoff.isQuickDictationReady()
+        DebugLog.info("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) quickDictationReady=\(quickDictationReady)", context: "KEYBOARD_DIAG")
+        KeyboardDictationHandoff.appendDiagnostic("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) quickDictationReady=\(quickDictationReady)")
         switch buttonState {
         case .startRequiresApp:
             startRecording(openAppIfNeeded: true)
@@ -354,7 +354,7 @@ class KeyboardViewController: UIInputViewController {
     private var primaryButtonState: PrimaryButtonState {
         switch keyboardState {
         case .idle:
-            return .startViaReadyApp
+            return KeyboardDictationHandoff.isQuickDictationReady() ? .startViaReadyApp : .startRequiresApp
         case .recording, .paused:
             return .finishRecording
         case .processing:

--- a/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
+++ b/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
@@ -57,6 +57,7 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
 
     private var audioRecorder: AVAudioRecorder?
     private var audioEngine: AVAudioEngine?
+    private var standbyEngine: AVAudioEngine?
     private var recordingURL: URL?
     private var isMonitoringOnly = false
     private var levelTimer: DispatchSourceTimer?
@@ -71,11 +72,22 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
     private var activeManagedCaptureGeneration: UInt64?
     #if os(iOS)
         private var isAudioSessionConfigured = false
+        private var isStandbySessionConfigured = false
         private var managedAudioSessionObserverTokens: [NSObjectProtocol] = []
     #endif
 
     // App Group identifier for sharing data between app and keyboard extension
     public static let appGroupIdentifier = "group.com.whispermate.shared"
+
+    /// Returns true if the audio session is in standby mode (ready to record but not recording).
+    /// This keeps iOS from suspending the app, enabling Quick Dictation for ~10 minutes.
+    #if os(iOS)
+    public var isStandbyActive: Bool {
+        standbyEngine?.isRunning == true && !isRecording
+    }
+    #else
+    public var isStandbyActive: Bool { false }
+    #endif
 
     override public init() {
         super.init()
@@ -110,6 +122,64 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
                 isAudioSessionConfigured = false
             } catch {
                 DebugLog.info("Failed to deactivate audio session: \(error)", context: "AudioRecorder LOG")
+            }
+        }
+
+        // MARK: - Audio Standby Mode
+
+        /// Starts audio session standby to keep iOS from suspending the app.
+        /// This enables Quick Dictation for ~10 minutes without opening the app.
+        /// The audio engine runs with a tap but doesn't capture to disk.
+        public func startStandby() throws {
+            guard !isRecording else { return }
+            guard standbyEngine?.isRunning != true else { return }
+
+            DebugLog.info("Starting audio standby mode", context: "AudioRecorder")
+
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(
+                .playAndRecord,
+                mode: .default,
+                options: [.mixWithOthers, .defaultToSpeaker, .allowBluetoothHFP]
+            )
+            try session.setActive(true)
+
+            let engine = AVAudioEngine()
+            let inputNode = engine.inputNode
+            let format = inputNode.outputFormat(forBus: 0)
+
+            guard format.sampleRate > 0, format.channelCount > 0 else {
+                try? session.setActive(false, options: .notifyOthersOnDeactivation)
+                throw ManagedAudioRecordingError.audioSessionUnavailable
+            }
+
+            // Install a tap that discards all samples. This keeps the audio session active.
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { _, _ in
+                // Discard samples - we're just keeping the session alive
+            }
+
+            engine.prepare()
+            try engine.start()
+
+            standbyEngine = engine
+            isStandbySessionConfigured = true
+            DebugLog.info("Audio standby mode active - app will stay alive in background", context: "AudioRecorder")
+        }
+
+        /// Stops audio standby mode and optionally deactivates the audio session.
+        public func stopStandby(deactivateAudioSession: Bool = true) {
+            guard !isRecording else { return }
+            guard let engine = standbyEngine else { return }
+
+            DebugLog.info("Stopping audio standby mode", context: "AudioRecorder")
+
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+            standbyEngine = nil
+            isStandbySessionConfigured = false
+
+            if deactivateAudioSession {
+                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
             }
         }
 

--- a/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
+++ b/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
@@ -154,7 +154,7 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
             }
 
             // Install a tap that discards all samples. This keeps the audio session active.
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { _, _ in
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { @Sendable _, _ in
                 // Discard samples - we're just keeping the session alive
             }
 

--- a/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
+++ b/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
@@ -145,9 +145,10 @@ public enum KeyboardDictationHandoff {
             heartbeatAt: Date? = nil
         ) {
             self.schemaVersion = Self.schemaVersion
-            self.activatedAt = Self.normalizedTimestamp(activatedAt)
+            let normalizedActivatedAt = Self.normalizedTimestamp(activatedAt)
+            self.activatedAt = normalizedActivatedAt
             self.expiresAt = Self.normalizedTimestamp(expiresAt ?? activatedAt.addingTimeInterval(Self.quickDictationWindowSeconds))
-            self.heartbeatAt = Self.normalizedTimestamp(heartbeatAt ?? activatedAt)
+            self.heartbeatAt = Self.normalizedTimestamp(heartbeatAt) ?? normalizedActivatedAt
         }
 
         public func isReady(at date: Date = Date()) -> Bool {
@@ -172,7 +173,7 @@ public enum KeyboardDictationHandoff {
         }
 
         private static func normalizedTimestamp(_ date: Date?) -> Date? {
-            date.map { Date(timeIntervalSince1970: $0.timeIntervalSince1970.rounded(.down)) }
+            date.map { Self.normalizedTimestamp($0) }
         }
 
         private static func normalizedTimestamp(_ date: Date) -> Date {

--- a/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
+++ b/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
@@ -959,7 +959,15 @@ public enum KeyboardDictationHandoff {
     public static func isAppReady(now: Date = Date()) -> Bool {
         withTransaction(or: false) { defaults in
             let timestamp = defaults.double(forKey: appReadyTimestampKey)
-            return timestamp > 0 && now.timeIntervalSince1970 - timestamp <= appReadyTTL
+            let age = now.timeIntervalSince1970 - timestamp
+            let ready = timestamp > 0 && age <= appReadyTTL
+            if !ready {
+                DebugLog.info(
+                    "isAppReady=false timestamp=\(timestamp) age=\(String(format: "%.2f", age))s ttl=\(appReadyTTL)s",
+                    context: "KEYBOARD_DIAG"
+                )
+            }
+            return ready
         }
     }
 

--- a/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
+++ b/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
@@ -120,6 +120,68 @@ public enum KeyboardDictationHandoff {
     public static let openAppNotification = Notification.Name("KeyboardDictationHandoffOpenApp")
     public static let stopAppNotification = Notification.Name("KeyboardDictationHandoffStopApp")
 
+    // MARK: - Quick Dictation Availability
+
+    /// Quick Dictation availability model with heartbeat mechanism.
+    /// The app arms Quick Dictation for up to 10 minutes, publishing heartbeats every few seconds.
+    /// The keyboard checks both the expiry window AND heartbeat freshness before attempting
+    /// in-place dictation without opening the app.
+    public struct QuickDictationAvailability: Codable, Equatable, Sendable {
+        public static let schemaVersion = 1
+        public static let heartbeatInterval: TimeInterval = 2
+        public static let heartbeatMaximumAge: TimeInterval = 6
+        public static let quickDictationWindowSeconds: TimeInterval = 10 * 60
+        public static let launchFallbackSeconds: TimeInterval = 1.5
+        public static let claimedLaunchDeadlineSeconds: TimeInterval = 8
+
+        public let schemaVersion: Int
+        public let activatedAt: Date
+        public let expiresAt: Date
+        public let heartbeatAt: Date?
+
+        public init(
+            activatedAt: Date = Date(),
+            expiresAt: Date? = nil,
+            heartbeatAt: Date? = nil
+        ) {
+            self.schemaVersion = Self.schemaVersion
+            self.activatedAt = Self.normalizedTimestamp(activatedAt)
+            self.expiresAt = Self.normalizedTimestamp(expiresAt ?? activatedAt.addingTimeInterval(Self.quickDictationWindowSeconds))
+            self.heartbeatAt = Self.normalizedTimestamp(heartbeatAt ?? activatedAt)
+        }
+
+        public func isReady(at date: Date = Date()) -> Bool {
+            guard schemaVersion == Self.schemaVersion,
+                  expiresAt > date,
+                  let heartbeatAt
+            else { return false }
+            let heartbeatAge = date.timeIntervalSince(heartbeatAt)
+            return heartbeatAge >= -1 && heartbeatAge <= Self.heartbeatMaximumAge
+        }
+
+        public func refreshingHeartbeat(at date: Date = Date()) -> QuickDictationAvailability {
+            QuickDictationAvailability(
+                activatedAt: activatedAt,
+                expiresAt: expiresAt,
+                heartbeatAt: date
+            )
+        }
+
+        public func acceptsRequest(createdAt: Date, grace: TimeInterval = 2) -> Bool {
+            createdAt >= activatedAt.addingTimeInterval(-grace) && createdAt < expiresAt
+        }
+
+        private static func normalizedTimestamp(_ date: Date?) -> Date? {
+            date.map { Date(timeIntervalSince1970: $0.timeIntervalSince1970.rounded(.down)) }
+        }
+
+        private static func normalizedTimestamp(_ date: Date) -> Date {
+            Date(timeIntervalSince1970: date.timeIntervalSince1970.rounded(.down))
+        }
+    }
+
+    private static let quickDictationAvailabilityKey = "keyboardDictation.quickDictationAvailability"
+
     /// The keyboard uses these deadlines to guarantee that every visible busy state ends.
     public static let startAcknowledgementTimeout: TimeInterval = 12
     public static let stopAcknowledgementTimeout: TimeInterval = 15
@@ -969,6 +1031,56 @@ public enum KeyboardDictationHandoff {
             }
             return ready
         }
+    }
+
+    // MARK: - Quick Dictation Availability Storage
+
+    public static func saveQuickDictationAvailability(_ availability: QuickDictationAvailability) {
+        withTransaction(or: ()) { defaults in
+            if let encoded = try? JSONEncoder().encode(availability) {
+                defaults.set(encoded, forKey: quickDictationAvailabilityKey)
+                defaults.synchronize()
+                DebugLog.info(
+                    "saved quick dictation availability expiresAt=\(availability.expiresAt) heartbeat=\(availability.heartbeatAt?.description ?? "nil")",
+                    context: "KEYBOARD_DIAG"
+                )
+            }
+        }
+    }
+
+    public static func loadQuickDictationAvailability() -> QuickDictationAvailability? {
+        withTransaction(or: nil) { defaults in
+            guard let data = defaults.data(forKey: quickDictationAvailabilityKey),
+                  let availability = try? JSONDecoder().decode(QuickDictationAvailability.self, from: data)
+            else { return nil }
+            return availability
+        }
+    }
+
+    public static func clearQuickDictationAvailability() {
+        withTransaction(or: ()) { defaults in
+            defaults.removeObject(forKey: quickDictationAvailabilityKey)
+            defaults.synchronize()
+            DebugLog.info("cleared quick dictation availability", context: "KEYBOARD_DIAG")
+        }
+    }
+
+    /// Checks if Quick Dictation is ready for in-place dictation.
+    /// Returns true only if the availability is valid, not expired, and has a fresh heartbeat.
+    public static func isQuickDictationReady(now: Date = Date()) -> Bool {
+        guard let availability = loadQuickDictationAvailability() else {
+            DebugLog.info("isQuickDictationReady=false reason=no_availability", context: "KEYBOARD_DIAG")
+            return false
+        }
+        let ready = availability.isReady(at: now)
+        if !ready {
+            let heartbeatAge = availability.heartbeatAt.map { now.timeIntervalSince($0) } ?? -1
+            DebugLog.info(
+                "isQuickDictationReady=false expires=\(availability.expiresAt) heartbeatAge=\(String(format: "%.1f", heartbeatAge))s",
+                context: "KEYBOARD_DIAG"
+            )
+        }
+        return ready
     }
 
     // MARK: - Compatibility text bridge


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements VocaPhone-style audio session standby to keep the iOS app alive in background for ~10 minutes, enabling true in-place keyboard dictation without opening the app UI.

## Root Cause

The previous implementation used a 6-second heartbeat grace period, but iOS would suspend the app shortly after it went to background. VocaPhone keeps an audio session in standby mode, which prevents iOS from suspending the app.

## Key Changes

### 1. AudioRecorder: Audio Standby Mode
```swift
/// Starts audio session standby to keep iOS from suspending the app.
public func startStandby() throws {
    let session = AVAudioSession.sharedInstance()
    try session.setCategory(
        .playAndRecord,
        mode: .default,
        options: [.mixWithOthers, .defaultToSpeaker, .allowBluetoothHFP]
    )
    try session.setActive(true)
    
    // Install a tap that discards samples - keeps session alive
    inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { _, _ in }
    engine.start()
}
```

### 2. ContentView: Quick Dictation Management
- `armQuickDictation()` starts audio standby, not just writes availability
- Polling loop continues while standby is active, even in background
- Heartbeat refreshes every 250ms while standby is running
- `clearQuickDictation()` stops standby and clears availability
- Checks standby expiry and cleans up after 10 minutes

### 3. Keyboard: No Immediate App Opening During Quick Dictation
- When `isQuickDictationReady()` is true, uses 8-second fallback (not 3s)
- The app should respond quickly from standby; fallback is safety net only
- Only opens app when Quick Dictation is definitely not ready (cold start/expired)

## How It Works

```
1. App opens → arms Quick Dictation → starts audio standby
2. User switches to Notes → app stays alive (audio session prevents suspension)
3. App continues polling and refreshing heartbeat in background
4. User taps keyboard mic → keyboard checks isQuickDictationReady() → true
5. Keyboard writes command, waits for app to respond (no app UI opens)
6. App picks up command, starts recording, publishes result
7. Keyboard inserts text via UITextDocumentProxy
```

## Previous Bugs Fixed

### Bug A: Swipe-back screen visibility
- Dismiss all sheets when showing KeyboardDictationReturnView
- Prevents sheets from opening when showing keyboard return screen

### Bug B: Keyboard always opening main app
- **NOW FIXED**: Audio standby keeps app alive for 10 minutes
- Keyboard checks `isQuickDictationReady()` before deciding to open app
- Only opens app on cold start or after standby expires

### Bug C: Ugly UI during transcription
- Removed text label and Cancel button from keyboard transcription view

## Verification Instructions

### Test Case: 10-Minute Keep-Alive
1. Build app to device with dev provisioning profile
2. Open AI Dictation app, let it fully load
3. Switch to Notes, open AI Dictation keyboard
4. **Wait 30 seconds or more** (test with 1-2 minutes for confidence)
5. Tap keyboard mic button
6. **Expected**: Recording starts IN the keyboard without opening the app
7. Speak, tap mic to finish
8. **Expected**: Transcript appears in Notes field

### Test Case: Cold Start
1. Force-quit AI Dictation app
2. Open Notes, switch to AI Dictation keyboard
3. Tap mic button
4. **Expected**: App opens showing "Recording is ready" swipe-back screen
5. Swipe back to Notes
6. **Expected**: Recording completes, transcript appears

### Test Case: Standby Expiry (10 minutes)
1. Open AI Dictation app
2. Switch to Notes
3. Wait 10+ minutes
4. Tap mic button
5. **Expected**: App opens (standby has expired) with swipe-back screen

## Files Changed
- `WhisperMateShared/Services/AudioRecorder.swift` - Audio standby mode
- `WhisperMateIOS/ContentView.swift` - Quick Dictation arming/clearing
- `WhisperMateKeyboard/KeyboardViewController.swift` - 8s fallback for Quick Dictation

## Requirements
- `UIBackgroundModes: audio` in Info.plist (already configured)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee38be54-d35c-45a0-891b-ef948cc733f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee38be54-d35c-45a0-891b-ef948cc733f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790150981&installation_model_id=432087&pr_number=101&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F101&signature=a8607ef9aed76f57d0a3b4c940f823d75f90402af7ecdb2eabb4033c7fe883a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->