### PR TITLE
Finish live transcription while saving audio

### DIFF
--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -74,6 +74,11 @@ class AppState: ObservableObject {
     private var terminationFinalizationTask: Task<Bool, Never>?
     private let processingAttemptFence = MacProcessingAttemptFence()
     private var realtimeTranscriptionClient: OpenAIRealtimeTranscriptionClient?
+    private var activeRealtimeFinishRequest: (
+        recordingID: UUID,
+        attemptID: UUID,
+        request: RealtimeTranscriptionFinishRequest
+    )?
     private var realtimeTranscript: String = ""
     private let diarizationTimeoutSeconds: UInt64 = 75
     private let llmPostProcessingTimeoutSeconds: UInt64 = 45
@@ -332,6 +337,14 @@ class AppState: ObservableObject {
 
             activeCaptureLease = prepared.lease
             overlayManager.initializeAudioObservers()
+            // Install realtime delivery before native capture starts. The
+            // preparation buffer that proves the recorder is ready must be in
+            // both the durable source and the realtime stream.
+            startRealtimeTranscriptionIfAvailable(
+                recordingID: recordingID,
+                attemptID: attemptID,
+                snapshot: resolvedAttemptSnapshot
+            )
             audioRecorder.startRecording(
                 recordingID: attemptID,
                 recordingURL: store.partialURL(for: recordingID)
@@ -413,11 +426,6 @@ class AppState: ObservableObject {
                 )
                 activeTranscriptionSnapshot = snapshot
                 scheduleCaptureDeadline(recordingID: recordingID, attemptID: attemptID)
-                startRealtimeTranscriptionIfAvailable(
-                    recordingID: recordingID,
-                    attemptID: attemptID,
-                    snapshot: snapshot
-                )
                 NotificationCenter.default.post(name: .recordingStarted, object: nil)
 
                 DebugLog.info("✅ Recording started successfully", context: "AppState")
@@ -447,6 +455,7 @@ class AppState: ObservableObject {
             }
 
         case .failed(let message):
+            closeLiveRealtimeTranscription()
             _ = try? await store.tombstone(recordingID: recordingID)
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
@@ -454,6 +463,7 @@ class AppState: ObservableObject {
             ) else { return }
             finishRecordingStart(recordingID: recordingID, terminalMessage: message)
         case .timedOut:
+            closeLiveRealtimeTranscription()
             _ = try? await store.tombstone(recordingID: recordingID)
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
@@ -464,6 +474,7 @@ class AppState: ObservableObject {
                 terminalMessage: "Recording didn’t start. Check your microphone and try again."
             )
         case .invalidated:
+            closeLiveRealtimeTranscription()
             _ = try? await store.tombstone(recordingID: recordingID)
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
@@ -474,6 +485,7 @@ class AppState: ObservableObject {
                 terminalMessage: "Your microphone changed before recording started. Please try again."
             )
         case .cancelled:
+            closeLiveRealtimeTranscription()
             _ = try? await store.tombstone(recordingID: recordingID)
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
@@ -481,6 +493,7 @@ class AppState: ObservableObject {
             ) else { return }
             finishRecordingStart(recordingID: recordingID, terminalMessage: nil)
         @unknown default:
+            closeLiveRealtimeTranscription()
             _ = try? await store.tombstone(recordingID: recordingID)
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
@@ -500,6 +513,7 @@ class AppState: ObservableObject {
         message: String
     ) async {
         let lease = activeCaptureLease
+        closeLiveRealtimeTranscription()
         audioRecorder.stopRecording(disposition: .submitIfValid) { _ in }
         if let lease {
             _ = try? await store.fail(lease, message: message)
@@ -605,6 +619,7 @@ class AppState: ObservableObject {
               let attemptID = recordingAttemptID
         else { return }
         recordingState = .finalizing
+        closeLiveRealtimeTranscription()
         Task { [weak self] in
             guard let self else { return }
             let store = await MacAudioProcessingStoreProvider.shared()
@@ -649,11 +664,45 @@ class AppState: ObservableObject {
                 to: .processing(isCommandMode: recordingMode == .command)
             )
         }
-        let realtimeClient = stopRealtimeTranscription()
+        let snapshot = activeTranscriptionSnapshot
+        let shouldFinishRealtime = disposition == .submitIfValid
+            && terminalMessage == nil
+            && snapshot?.outputMode == .dictation
+            && snapshot?.transcriptionOptions.diarization == false
+            && snapshot?.transport == .realtime
+        let realtimeFinishTimeout = snapshot?.provider == .custom
+            ? 6.0
+            : 2.0
+        let realtimeFinishRequest = takeRealtimeTranscription(
+            recordingID: recordingID,
+            attemptID: attemptID,
+            drainDeadline: shouldFinishRealtime ? realtimeFinishTimeout : nil
+        )
+        if !shouldFinishRealtime {
+            audioRecorder.detachRealtimeAudioChunkHandlerAndDrain {}
+            realtimeFinishRequest?.close()
+        }
         DebugLog.info(
-            "Realtime client captured on stop: \(realtimeClient != nil)",
+            "Realtime finish requested on stop: \(realtimeFinishRequest != nil && shouldFinishRealtime)",
             context: "DictationFlow"
         )
+        let afterRealtimeAudioDrained: (@Sendable (Bool) -> Void)?
+        if shouldFinishRealtime {
+            afterRealtimeAudioDrained = { [realtimeFinishRequest] coverageIsComplete in
+                if coverageIsComplete {
+                    realtimeFinishRequest?.requestFinish(
+                        timeout: realtimeFinishTimeout
+                    )
+                } else {
+                    // The durable source contains audio the realtime stream
+                    // could not encode. Close the speculative result and let
+                    // the proven finalized file use batch recognition.
+                    realtimeFinishRequest?.close()
+                }
+            }
+        } else {
+            afterRealtimeAudioDrained = nil
+        }
 
         Task { [weak self] in
             guard let self else { return }
@@ -662,7 +711,7 @@ class AppState: ObservableObject {
                 recordingID: recordingID,
                 attemptID: attemptID
             ) else {
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 return
             }
             do {
@@ -672,7 +721,7 @@ class AppState: ObservableObject {
                         recordingID: recordingID,
                         attemptID: attemptID
                     ) else {
-                        realtimeClient?.close()
+                        realtimeFinishRequest?.close()
                         return
                     }
                 } else {
@@ -687,7 +736,10 @@ class AppState: ObservableObject {
                               attemptID: attemptID
                           ),
                           self.recordingState == .finalizing
-                    else { return }
+                    else {
+                        realtimeFinishRequest?.close()
+                        return
+                    }
                     self.activeCaptureLease = finalizing.lease
                 }
 
@@ -696,8 +748,14 @@ class AppState: ObservableObject {
                           attemptID: attemptID
                       ),
                       self.recordingState == .finalizing
-                else { return }
-                self.audioRecorder.stopRecording(disposition: disposition) { [weak self] terminal in
+                else {
+                    realtimeFinishRequest?.close()
+                    return
+                }
+                self.audioRecorder.stopRecording(
+                    disposition: disposition,
+                    afterRealtimeAudioDrained: afterRealtimeAudioDrained
+                ) { [weak self] terminal in
                     Task { @MainActor [weak self] in
                         await self?.handleRecorderFinalizationTerminal(
                             terminal,
@@ -706,7 +764,7 @@ class AppState: ObservableObject {
                             attemptID: attemptID,
                             disposition: disposition,
                             terminalMessage: terminalMessage,
-                            realtimeClient: realtimeClient
+                            realtimeFinishRequest: realtimeFinishRequest
                         )
                     }
                 }
@@ -715,7 +773,7 @@ class AppState: ObservableObject {
                     recordingID: recordingID,
                     attemptID: attemptID
                 ) else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     return
                 }
                 self.audioRecorder.stopRecording(disposition: .submitIfValid) { _ in }
@@ -729,10 +787,10 @@ class AppState: ObservableObject {
                     recordingID: recordingID,
                     attemptID: attemptID
                 ) else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     return
                 }
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 _ = self.persistActiveRecording(
                     recordingID: recordingID,
                     audioURL: store.partialURL(for: recordingID),
@@ -755,12 +813,12 @@ class AppState: ObservableObject {
         attemptID: UUID,
         disposition: AudioRecorder.StopDisposition,
         terminalMessage: String?,
-        realtimeClient: OpenAIRealtimeTranscriptionClient?
+        realtimeFinishRequest: RealtimeTranscriptionFinishRequest?
     ) async {
         guard ownsProcessingAttempt(recordingID: recordingID, attemptID: attemptID),
               recordingState == .finalizing
         else {
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             return
         }
 
@@ -769,7 +827,7 @@ class AppState: ObservableObject {
             guard case .confirmed(let nativeCloseAttestation) =
                 audioRecorder.nativeCloseState(recordingID: attemptID)
             else {
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 let message =
                     "Recording is still finishing. The available audio was kept for recovery."
                 if let lease = activeCaptureLease {
@@ -799,7 +857,7 @@ class AppState: ObservableObject {
             }
             audioRecorder.acknowledgeConfirmedClose(recordingID: attemptID)
             guard let lease = activeCaptureLease else {
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 finishRecordingWithoutTranscription(
                     recordingID: recordingID,
                     message: "Recording ownership could not be confirmed. The available audio was kept."
@@ -820,7 +878,7 @@ class AppState: ObservableObject {
                     recordingID: recordingID,
                     attemptID: attemptID
                 ) else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     return
                 }
                 let checkpoint = try await store.checkpointClosedAudio(lease, proof: proof)
@@ -829,7 +887,7 @@ class AppState: ObservableObject {
                     recordingID: recordingID,
                     attemptID: attemptID
                 ) else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     return
                 }
                 closedAudioWasCheckpointed = true
@@ -840,7 +898,7 @@ class AppState: ObservableObject {
                     recordingID: recordingID,
                     attemptID: attemptID
                 ) else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     return
                 }
                 activeCaptureLease = ready.lease
@@ -852,7 +910,7 @@ class AppState: ObservableObject {
                         recordingID: recordingID,
                         attemptID: attemptID
                     ) else {
-                        realtimeClient?.close()
+                        realtimeFinishRequest?.close()
                         return
                     }
                     activeCaptureLease = failed.lease
@@ -863,7 +921,7 @@ class AppState: ObservableObject {
                         errorMessage: terminalMessage,
                         sourceIntegrity: .complete
                     )
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     finishRecordingWithoutTranscription(
                         recordingID: recordingID,
                         message: terminalMessage
@@ -883,10 +941,10 @@ class AppState: ObservableObject {
                     ready: ready,
                     recordingID: recordingID,
                     captureAttemptID: attemptID,
-                    realtimeClient: realtimeClient
+                    realtimeFinishRequest: realtimeFinishRequest
                 )
             } catch {
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 guard ownsProcessingAttempt(
                     recordingID: recordingID,
                     attemptID: attemptID
@@ -931,7 +989,7 @@ class AppState: ObservableObject {
 
         case .failed(let message, let recoverableURL):
             audioRecorder.acknowledgeConfirmedClose(recordingID: attemptID)
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             let displayedMessage = terminalMessage ?? message
             if let lease = activeCaptureLease {
                 _ = try? await store.fail(lease, message: displayedMessage)
@@ -950,7 +1008,7 @@ class AppState: ObservableObject {
             finishRecordingWithoutTranscription(recordingID: recordingID, message: displayedMessage)
 
         case .timedOut(let recoverableURL):
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             scheduleLateNativeCloseReconciliation(
                 store: store,
                 recordingID: recordingID,
@@ -985,7 +1043,7 @@ class AppState: ObservableObject {
 
         case .discarded:
             audioRecorder.acknowledgeConfirmedClose(recordingID: attemptID)
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             _ = historyManager.removeRecordingMetadata(id: recordingID)
             finishRecordingWithoutTranscription(recordingID: recordingID, message: terminalMessage)
 
@@ -994,7 +1052,7 @@ class AppState: ObservableObject {
             // retain and acknowledge its proof instead of treating that gap as
             // evidence that the writer was never closed.
             audioRecorder.acknowledgeConfirmedClose(recordingID: attemptID)
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             if disposition == .discard {
                 scheduleLateNativeCloseReconciliation(
                     store: store,
@@ -1026,7 +1084,7 @@ class AppState: ObservableObject {
             finishRecordingWithoutTranscription(recordingID: recordingID, message: displayedMessage)
 
         @unknown default:
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             let message = terminalMessage ?? "Recording couldn’t be saved. Please try again."
             if let lease = activeCaptureLease {
                 _ = try? await store.fail(lease, message: message)
@@ -1097,6 +1155,8 @@ class AppState: ObservableObject {
         removeMetadata: Bool = false
     ) {
         DictationActivityAssertion.release()
+        closeLiveRealtimeTranscription()
+        closeActiveRealtimeFinishRequest(recordingID: recordingID)
         captureDeadlineTask?.cancel()
         captureDeadlineTask = nil
         var metadataRemovalFailed = false
@@ -1131,8 +1191,8 @@ class AppState: ObservableObject {
     private func finishRecordingStart(recordingID: UUID, terminalMessage: String?) {
         captureDeadlineTask?.cancel()
         captureDeadlineTask = nil
-        let realtimeClient = stopRealtimeTranscription()
-        realtimeClient?.close()
+        closeLiveRealtimeTranscription()
+        closeActiveRealtimeFinishRequest(recordingID: recordingID)
         let removedMetadata = historyManager.removeRecordingMetadata(id: recordingID)
         historyManager.unregisterActiveRecording(id: recordingID)
         if activeRecordingID == recordingID {
@@ -1424,7 +1484,7 @@ class AppState: ObservableObject {
                 audioURL: finalURL,
                 transientWorkspace: transientWorkspace,
                 snapshot: snapshot,
-                realtimeClient: nil,
+                realtimeFinishRequest: nil,
                 isLiveRecording: false
             )
         } catch {
@@ -1468,6 +1528,7 @@ class AppState: ObservableObject {
             recordingAttemptID = nil
             activeCaptureLease = nil
             activeTranscriptionSnapshot = nil
+            closeActiveRealtimeFinishRequest(recordingID: recording.id)
             let realtime = stopRealtimeTranscription()
             realtime?.close()
             if recordingState == .starting {
@@ -1536,6 +1597,7 @@ class AppState: ObservableObject {
         recordingAttemptID = nil
         activeCaptureLease = nil
         activeTranscriptionSnapshot = nil
+        closeActiveRealtimeFinishRequest()
         let realtime = stopRealtimeTranscription()
         realtime?.close()
         if recordingState == .starting {
@@ -1722,6 +1784,7 @@ class AppState: ObservableObject {
         captureDeadlineTask?.cancel()
         captureDeadlineTask = nil
         for task in transcriptionTasks.values { task.cancel() }
+        closeActiveRealtimeFinishRequest()
         let realtime = stopRealtimeTranscription()
         realtime?.close()
 
@@ -1954,13 +2017,13 @@ class AppState: ObservableObject {
         ready: MacAudioProcessingStore.Mutation,
         recordingID: UUID,
         captureAttemptID: UUID,
-        realtimeClient: OpenAIRealtimeTranscriptionClient?
+        realtimeFinishRequest: RealtimeTranscriptionFinishRequest?
     ) async {
         guard ownsProcessingAttempt(
             recordingID: recordingID,
             attemptID: captureAttemptID
         ) else {
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             return
         }
 
@@ -1984,7 +2047,7 @@ class AppState: ObservableObject {
                 recordingID: recordingID,
                 attemptID: captureAttemptID
             ) else {
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 return
             }
             let transientWorkspace = try await store.makeTransientWorkspace(
@@ -1995,7 +2058,7 @@ class AppState: ObservableObject {
                 attemptID: captureAttemptID
             ) else {
                 transientWorkspace.cleanup()
-                realtimeClient?.close()
+                realtimeFinishRequest?.close()
                 return
             }
             recordingAttemptID = recognitionAttemptID
@@ -2031,13 +2094,13 @@ class AppState: ObservableObject {
                     audioURL: store.finalURL(for: recordingID),
                     transientWorkspace: transientWorkspace,
                     snapshot: snapshot,
-                    realtimeClient: realtimeClient,
+                    realtimeFinishRequest: realtimeFinishRequest,
                     isLiveRecording: true
                 )
             }
             transcriptionTasks[recordingID] = task
         } catch {
-            realtimeClient?.close()
+            realtimeFinishRequest?.close()
             guard ownsProcessingAttempt(
                 recordingID: recordingID,
                 attemptID: captureAttemptID
@@ -2062,11 +2125,11 @@ class AppState: ObservableObject {
         audioURL: URL,
         transientWorkspace: MacTransientWorkspace,
         snapshot: MacTranscriptionAttemptSnapshot,
-        realtimeClient: OpenAIRealtimeTranscriptionClient? = nil,
+        realtimeFinishRequest: RealtimeTranscriptionFinishRequest? = nil,
         isLiveRecording: Bool
     ) async {
         defer { transientWorkspace.cleanup() }
-        defer { realtimeClient?.close() }
+        defer { finishRealtimeRequest(realtimeFinishRequest) }
         do {
             try Task.checkCancellation()
             DictationStopwatch.mark("transcription attempt entered")
@@ -2087,13 +2150,12 @@ class AppState: ObservableObject {
 
             let realtimeResult: String?
             if isLiveRecording, activeTransport == .realtime {
-                let finishTimeout = snapshot.provider == .custom ? 6.0 : 2.0
-                let result = await realtimeClient?.finish(timeout: finishTimeout)?
+                let result = await realtimeFinishRequest?.finish()?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if result?.isEmpty == false {
                     realtimeResult = result
                 } else {
-                    realtimeClient?.close()
+                    realtimeFinishRequest?.close()
                     realtimeResult = nil
                 }
             } else {
@@ -2425,6 +2487,7 @@ class AppState: ObservableObject {
     ) {
         DictationActivityAssertion.release()
         guard activeRecordingID == recordingID else { return }
+        closeActiveRealtimeFinishRequest(recordingID: recordingID)
 
         let recording = persistActiveRecording(
             recordingID: recordingID,
@@ -2499,8 +2562,11 @@ class AppState: ObservableObject {
         let provider = snapshot.provider
         let transport = snapshot.transport
 
-        if snapshot.transcriptionOptions.diarization {
-            DebugLog.info("Skipping realtime start because speaker labels require batch transcription", context: "AppState")
+        if snapshot.outputMode != .dictation || snapshot.transcriptionOptions.diarization {
+            DebugLog.info(
+                "Skipping realtime start because this output requires batch transcription",
+                context: "AppState"
+            )
             return
         }
 
@@ -2607,10 +2673,10 @@ class AppState: ObservableObject {
         }
 
         realtimeTranscriptionClient = client
+        client.start()
         audioRecorder.realtimeAudioChunkHandler = { [weak client] chunk in
             client?.sendAudio(chunk)
         }
-        client.start()
         DebugLog.info("Started realtime transcription stream for \(provider.displayName)", context: "AppState")
     }
 
@@ -2690,11 +2756,58 @@ class AppState: ObservableObject {
         return model
     }
 
-    private func stopRealtimeTranscription() -> OpenAIRealtimeTranscriptionClient? {
-        audioRecorder.realtimeAudioChunkHandler = nil
+    /// Removes AppState's live client ownership without sealing audio delivery.
+    /// The normal key-up path carries this request to AudioRecorder, which owns
+    /// the only safe durable-write/realtime-admission cutoff.
+    private func takeRealtimeTranscription(
+        recordingID: UUID? = nil,
+        attemptID: UUID? = nil,
+        drainDeadline: TimeInterval? = nil
+    ) -> RealtimeTranscriptionFinishRequest? {
         let client = realtimeTranscriptionClient
         realtimeTranscriptionClient = nil
-        return client
+        let request = client.map(RealtimeTranscriptionFinishRequest.init(client:))
+
+        if let recordingID, let attemptID, let request {
+            activeRealtimeFinishRequest?.request.close()
+            activeRealtimeFinishRequest = (recordingID, attemptID, request)
+        }
+        if let request, let drainDeadline {
+            request.armDrainDeadline(timeout: drainDeadline)
+        }
+        return request
+    }
+
+    private func stopRealtimeTranscription() -> RealtimeTranscriptionFinishRequest? {
+        let request = takeRealtimeTranscription()
+        audioRecorder.detachRealtimeAudioChunkHandlerAndDrain {}
+        return request
+    }
+
+    private func closeLiveRealtimeTranscription() {
+        let request = stopRealtimeTranscription()
+        request?.close()
+    }
+
+    private func closeActiveRealtimeFinishRequest(recordingID: UUID? = nil) {
+        guard let activeRealtimeFinishRequest else { return }
+        if let recordingID,
+           activeRealtimeFinishRequest.recordingID != recordingID
+        {
+            return
+        }
+        self.activeRealtimeFinishRequest = nil
+        activeRealtimeFinishRequest.request.close()
+    }
+
+    private func finishRealtimeRequest(
+        _ request: RealtimeTranscriptionFinishRequest?
+    ) {
+        guard let request else { return }
+        if activeRealtimeFinishRequest?.request === request {
+            activeRealtimeFinishRequest = nil
+        }
+        request.close()
     }
 
     private func handleRealtimePartial(

--- a/Whishpermate/Whispermate/Services/AudioRecorder.swift
+++ b/Whishpermate/Whispermate/Services/AudioRecorder.swift
@@ -37,17 +37,9 @@ class AudioRecorder: NSObject, ObservableObject {
     @Published var isRecording = false
     @Published var audioLevel: Float = 0.0 // Audio level for visualization (0.0 to 1.0)
     @Published var frequencyBands: [Float] = Array(repeating: 0.0, count: frequencyBandCount) // Frequency spectrum data
-    var realtimeAudioChunkHandler: ((Data) -> Void)? {
-        get {
-            realtimeHandlerLock.lock()
-            defer { realtimeHandlerLock.unlock() }
-            return storedRealtimeAudioChunkHandler
-        }
-        set {
-            realtimeHandlerLock.lock()
-            storedRealtimeAudioChunkHandler = newValue
-            realtimeHandlerLock.unlock()
-        }
+    var realtimeAudioChunkHandler: (@Sendable (Data) -> Void)? {
+        get { realtimeAudioDelivery.handler }
+        set { realtimeAudioDelivery.handler = newValue }
     }
     var captureFailureHandler: ((String) -> Void)?
 
@@ -63,9 +55,7 @@ class AudioRecorder: NSObject, ObservableObject {
         [UUID: MacAudioProcessingStore.NativeWriterCloseAttestation] = [:]
     private var nativeRecordingURLs: [UUID: URL] = [:]
     private var terminationCloseRequested = false
-    private let realtimeHandlerLock = NSLock()
-    private var storedRealtimeAudioChunkHandler: ((Data) -> Void)?
-    private let realtimeAudioQueue = DispatchQueue(label: "ai.writingmate.realtime-audio")
+    private let realtimeAudioDelivery = RealtimeAudioDeliveryQueue()
     /// Whether the process-wide CoreAudio input path has been warmed once.
     ///
     /// The first `inputNode.outputFormat(forBus:)` in a process costs 180–622ms
@@ -516,6 +506,12 @@ class AudioRecorder: NSObject, ObservableObject {
         session: MacCaptureSession,
         preparation: MacCapturePreparation
     ) {
+        // Reserve realtime delivery before any file/conversion work. Native
+        // stop seals this generation after retiring write admission and waits
+        // for every reservation, so no written head or tail buffer is omitted.
+        let realtimeDeliveryLease = realtimeAudioDelivery.beginDelivery()
+        defer { realtimeDeliveryLease?.discard() }
+
         // Keep every callback-local AVAudioFile reference inside this lexical
         // scope. It must be released before finishWrite decrements activeWrites;
         // cleanup is then free to nil the session's final reference and attest
@@ -607,21 +603,37 @@ class AudioRecorder: NSObject, ObservableObject {
             }
         }
 
-        guard session.isActive else { return }
-        let bands = frequencyAnalyzer.analyze(buffer: buffer)
-        let level = calculateAudioLevel(from: buffer)
-        DispatchQueue.main.async { [weak self, weak session] in
-            guard let self, let session, self.activeCapture === session else { return }
-            self.lastAudioBufferAt = Date()
-            self.frequencyBands = bands
-            self.audioLevel = level
-        }
-
-        if let chunk = realtimePCMChunk(from: buffer), let handler = realtimeAudioChunkHandler {
-            realtimeAudioQueue.async {
-                handler(chunk)
+        // Meter updates are only useful while capture remains active. Realtime
+        // delivery is intentionally not gated by this later state check: a
+        // lease acquired before key-up still corresponds to audio that was
+        // successfully written above and must reach the final commit.
+        if session.isActive {
+            let bands = frequencyAnalyzer.analyze(buffer: buffer)
+            let level = calculateAudioLevel(from: buffer)
+            DispatchQueue.main.async { [weak self, weak session] in
+                guard let self, let session, self.activeCapture === session else { return }
+                self.lastAudioBufferAt = Date()
+                self.frequencyBands = bands
+                self.audioLevel = level
             }
         }
+
+        if let realtimeDeliveryLease {
+            if let chunk = realtimePCMChunk(from: buffer) {
+                realtimeDeliveryLease.deliver(chunk)
+            } else {
+                realtimeDeliveryLease.failCoverage()
+            }
+        }
+    }
+
+    /// Stops admitting realtime chunks and runs `completion` after every chunk
+    /// admitted by the old handler has been delivered. This is the only safe
+    /// point to commit the final realtime audio buffer.
+    func detachRealtimeAudioChunkHandlerAndDrain(
+        _ completion: @escaping @Sendable () -> Void
+    ) {
+        realtimeAudioDelivery.detachAndDrain { _ in completion() }
     }
 
     private func signalPreparationReady(_ preparation: MacCapturePreparation, session: MacCaptureSession) {
@@ -862,11 +874,16 @@ class AudioRecorder: NSObject, ObservableObject {
 
     func stopRecording(
         disposition: StopDisposition = .submitIfValid,
+        afterRealtimeAudioDrained: (@Sendable (Bool) -> Void)? = nil,
         completion: @escaping (RecordingFinalizationAttempt.Terminal) -> Void
     ) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
-                self?.stopRecording(disposition: disposition, completion: completion)
+                self?.stopRecording(
+                    disposition: disposition,
+                    afterRealtimeAudioDrained: afterRealtimeAudioDrained,
+                    completion: completion
+                )
             }
             return
         }
@@ -876,16 +893,19 @@ class AudioRecorder: NSObject, ObservableObject {
 
         if pendingPreparation != nil {
             cancelPendingRecordingStart()
+            realtimeAudioDelivery.detachAndDrain { _ in }
             completion(.discarded)
             return
         }
 
         stopRecordingWatchdog()
         guard pendingFinalization == nil else {
+            realtimeAudioDelivery.detachAndDrain { _ in }
             completion(.unavailable("Recording is already being saved."))
             return
         }
         guard let session = activeCapture else {
+            realtimeAudioDelivery.detachAndDrain { _ in }
             resetFailedStart()
             let closedCandidates = nativeCloseProofs.compactMap { recordingID, proof in
                 proof.isConfirmedClosed
@@ -902,7 +922,14 @@ class AudioRecorder: NSObject, ObservableObject {
         }
         activeCapture = nil
         isRecording = false
+        // Retiring the exact capture session closes durable write admission.
+        // Only after that cutoff may realtime admission be sealed. A callback
+        // that acquired both leases before retirement can finish both; one
+        // arriving afterwards can enter neither pipeline.
         session.retire()
+        realtimeAudioDelivery.detachAndDrain { coverageIsComplete in
+            afterRealtimeAudioDrained?(coverageIsComplete)
+        }
         let finalization = MacCaptureFinalization(
             session: session,
             deletesFile: disposition == .discard,

--- a/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
+++ b/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
@@ -189,7 +189,7 @@ private extension String {
     }
 }
 
-final class OpenAIRealtimeTranscriptionClient {
+nonisolated final class OpenAIRealtimeTranscriptionClient: @unchecked Sendable, RealtimeTranscriptionFinalizing {
     static let defaultTranscriptionModel = "gpt-realtime-whisper"
     private static let realtimeBytesPerSecond = 24_000 * MemoryLayout<Int16>.size
     private static let liveCommitByteThreshold = Int(Double(realtimeBytesPerSecond) * 0.8)
@@ -213,15 +213,16 @@ final class OpenAIRealtimeTranscriptionClient {
     private let onPartialTranscript: @MainActor (String) -> Void
     private let onError: @MainActor (String) -> Void
     private let session: URLSession
-    private let sendQueue = DispatchQueue(label: "ai.writingmate.openai-realtime-send")
+    private let sendQueue: DispatchQueue
+    private let finishGate: RealtimeTranscriptionFinishGate
 
     private var task: URLSessionWebSocketTask?
+    private var authorizationTask: Task<Void, Never>?
     private var pendingEvents: [[String: Any]] = []
     private var isClosed = false
     private var accumulatedTranscript = ""
     private var finalTranscript: String?
     private var failedMessage: String?
-    private lazy var finishGate = RealtimeTranscriptionFinishGate(queue: sendQueue)
     private var didRequestFinish = false
     private var audioChunkCount = 0
     private var audioByteCount = 0
@@ -244,6 +245,9 @@ final class OpenAIRealtimeTranscriptionClient {
         onError: @escaping @MainActor (String) -> Void
     ) {
         let model = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sendQueue = DispatchQueue(label: "ai.writingmate.openai-realtime-send")
+        self.sendQueue = sendQueue
+        self.finishGate = RealtimeTranscriptionFinishGate(queue: sendQueue)
         self.authorizationProvider = {
             guard let url = webSocketURL ?? Self.webSocketURL() else {
                 throw OpenAIRealtimeTranscriptionClientError.clientSecretRequestFailed("Invalid OpenAI Realtime URL")
@@ -268,6 +272,9 @@ final class OpenAIRealtimeTranscriptionClient {
         onError: @escaping @MainActor (String) -> Void
     ) {
         let model = transcriptionModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sendQueue = DispatchQueue(label: "ai.writingmate.openai-realtime-send")
+        self.sendQueue = sendQueue
+        self.finishGate = RealtimeTranscriptionFinishGate(queue: sendQueue)
         self.authorizationProvider = authorizationProvider
         self.prompt = prompt
         self.transcriptionModel = model.isEmpty ? Self.defaultTranscriptionModel : model
@@ -282,7 +289,8 @@ final class OpenAIRealtimeTranscriptionClient {
         sendQueue.async { [weak self] in
             guard let self else { return }
             self.requireSendQueue()
-            self.finishGate.resolve(with: nil)
+            self.authorizationTask?.cancel()
+            self.finishGate.reset()
             self.isClosed = false
             self.audioChunkCount = 0
             self.audioByteCount = 0
@@ -302,15 +310,17 @@ final class OpenAIRealtimeTranscriptionClient {
                 "Realtime start requested model=\(self.transcriptionModel) language=\(self.language ?? "auto") promptIncluded=\(self.supportsPromptSteering && self.prompt?.isEmpty == false)",
                 context: "OpenAIRealtime"
             )
-        }
-
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                let authorization = try await authorizationProvider()
-                openSocket(authorization: authorization)
-            } catch {
-                self.fail("OpenAI Realtime token failed: \(error.localizedDescription)")
+            self.authorizationTask = Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let authorization = try await self.authorizationProvider()
+                    try Task.checkCancellation()
+                    self.openSocket(authorization: authorization)
+                } catch is CancellationError {
+                    return
+                } catch {
+                    self.fail("OpenAI Realtime token failed: \(error.localizedDescription)")
+                }
             }
         }
     }
@@ -324,7 +334,7 @@ final class OpenAIRealtimeTranscriptionClient {
         ]
         sendQueue.async { [weak self] in
             guard let self else { return }
-            guard !self.isClosed else { return }
+            guard !self.isClosed, !self.didRequestFinish else { return }
 
             self.audioChunkCount += 1
             self.audioByteCount += pcm24kMono16.count
@@ -346,46 +356,25 @@ final class OpenAIRealtimeTranscriptionClient {
         }
     }
 
-    func finish(timeout: TimeInterval = 1.5) async -> String? {
-        return await withCheckedContinuation { continuation in
+    /// Starts the single final realtime commit without waiting for its result.
+    /// Call this only after the recorder's realtime delivery queue has drained.
+    func requestFinish(timeout: TimeInterval = 1.5) {
+        sendQueue.async { [weak self] in
+            self?.beginFinishOnQueue(timeout: timeout)
+        }
+    }
+
+    /// Awaits the result of `requestFinish` without owning commit authority.
+    /// The recorder's drain callback is the only caller allowed to start the
+    /// final commit, so this consumer can never overtake tail conversion.
+    func awaitFinish() async -> String? {
+        await withCheckedContinuation { continuation in
             sendQueue.async { [weak self] in
                 guard let self else {
                     continuation.resume(returning: nil)
                     return
                 }
-                self.requireSendQueue()
-                DebugLog.info(
-                    "Realtime finish requested timeout=\(timeout)s accumulatedLength=\(self.accumulatedTranscript.count) finalLength=\(self.finalTranscript?.count ?? 0) failed=\(self.failedMessage != nil)",
-                    context: "OpenAIRealtime"
-                )
-                guard self.failedMessage == nil else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                if self.isTransportDrained, let finalTranscript = self.finalTranscript {
-                    self.abandonTransportOnQueue()
-                    continuation.resume(returning: finalTranscript)
-                    return
-                }
-
-                self.didRequestFinish = true
-                self.finishGate.begin(
-                    timeout: timeout,
-                    continuation: continuation
-                ) { [weak self] in
-                    guard let self else { return }
-                    DebugLog.info(
-                        "Realtime finish timeout elapsed; discarding unproven stream finalLength=\(self.finalTranscript?.count ?? 0) accumulatedLength=\(self.accumulatedTranscript.count)",
-                        context: "OpenAIRealtime"
-                    )
-                    self.abandonTransportOnQueue()
-                }
-                DebugLog.info(
-                    "Realtime commit queued chunks=\(self.audioChunkCount) bytes=\(self.audioByteCount) currentLength=\(self.accumulatedTranscript.count)",
-                    context: "OpenAIRealtime"
-                )
-                self.commitAudioBuffer(reason: "finish")
-                self.resumeFinishIfReady()
+                self.finishGate.wait(continuation)
             }
         }
     }
@@ -423,6 +412,42 @@ final class OpenAIRealtimeTranscriptionClient {
             self.pendingEvents.removeAll()
             queuedEvents.forEach { self.sendEventOnQueue($0) }
         }
+    }
+
+    private func beginFinishOnQueue(timeout: TimeInterval) {
+        requireSendQueue()
+        guard !didRequestFinish else { return }
+        didRequestFinish = true
+
+        DebugLog.info(
+            "Realtime finish requested timeout=\(timeout)s accumulatedLength=\(accumulatedTranscript.count) finalLength=\(finalTranscript?.count ?? 0) failed=\(failedMessage != nil)",
+            context: "OpenAIRealtime"
+        )
+        guard failedMessage == nil, !isClosed else {
+            finishGate.resolve(with: nil)
+            return
+        }
+        if isTransportDrained {
+            let completedTranscript = finalTranscript
+            abandonTransportOnQueue()
+            finishGate.resolve(with: completedTranscript)
+            return
+        }
+
+        finishGate.begin(timeout: timeout) { [weak self] in
+            guard let self else { return }
+            DebugLog.info(
+                "Realtime finish timeout elapsed; discarding unproven stream finalLength=\(self.finalTranscript?.count ?? 0) accumulatedLength=\(self.accumulatedTranscript.count)",
+                context: "OpenAIRealtime"
+            )
+            self.abandonTransportOnQueue()
+        }
+        DebugLog.info(
+            "Realtime commit queued chunks=\(audioChunkCount) bytes=\(audioByteCount) currentLength=\(accumulatedTranscript.count)",
+            context: "OpenAIRealtime"
+        )
+        commitAudioBuffer(reason: "finish")
+        resumeFinishIfReady()
     }
 
     private func sessionUpdateEvent() -> [String: Any] {
@@ -694,6 +719,8 @@ final class OpenAIRealtimeTranscriptionClient {
     private func abandonTransportOnQueue() {
         requireSendQueue()
         isClosed = true
+        authorizationTask?.cancel()
+        authorizationTask = nil
         pendingEvents.removeAll()
         task?.cancel(with: .normalClosure, reason: nil)
         task = nil

--- a/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
+++ b/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
@@ -1,40 +1,370 @@
 import Foundation
 
-/// Resolves one realtime finalization attempt on its owning serial queue.
+nonisolated protocol RealtimeTranscriptionFinalizing: AnyObject, Sendable {
+    func requestFinish(timeout: TimeInterval)
+    func awaitFinish() async -> String?
+    func close()
+}
+
+/// Attempt-scoped owner for one realtime stream finalization. It keeps the
+/// transport alive after the recorder drops its weak audio handler and gives
+/// every cancellation path one idempotent close operation.
+nonisolated final class RealtimeTranscriptionFinishRequest: @unchecked Sendable {
+    private let lock = NSLock()
+    private let client: any RealtimeTranscriptionFinalizing
+    private let resultTask: Task<String?, Never>
+    private var isClosed = false
+    private var didRequestFinish = false
+    private var drainDeadlineTask: Task<Void, Never>?
+    private var drainDeadlineGeneration: UInt64 = 0
+
+    init(client: any RealtimeTranscriptionFinalizing) {
+        self.client = client
+        resultTask = Task {
+            await client.awaitFinish()
+        }
+    }
+
+    /// Bounds the gap between key-up and the delivery queue's drain callback.
+    /// A stuck conversion closes the stream so the durable source can use batch
+    /// fallback instead of waiting forever.
+    func armDrainDeadline(timeout: TimeInterval) {
+        lock.lock()
+        guard !isClosed, !didRequestFinish else {
+            lock.unlock()
+            return
+        }
+        drainDeadlineGeneration &+= 1
+        let generation = drainDeadlineGeneration
+        let previousDeadline = drainDeadlineTask
+        let deadlineTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(max(0, timeout)))
+            } catch {
+                return
+            }
+            self?.expireDrainDeadline(generation: generation)
+        }
+        drainDeadlineTask = deadlineTask
+        lock.unlock()
+        previousDeadline?.cancel()
+    }
+
+    func requestFinish(timeout: TimeInterval) {
+        lock.lock()
+        guard !isClosed, !didRequestFinish else {
+            lock.unlock()
+            return
+        }
+        didRequestFinish = true
+        drainDeadlineGeneration &+= 1
+        let drainDeadlineTask = self.drainDeadlineTask
+        self.drainDeadlineTask = nil
+        lock.unlock()
+        drainDeadlineTask?.cancel()
+        client.requestFinish(timeout: timeout)
+    }
+
+    func finish() async -> String? {
+        await withTaskCancellationHandler {
+            return await resultTask.value
+        } onCancel: { [weak self] in
+            self?.close()
+        }
+    }
+
+    func close() {
+        lock.lock()
+        guard !isClosed else {
+            lock.unlock()
+            return
+        }
+        isClosed = true
+        drainDeadlineGeneration &+= 1
+        let drainDeadlineTask = self.drainDeadlineTask
+        self.drainDeadlineTask = nil
+        lock.unlock()
+        drainDeadlineTask?.cancel()
+        client.close()
+    }
+
+    deinit {
+        close()
+    }
+
+    private func expireDrainDeadline(generation: UInt64) {
+        lock.lock()
+        guard generation == drainDeadlineGeneration,
+              !didRequestFinish,
+              !isClosed
+        else {
+            lock.unlock()
+            return
+        }
+        isClosed = true
+        drainDeadlineGeneration &+= 1
+        drainDeadlineTask = nil
+        lock.unlock()
+        client.close()
+    }
+}
+
+/// Serializes converted realtime audio delivery and provides an atomic
+/// detach-and-drain boundary.
+///
+/// Enqueueing a chunk and enqueueing the drain marker both happen while the
+/// same lock is held. A capture callback that acquired the old handler must
+/// therefore place its chunk before the marker; a callback that arrives after
+/// detachment cannot place a chunk at all.
+nonisolated final class RealtimeAudioDeliveryQueue: @unchecked Sendable {
+    typealias Handler = @Sendable (Data) -> Void
+
+    fileprivate enum DeliveryOutcome: Sendable {
+        case delivered(Data)
+        case discarded
+        case coverageFailed
+    }
+
+    final class Lease: @unchecked Sendable {
+        private let lock = NSLock()
+        private var completion: (@Sendable (DeliveryOutcome) -> Void)?
+
+        fileprivate init(
+            completion: @escaping @Sendable (DeliveryOutcome) -> Void
+        ) {
+            self.completion = completion
+        }
+
+        func deliver(_ chunk: Data) {
+            finish(with: .delivered(chunk))
+        }
+
+        func discard() {
+            finish(with: .discarded)
+        }
+
+        /// The corresponding native buffer was written successfully, but its
+        /// realtime representation could not be produced. This poisons the
+        /// generation so its transcript can never be accepted as complete.
+        func failCoverage() {
+            finish(with: .coverageFailed)
+        }
+
+        private func finish(with outcome: DeliveryOutcome) {
+            lock.lock()
+            let completion = self.completion
+            self.completion = nil
+            lock.unlock()
+            completion?(outcome)
+        }
+
+        deinit {
+            discard()
+        }
+    }
+
+    private final class Generation: @unchecked Sendable {
+        let handler: Handler
+        var inFlight = 0
+        var isSealed = false
+        var coverageIsComplete = true
+
+        init(handler: @escaping Handler) {
+            self.handler = handler
+        }
+    }
+
+    private struct DrainRequest {
+        let generations: [Generation]
+        let completion: @Sendable (Bool) -> Void
+    }
+
+    private let lock = NSLock()
+    private let queue: DispatchQueue
+    private var activeGeneration: Generation?
+    private var sealedGenerations: [Generation] = []
+    private var pendingDrainRequests: [DrainRequest] = []
+
+    init(label: String = "ai.writingmate.realtime-audio") {
+        queue = DispatchQueue(label: label)
+    }
+
+    var handler: Handler? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return activeGeneration?.handler
+        }
+        set {
+            lock.lock()
+            sealActiveGenerationLocked()
+            if let newValue {
+                activeGeneration = Generation(handler: newValue)
+            }
+            lock.unlock()
+        }
+    }
+
+    /// Reserves one delivery before the caller begins converting its capture
+    /// buffer. Detachment seals the generation but waits for every reserved
+    /// lease, so conversion that was already in flight cannot lose the tail.
+    func beginDelivery() -> Lease? {
+        lock.lock()
+        guard let generation = activeGeneration,
+              !generation.isSealed
+        else {
+            lock.unlock()
+            return nil
+        }
+        generation.inFlight += 1
+        lock.unlock()
+
+        return Lease { [weak self, generation] outcome in
+            self?.finishDelivery(outcome, generation: generation)
+        }
+    }
+
+    func detachAndDrain(_ completion: @escaping @Sendable (Bool) -> Void) {
+        lock.lock()
+        sealActiveGenerationLocked()
+        let generations = sealedGenerations
+        guard !generations.isEmpty else {
+            queue.async {
+                completion(true)
+            }
+            lock.unlock()
+            return
+        }
+        pendingDrainRequests.append(
+            DrainRequest(generations: generations, completion: completion)
+        )
+        enqueueReadyDrainsLocked()
+        lock.unlock()
+    }
+
+    private func finishDelivery(
+        _ outcome: DeliveryOutcome,
+        generation: Generation
+    ) {
+        lock.lock()
+        guard generation.inFlight > 0 else {
+            lock.unlock()
+            return
+        }
+        switch outcome {
+        case .delivered(let chunk):
+            if !chunk.isEmpty {
+                let handler = generation.handler
+                queue.async {
+                    handler(chunk)
+                }
+            } else {
+                generation.coverageIsComplete = false
+            }
+        case .coverageFailed:
+            generation.coverageIsComplete = false
+        case .discarded:
+            break
+        }
+        generation.inFlight -= 1
+        enqueueReadyDrainsLocked()
+        lock.unlock()
+    }
+
+    private func sealActiveGenerationLocked() {
+        guard let generation = activeGeneration else { return }
+        generation.isSealed = true
+        sealedGenerations.append(generation)
+        activeGeneration = nil
+    }
+
+    private func enqueueReadyDrainsLocked() {
+        var ready: [DrainRequest] = []
+        pendingDrainRequests.removeAll { request in
+            let isReady = request.generations.allSatisfy {
+                $0.isSealed && $0.inFlight == 0
+            }
+            if isReady {
+                ready.append(request)
+            }
+            return isReady
+        }
+        guard !ready.isEmpty else { return }
+
+        let stillReferenced = Set(
+            pendingDrainRequests.flatMap(\.generations).map(ObjectIdentifier.init)
+        )
+        let drained = Set(
+            ready.flatMap(\.generations).map(ObjectIdentifier.init)
+        )
+        sealedGenerations.removeAll {
+            let identity = ObjectIdentifier($0)
+            return drained.contains(identity) && !stillReferenced.contains(identity)
+        }
+        for request in ready {
+            let completion = request.completion
+            let coverageIsComplete = request.generations.allSatisfy(
+                \.coverageIsComplete
+            )
+            queue.async {
+                completion(coverageIsComplete)
+            }
+        }
+    }
+}
+
+/// Resolves one idempotent realtime finalization attempt on its owning serial
+/// queue. Finalization may begin before its consumer starts waiting.
 ///
 /// The generation check prevents a cancelled timeout from resolving a later
-/// attempt, while `resolve` guarantees that completion, timeout, failure, and
-/// close can race without resuming a continuation more than once.
-final class RealtimeTranscriptionFinishGate: @unchecked Sendable {
+/// attempt. A stored terminal outcome lets the durable-audio pipeline await an
+/// already-started stream without issuing a second commit.
+nonisolated final class RealtimeTranscriptionFinishGate: @unchecked Sendable {
+    private enum Outcome {
+        case resolved(String?)
+    }
+
     private let queue: DispatchQueue
-    private var continuation: CheckedContinuation<String?, Never>?
+    private var continuations: [CheckedContinuation<String?, Never>] = []
     private var timeoutWorkItem: DispatchWorkItem?
     private var generation: UInt64 = 0
+    private var didBegin = false
+    private var outcome: Outcome?
 
     init(queue: DispatchQueue) {
         self.queue = queue
     }
 
+    /// Clears the previous attempt after resolving any abandoned waiter.
+    func reset() {
+        requireOwningQueue()
+        generation &+= 1
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
+        let abandoned = continuations
+        continuations.removeAll()
+        didBegin = false
+        outcome = nil
+        abandoned.forEach { $0.resume(returning: nil) }
+    }
+
+    @discardableResult
     func begin(
         timeout: TimeInterval,
-        continuation: CheckedContinuation<String?, Never>,
         onTimeout: @escaping @Sendable () -> Void
-    ) {
+    ) -> Bool {
         requireOwningQueue()
-        guard self.continuation == nil else {
-            continuation.resume(returning: nil)
-            return
-        }
+        guard !didBegin, outcome == nil else { return false }
 
+        didBegin = true
         generation &+= 1
         let activeGeneration = generation
-        self.continuation = continuation
 
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.requireOwningQueue()
             guard self.generation == activeGeneration,
-                  self.continuation != nil
+                  self.outcome == nil
             else {
                 return
             }
@@ -46,17 +376,30 @@ final class RealtimeTranscriptionFinishGate: @unchecked Sendable {
             deadline: .now() + max(0, timeout),
             execute: workItem
         )
+        return true
+    }
+
+    func wait(_ continuation: CheckedContinuation<String?, Never>) {
+        requireOwningQueue()
+        if case .resolved(let transcript) = outcome {
+            continuation.resume(returning: transcript)
+            return
+        }
+        continuations.append(continuation)
     }
 
     @discardableResult
     func resolve(with transcript: String?) -> Bool {
         requireOwningQueue()
-        guard let continuation else { return false }
+        guard outcome == nil else { return false }
 
-        self.continuation = nil
+        outcome = .resolved(transcript)
+        generation &+= 1
         timeoutWorkItem?.cancel()
         timeoutWorkItem = nil
-        continuation.resume(returning: transcript)
+        let waiting = continuations
+        continuations.removeAll()
+        waiting.forEach { $0.resume(returning: transcript) }
         return true
     }
 

--- a/scripts/validate_macos_realtime_finalization.swift
+++ b/scripts/validate_macos_realtime_finalization.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-private final class LockedCounter: @unchecked Sendable {
+private nonisolated final class LockedCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
 
@@ -17,23 +17,132 @@ private final class LockedCounter: @unchecked Sendable {
     }
 }
 
-private func waitForFinish(
+private nonisolated final class LockedEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    func append(_ event: String) {
+        lock.lock()
+        storage.append(event)
+        lock.unlock()
+    }
+
+    var value: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+private nonisolated final class HangingFinalizer: @unchecked Sendable, RealtimeTranscriptionFinalizing {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<String?, Never>?
+    private var closed = false
+    private var storedRequestCount = 0
+    private var storedCloseCount = 0
+    private var storedFinishStarted = false
+
+    var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRequestCount
+    }
+
+    var closeCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedCloseCount
+    }
+
+    var finishStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedFinishStarted
+    }
+
+    func requestFinish(timeout _: TimeInterval) {
+        lock.lock()
+        storedRequestCount += 1
+        lock.unlock()
+    }
+
+    func awaitFinish() async -> String? {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            storedFinishStarted = true
+            if closed {
+                lock.unlock()
+                continuation.resume(returning: nil)
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+    }
+
+    func close() {
+        lock.lock()
+        storedCloseCount += 1
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: nil)
+    }
+}
+
+private func beginFinish(
     gate: RealtimeTranscriptionFinishGate,
     queue: DispatchQueue,
     timeout: TimeInterval,
-    timeoutCounter: LockedCounter
+    timeoutCounter: LockedCounter,
+    reset: Bool = true
+) async -> Bool {
+    await withCheckedContinuation { continuation in
+        queue.async {
+            if reset {
+                gate.reset()
+            }
+            let began = gate.begin(timeout: timeout) {
+                timeoutCounter.increment()
+            }
+            continuation.resume(returning: began)
+        }
+    }
+}
+
+private func resolveFinish(
+    gate: RealtimeTranscriptionFinishGate,
+    queue: DispatchQueue,
+    transcript: String?
+) async -> Bool {
+    await withCheckedContinuation { continuation in
+        queue.async {
+            continuation.resume(returning: gate.resolve(with: transcript))
+        }
+    }
+}
+
+private func waitForFinish(
+    gate: RealtimeTranscriptionFinishGate,
+    queue: DispatchQueue
 ) async -> String? {
     await withCheckedContinuation { continuation in
         queue.async {
-            gate.begin(
-                timeout: timeout,
-                continuation: continuation,
-                onTimeout: {
-                    timeoutCounter.increment()
-                }
-            )
+            gate.wait(continuation)
         }
     }
+}
+
+private func waitForSignal(
+    _ semaphore: DispatchSemaphore,
+    timeout: TimeInterval
+) -> Bool {
+    semaphore.wait(timeout: .now() + timeout) == .success
 }
 
 @main
@@ -43,98 +152,366 @@ struct ValidateMacOSRealtimeFinalization {
         let gate = RealtimeTranscriptionFinishGate(queue: queue)
 
         let completionTimeouts = LockedCounter()
-        queue.asyncAfter(deadline: .now() + 0.01) {
-            precondition(gate.resolve(with: "complete"))
-            precondition(!gate.resolve(with: "late"))
-        }
-        let completed = await waitForFinish(
+        let didBeginCompletion = await beginFinish(
             gate: gate,
             queue: queue,
             timeout: 0.05,
             timeoutCounter: completionTimeouts
         )
+        precondition(didBeginCompletion)
+        let didBeginDuplicate = await beginFinish(
+            gate: gate,
+            queue: queue,
+            timeout: 0.05,
+            timeoutCounter: completionTimeouts,
+            reset: false
+        )
+        precondition(!didBeginDuplicate)
+        let didResolveCompletion = await resolveFinish(
+            gate: gate,
+            queue: queue,
+            transcript: "complete"
+        )
+        precondition(didResolveCompletion)
+        let didResolveLateCompletion = await resolveFinish(
+            gate: gate,
+            queue: queue,
+            transcript: "late"
+        )
+        precondition(!didResolveLateCompletion)
+        let completed = await waitForFinish(gate: gate, queue: queue)
         precondition(completed == "complete")
         try await Task.sleep(for: .milliseconds(60))
         precondition(completionTimeouts.value == 0)
 
-        let closeTimeouts = LockedCounter()
-        queue.asyncAfter(deadline: .now() + 0.01) {
-            precondition(gate.resolve(with: nil))
-            precondition(!gate.resolve(with: "partial"))
-        }
-        let closed = await waitForFinish(
-            gate: gate,
-            queue: queue,
-            timeout: 0.05,
-            timeoutCounter: closeTimeouts
-        )
-        precondition(closed == nil)
-        try await Task.sleep(for: .milliseconds(60))
-        precondition(closeTimeouts.value == 0)
-
         let pendingTimeouts = LockedCounter()
-        let timedOut = await waitForFinish(
+        let didBeginTimeout = await beginFinish(
             gate: gate,
             queue: queue,
             timeout: 0.01,
             timeoutCounter: pendingTimeouts
         )
+        precondition(didBeginTimeout)
+        try await Task.sleep(for: .milliseconds(30))
+        let timedOut = await waitForFinish(gate: gate, queue: queue)
         precondition(timedOut == nil)
         precondition(pendingTimeouts.value == 1)
+        let didResolveAfterTimeout = await resolveFinish(
+            gate: gate,
+            queue: queue,
+            transcript: "incomplete"
+        )
+        precondition(!didResolveAfterTimeout)
+
+        let closeTimeouts = LockedCounter()
+        let didBeginClose = await beginFinish(
+            gate: gate,
+            queue: queue,
+            timeout: 0.05,
+            timeoutCounter: closeTimeouts
+        )
+        precondition(didBeginClose)
+        let didResolveClose = await resolveFinish(gate: gate, queue: queue, transcript: nil)
+        precondition(didResolveClose)
+        let closed = await waitForFinish(gate: gate, queue: queue)
+        precondition(closed == nil)
+        try await Task.sleep(for: .milliseconds(60))
+        precondition(closeTimeouts.value == 0)
+
+        let delivery = RealtimeAudioDeliveryQueue(label: "realtime-tail-validator")
+        let orderedEvents = LockedEvents()
+        delivery.handler = { chunk in
+            orderedEvents.append("audio-\(chunk.first ?? 0)")
+        }
+        let firstTail = delivery.beginDelivery()
+        let secondTail = delivery.beginDelivery()
+        precondition(firstTail != nil && secondTail != nil)
+        let drained = DispatchSemaphore(value: 0)
+        delivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            orderedEvents.append("finish")
+            drained.signal()
+        }
+        precondition(delivery.beginDelivery() == nil)
+        precondition(!waitForSignal(drained, timeout: 0.01))
+        firstTail?.deliver(Data([1]))
+        secondTail?.deliver(Data([2]))
+        precondition(waitForSignal(drained, timeout: 1))
+        precondition(orderedEvents.value == ["audio-1", "audio-2", "finish"])
+
+        // Key-up captures the finish request but leaves delivery open until
+        // native stop retires durable write admission. A callback beginning in
+        // that gap is therefore still part of the shared cutoff and must drain.
+        let gapDelivery = RealtimeAudioDeliveryQueue(label: "realtime-keyup-stop-gap-validator")
+        let gapEvents = LockedEvents()
+        gapDelivery.handler = { chunk in
+            gapEvents.append("gap-audio-\(chunk.first ?? 0)")
+        }
+        // Key-up: request ownership changes, but the delivery generation stays open.
+        let keyUpToStopTail = gapDelivery.beginDelivery()
+        precondition(keyUpToStopTail != nil)
+        let gapDrained = DispatchSemaphore(value: 0)
+        // Native stop: durable admission is retired immediately before this seal.
+        gapDelivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            gapEvents.append("finish")
+            gapDrained.signal()
+        }
+        precondition(!waitForSignal(gapDrained, timeout: 0.01))
+        keyUpToStopTail?.deliver(Data([9]))
+        precondition(waitForSignal(gapDrained, timeout: 1))
+        precondition(gapEvents.value == ["gap-audio-9", "finish"])
+
+        let discardDelivery = RealtimeAudioDeliveryQueue(label: "realtime-discard-validator")
+        discardDelivery.handler = { _ in }
+        let discarded = discardDelivery.beginDelivery()
+        let discardDrained = DispatchSemaphore(value: 0)
+        discardDelivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            discardDrained.signal()
+        }
+        precondition(!waitForSignal(discardDrained, timeout: 0.01))
+        discarded?.discard()
+        precondition(waitForSignal(discardDrained, timeout: 1))
+
+        let repeatedDelivery = RealtimeAudioDeliveryQueue(label: "realtime-repeat-validator")
+        let repeatedEvents = LockedEvents()
+        repeatedDelivery.handler = { chunk in
+            repeatedEvents.append("audio-\(chunk.first ?? 0)")
+        }
+        let repeatedTail = repeatedDelivery.beginDelivery()
+        let firstDrain = DispatchSemaphore(value: 0)
+        let secondDrain = DispatchSemaphore(value: 0)
+        repeatedDelivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            repeatedEvents.append("finish-1")
+            firstDrain.signal()
+        }
+        repeatedDelivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            repeatedEvents.append("finish-2")
+            secondDrain.signal()
+        }
+        precondition(!waitForSignal(firstDrain, timeout: 0.01))
+        precondition(!waitForSignal(secondDrain, timeout: 0.01))
+        repeatedTail?.deliver(Data([3]))
+        precondition(waitForSignal(firstDrain, timeout: 1))
+        precondition(waitForSignal(secondDrain, timeout: 1))
+        precondition(repeatedEvents.value == ["audio-3", "finish-1", "finish-2"])
+
+        let replacementDelivery = RealtimeAudioDeliveryQueue(label: "realtime-replace-validator")
+        let replacementEvents = LockedEvents()
+        replacementDelivery.handler = { _ in replacementEvents.append("old") }
+        let oldLease = replacementDelivery.beginDelivery()
+        replacementDelivery.handler = { _ in replacementEvents.append("new") }
+        let newLease = replacementDelivery.beginDelivery()
+        let replacementDrained = DispatchSemaphore(value: 0)
+        replacementDelivery.detachAndDrain { coverageIsComplete in
+            precondition(coverageIsComplete)
+            replacementEvents.append("finish")
+            replacementDrained.signal()
+        }
+        oldLease?.deliver(Data([1]))
+        precondition(!waitForSignal(replacementDrained, timeout: 0.01))
+        newLease?.deliver(Data([2]))
+        precondition(waitForSignal(replacementDrained, timeout: 1))
+        precondition(replacementEvents.value == ["old", "new", "finish"])
+
+        // A native-success buffer whose realtime conversion fails poisons the
+        // entire generation. Earlier valid chunks may have streamed, but the
+        // drain result must force the caller onto complete-file batch fallback.
+        let poisonedDelivery = RealtimeAudioDeliveryQueue(label: "realtime-poison-validator")
+        let poisonedEvents = LockedEvents()
+        poisonedDelivery.handler = { _ in poisonedEvents.append("audio") }
+        let validLease = poisonedDelivery.beginDelivery()
+        let failedConversionLease = poisonedDelivery.beginDelivery()
+        validLease?.deliver(Data([1]))
+        failedConversionLease?.failCoverage()
+        let poisonedClient = HangingFinalizer()
+        let poisonedRequest = RealtimeTranscriptionFinishRequest(client: poisonedClient)
+        let poisonDrained = DispatchSemaphore(value: 0)
+        poisonedDelivery.detachAndDrain { coverageIsComplete in
+            poisonedEvents.append(coverageIsComplete ? "complete" : "incomplete")
+            if coverageIsComplete {
+                poisonedRequest.requestFinish(timeout: 1)
+            } else {
+                poisonedRequest.close()
+            }
+            poisonDrained.signal()
+        }
+        precondition(waitForSignal(poisonDrained, timeout: 1))
+        precondition(poisonedEvents.value == ["audio", "incomplete"])
+        let poisonedResult = await poisonedRequest.finish()
+        precondition(poisonedResult == nil)
+        precondition(poisonedClient.requestCount == 0)
+        precondition(poisonedClient.closeCount == 1)
+
+        let hangingClient = HangingFinalizer()
+        let request = RealtimeTranscriptionFinishRequest(client: hangingClient)
+        let waitingTask = Task {
+            await request.finish()
+        }
+        while !hangingClient.finishStarted {
+            await Task.yield()
+        }
+        waitingTask.cancel()
+        let cancelledResult = await waitingTask.value
+        precondition(cancelledResult == nil)
+        precondition(hangingClient.closeCount == 1)
+
+        let deadlineClient = HangingFinalizer()
+        let deadlineRequest = RealtimeTranscriptionFinishRequest(client: deadlineClient)
+        deadlineRequest.armDrainDeadline(timeout: 0.01)
+        let deadlineResult = await deadlineRequest.finish()
+        precondition(deadlineResult == nil)
+        precondition(deadlineClient.closeCount == 1)
+        precondition(deadlineClient.requestCount == 0)
+
+        // If requestFinish wins the same instant a zero-delay drain deadline
+        // wakes, the stale deadline must not close the newly started commit.
+        for _ in 0 ..< 200 {
+            let racingClient = HangingFinalizer()
+            let racingRequest = RealtimeTranscriptionFinishRequest(client: racingClient)
+            racingRequest.armDrainDeadline(timeout: 0)
+            racingRequest.requestFinish(timeout: 1)
+            await Task.yield()
+            if racingClient.requestCount == 1 {
+                precondition(racingClient.closeCount == 0)
+            }
+            racingRequest.close()
+        }
+
+        let lateClient = HangingFinalizer()
+        let lateRequest = RealtimeTranscriptionFinishRequest(client: lateClient)
+        let lateDelivery = RealtimeAudioDeliveryQueue(label: "realtime-late-validator")
+        lateDelivery.handler = { _ in }
+        let lateLease = lateDelivery.beginDelivery()
+        let lateDrain = DispatchSemaphore(value: 0)
+        lateDelivery.detachAndDrain { _ in
+            lateRequest.requestFinish(timeout: 1)
+            lateDrain.signal()
+        }
+        lateRequest.close()
+        lateLease?.deliver(Data([4]))
+        precondition(waitForSignal(lateDrain, timeout: 1))
+        precondition(lateClient.closeCount == 1)
+        precondition(lateClient.requestCount == 0)
 
         let clientSource = try String(
             contentsOfFile: "Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift",
             encoding: .utf8
         )
-        precondition(clientSource.contains(
-            "func finish(timeout: TimeInterval = 1.5) async -> String? {\n"
-                + "        return await withCheckedContinuation { continuation in\n"
-                + "            sendQueue.async"
-        ))
-        precondition(clientSource.contains(
-            "guard self.isTransportDrained, let finalTranscript = self.finalTranscript"
-        ) || clientSource.contains(
-            "if self.isTransportDrained, let finalTranscript = self.finalTranscript"
-        ))
-        precondition(clientSource.contains(
-            "trackedItemIDs.isSubset(of: completedItemIDs)"
-        ))
-        precondition(clientSource.contains(
-            "self.abandonTransportOnQueue()\n"
-                + "            self.finishGate.resolve(with: nil)"
-        ))
-        precondition(clientSource.contains(
-            "Realtime finish timeout elapsed; discarding unproven stream"
-        ))
-        precondition(clientSource.contains(
-            "context: \"OpenAIRealtime\"\n"
-                + "                    )\n"
-                + "                    self.abandonTransportOnQueue()"
-        ))
-        precondition(clientSource.contains(
-            "self.sendQueue.async { [weak self] in\n"
-                + "                guard let self, !self.isClosed else { return }"
-        ))
-        precondition(clientSource.contains(
-            "failOnQueue(\"Realtime commit acknowledgement was missing its item ID\")"
-        ))
-        precondition(clientSource.contains(
-            "self.fail(\"OpenAI Realtime send failed:"
-        ))
-        precondition(clientSource.contains(
-            "failedMessage = message\n"
-                + "        DebugLog.warning"
-        ))
-        precondition(clientSource.contains(
-            "abandonTransportOnQueue()\n"
-                + "        finishGate.resolve(with: nil)"
-        ))
-        precondition(clientSource.contains(
-            "guard !self.isClosed else { return }"
-        ))
+        precondition(clientSource.contains("func requestFinish(timeout: TimeInterval = 1.5)"))
+        precondition(clientSource.contains("guard !didRequestFinish else { return }"))
+        precondition(clientSource.contains("func awaitFinish() async -> String?"))
+        precondition(clientSource.contains("self.finishGate.wait(continuation)"))
+        precondition(!clientSource.contains("self.beginFinishOnQueue(timeout: timeout)\n                self.finishGate.wait"))
+        precondition(clientSource.contains("guard !self.isClosed, !self.didRequestFinish else { return }"))
+        precondition(clientSource.contains("authorizationTask?.cancel()"))
+        precondition(clientSource.contains("Realtime finish timeout elapsed; discarding unproven stream"))
+        precondition(clientSource.contains("trackedItemIDs.isSubset(of: completedItemIDs)"))
+        precondition(clientSource.contains("failOnQueue(\"Realtime commit acknowledgement was missing its item ID\")"))
+        precondition(clientSource.contains("self.fail(\"OpenAI Realtime send failed:"))
         precondition(!clientSource.contains("finalTranscript ?? currentTranscript"))
-        precondition(!clientSource.contains("resumeFinishIfNeeded"))
 
-        print("macOS realtime finalization is queue-confined and fails closed")
+        let recorderSource = try String(
+            contentsOfFile: "Whishpermate/Whispermate/Services/AudioRecorder.swift",
+            encoding: .utf8
+        )
+        let leasePosition = recorderSource.range(
+            of: "let realtimeDeliveryLease = realtimeAudioDelivery.beginDelivery()"
+        )?.lowerBound
+        let writePosition = recorderSource.range(
+            of: "guard let writeResult = autoreleasepool"
+        )?.lowerBound
+        precondition(leasePosition != nil && writePosition != nil && leasePosition! < writePosition!)
+        precondition(recorderSource.contains("defer { realtimeDeliveryLease?.discard() }"))
+        precondition(!recorderSource.contains("guard session.isActive else { return }"))
+
+        let appStateSource = try String(
+            contentsOfFile: "Whishpermate/Whispermate/Services/AppState.swift",
+            encoding: .utf8
+        )
+        precondition(appStateSource.contains("drainDeadline: shouldFinishRealtime ? realtimeFinishTimeout : nil"))
+        precondition(appStateSource.contains("snapshot?.outputMode == .dictation"))
+        precondition(appStateSource.contains("snapshot?.transcriptionOptions.diarization == false"))
+        precondition(appStateSource.contains("let afterRealtimeAudioDrained: (@Sendable (Bool) -> Void)?"))
+        precondition(appStateSource.contains("afterRealtimeAudioDrained: afterRealtimeAudioDrained"))
+        precondition(appStateSource.contains("if coverageIsComplete {"))
+        precondition(appStateSource.contains("realtimeFinishRequest?.close()"))
+        let storeFinalizationPosition = appStateSource.range(
+            of: "let finalizing = try await store.beginFinalization("
+        )?.lowerBound
+        let nativeStopPosition = appStateSource.range(
+            of: "self.audioRecorder.stopRecording(\n                    disposition: disposition,"
+        )?.lowerBound
+        precondition(
+            storeFinalizationPosition != nil
+                && nativeStopPosition != nil
+                && storeFinalizationPosition! < nativeStopPosition!
+        )
+        let takeStart = appStateSource.range(
+            of: "private func takeRealtimeTranscription("
+        )?.lowerBound
+        let stopHelperStart = appStateSource.range(
+            of: "private func stopRealtimeTranscription()"
+        )?.lowerBound
+        precondition(takeStart != nil && stopHelperStart != nil)
+        let takeHelper = String(appStateSource[takeStart! ..< stopHelperStart!])
+        precondition(!takeHelper.contains("detachRealtimeAudioChunkHandlerAndDrain"))
+        let realtimeStartPosition = appStateSource.range(
+            of: "startRealtimeTranscriptionIfAvailable(\n                recordingID: recordingID,"
+        )?.lowerBound
+        let recorderStartPosition = appStateSource.range(
+            of: "audioRecorder.startRecording(\n                recordingID: attemptID,"
+        )?.lowerBound
+        precondition(
+            realtimeStartPosition != nil
+                && recorderStartPosition != nil
+                && realtimeStartPosition! < recorderStartPosition!
+        )
+        precondition(
+            appStateSource.components(
+                separatedBy: "startRealtimeTranscriptionIfAvailable("
+            ).count == 3
+        )
+        precondition(appStateSource.contains("snapshot.outputMode != .dictation || snapshot.transcriptionOptions.diarization"))
+        precondition(appStateSource.contains(
+            "case .failed(let message):\n            closeLiveRealtimeTranscription()"
+        ))
+        precondition(appStateSource.contains(
+            "let lease = activeCaptureLease\n        closeLiveRealtimeTranscription()"
+        ))
+        precondition(appStateSource.contains(
+            "recordingState = .finalizing\n        closeLiveRealtimeTranscription()"
+        ))
+        precondition(appStateSource.contains(
+            "private func closeLiveRealtimeTranscription()"
+        ))
+        precondition(appStateSource.contains("closeActiveRealtimeFinishRequest()"))
+        precondition(appStateSource.contains("defer { finishRealtimeRequest(realtimeFinishRequest) }"))
+
+        let recorderStopStart = recorderSource.range(
+            of: "func stopRecording(\n        disposition: StopDisposition"
+        )?.lowerBound
+        let recorderStopEnd = recorderSource.range(
+            of: "private func finishFinalization("
+        )?.lowerBound
+        precondition(recorderStopStart != nil && recorderStopEnd != nil)
+        let recorderStop = String(
+            recorderSource[recorderStopStart! ..< recorderStopEnd!]
+        )
+        let retirePosition = recorderStop.range(of: "session.retire()")?.lowerBound
+        let recorderDrainPosition = recorderStop.range(
+            of: "realtimeAudioDelivery.detachAndDrain { coverageIsComplete in\n            afterRealtimeAudioDrained?(coverageIsComplete)"
+        )?.lowerBound
+        precondition(
+            retirePosition != nil
+                && recorderDrainPosition != nil
+                && retirePosition! < recorderDrainPosition!
+        )
+        precondition(recorderSource.contains("realtimeDeliveryLease.failCoverage()"))
+
+        print("macOS realtime finalization covers the durable stream, starts once, and fails closed")
     }
 }


### PR DESCRIPTION
Starts live transcript finalization at the exact capture cutoff while durable audio finalization continues. Preserves complete head and tail coverage, rejects incomplete live streams, and safely falls back to the finalized recording.\n\nVerified with the strict concurrency validator, the full Apple recovery matrix, 62 macOS tests, and a full unsigned Debug build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790362887&installation_model_id=432087&pr_number=102&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F102&signature=682ba52657464a7713bf4a2cc21a048a3939165270c58da418ba4bb0c640eb15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->