### PR TITLE
Ship secure realtime dictation and macOS 0.0.112

### DIFF
--- a/Whishpermate/WhisperMateShared/Services/AuthManager.swift
+++ b/Whishpermate/WhisperMateShared/Services/AuthManager.swift
@@ -252,6 +252,22 @@ public class AuthManager: ObservableObject {
         return authURL
     }
 
+    /// Returns a fresh first-party access token for protected Writingmate APIs.
+    /// The Supabase session and refresh token remain in the app's Keychain-backed
+    /// auth storage; callers should use the returned token only for the request
+    /// they are about to make.
+    public func accessToken() async throws -> String {
+        guard await ensureValidSession(), let client = supabase.client else {
+            throw NSError(
+                domain: "AuthManager",
+                code: 401,
+                userInfo: [NSLocalizedDescriptionKey: "Sign in to use cloud transcription."]
+            )
+        }
+
+        return try await client.auth.session.accessToken
+    }
+
     public func openSignUp() {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in

--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -133,6 +133,11 @@ class AppState: ObservableObject {
             return
         }
 
+        guard !overlayManager.showMissingPermissionIfNeeded() else {
+            DebugLog.info("Recording blocked by missing system permission", context: "AppState")
+            return
+        }
+
         // Reset recording mode - command mode is only active when explicitly requested
         if !isCommandMode {
             recordingMode = .dictation
@@ -2605,9 +2610,6 @@ class AppState: ObservableObject {
                 }
             )
         case .custom:
-            guard let apiKey = snapshot.transcriptionAPIKey, !apiKey.isEmpty else {
-                return
-            }
             let realtimeModel = resolvedRealtimeTranscriptionModel(
                 configuredModel: snapshot.transcriptionModel,
                 overrideModel: snapshot.customRealtimeModel
@@ -2617,6 +2619,9 @@ class AppState: ObservableObject {
                 configuredEndpoint: snapshot.transcriptionEndpoint,
                 overrideEndpoint: snapshot.customRealtimeEndpoint
             ) {
+                guard let apiKey = snapshot.transcriptionAPIKey, !apiKey.isEmpty else {
+                    return
+                }
                 client = OpenAIRealtimeTranscriptionClient(
                     apiKey: apiKey,
                     webSocketURL: webSocketURL,
@@ -2645,9 +2650,19 @@ class AppState: ObservableObject {
 
                 client = OpenAIRealtimeTranscriptionClient(
                     authorizationProvider: {
-                        try await WritingmateRealtimeClientSecretProvider.fetchAuthorization(
+                        let token: String
+                        if Self.isWritingmateRealtimeSessionEndpoint(endpoint) {
+                            token = try await AuthManager.shared.accessToken()
+                        } else if let apiKey = snapshot.transcriptionAPIKey, !apiKey.isEmpty {
+                            token = apiKey
+                        } else {
+                            throw OpenAIRealtimeTranscriptionClientError.clientSecretRequestFailed(
+                                "Cloud transcription credentials are unavailable"
+                            )
+                        }
+                        return try await WritingmateRealtimeClientSecretProvider.fetchAuthorization(
                             endpoint: endpoint,
-                            apiKey: apiKey,
+                            apiKey: token,
                             model: realtimeModel,
                             prompt: realtimePrompt,
                             language: languageCode
@@ -2693,6 +2708,13 @@ class AppState: ObservableObject {
         return WritingmateRealtimeClientSecretProvider.endpoint(
             from: configuredEndpoint
         )
+    }
+
+    private static func isWritingmateRealtimeSessionEndpoint(_ endpoint: URL) -> Bool {
+        let host = endpoint.host?.lowercased()
+        return endpoint.scheme?.lowercased() == "https"
+            && (host == "writingmate.ai" || host == "www.writingmate.ai")
+            && endpoint.path == "/api/openai/v1/realtime/client_secrets"
     }
 
     private func customRealtimeWebSocketURL(

--- a/Whishpermate/Whispermate/Services/AudioRecorder.swift
+++ b/Whishpermate/Whispermate/Services/AudioRecorder.swift
@@ -11,6 +11,7 @@ class AudioRecorder: NSObject, ObservableObject {
     private enum Constants {
         static let recordingWatchdogInterval: TimeInterval = 1.0
         static let recordingBufferStallThreshold: TimeInterval = 2.5
+        static let captureRecoveryDelays: [TimeInterval] = [0.15, 0.5]
         static let recordingPreparationTimeout: TimeInterval = 5.0
         static let recordingFinalizationTimeout: TimeInterval = 5.0
 
@@ -142,10 +143,9 @@ class AudioRecorder: NSObject, ObservableObject {
             if changedDeviceUID == session.deviceResolution.device.uniqueID {
                 return
             }
-            session.retire()
-            reportCaptureFailure(
-                "The microphone changed while recording. Please record again.",
-                session: session
+            attemptCaptureRecovery(
+                session,
+                reason: "input device changed"
             )
         }
     }
@@ -166,12 +166,12 @@ class AudioRecorder: NSObject, ObservableObject {
             invalidatePendingPreparation(
                 message: "The microphone changed before recording started. Please try again."
             )
-        } else if isRecording, let session = activeCapture, session.engine === changedEngine {
-            session.retire()
-            reportCaptureFailure(
-                "The microphone changed while recording. Please record again.",
-                session: session
-            )
+        } else if isRecording,
+                  let session = activeCapture,
+                  session.owns(engine: changedEngine),
+                  !changedEngine.isRunning
+        {
+            attemptCaptureRecovery(session, reason: "audio configuration changed")
         }
     }
 
@@ -470,9 +470,19 @@ class AudioRecorder: NSObject, ObservableObject {
             )
             preparation.setSession(session)
 
-            inputNode.installTap(onBus: bus, bufferSize: 2048, format: nil) { [weak self, preparation, weak session] buffer, _ in
+            let generation = session.currentEngineGeneration
+            inputNode.installTap(onBus: bus, bufferSize: 2048, format: nil) { [weak self, preparation, weak session, weak engine] buffer, _ in
                 guard let self, let session else { return }
-                self.processCaptureBuffer(buffer, session: session, preparation: preparation)
+                guard let engine,
+                      session.accepts(engine: engine, generation: generation)
+                else { return }
+                self.processCaptureBuffer(
+                    buffer,
+                    session: session,
+                    preparation: preparation,
+                    engine: engine,
+                    generation: generation
+                )
             }
 
             guard preparation.attempt.isPending else {
@@ -504,7 +514,9 @@ class AudioRecorder: NSObject, ObservableObject {
     private func processCaptureBuffer(
         _ buffer: AVAudioPCMBuffer,
         session: MacCaptureSession,
-        preparation: MacCapturePreparation
+        preparation: MacCapturePreparation?,
+        engine: AVAudioEngine,
+        generation: UInt64
     ) {
         // Reserve realtime delivery before any file/conversion work. Native
         // stop seals this generation after retiring write admission and waits
@@ -580,11 +592,13 @@ class AudioRecorder: NSObject, ObservableObject {
 
             switch outcome {
             case .preparationFailed:
-                failPreparation(
-                    preparation,
-                    message: "The recording could not be saved. Please try again."
-                )
-                preparation.scheduleCleanup(deleteFile: true)
+                if let preparation {
+                    failPreparation(
+                        preparation,
+                        message: "The recording could not be saved. Please try again."
+                    )
+                    preparation.scheduleCleanup(deleteFile: true)
+                }
             case .activeFailed:
                 reportCaptureFailure(
                     "The recording could not be saved completely. Please record again.",
@@ -599,7 +613,9 @@ class AudioRecorder: NSObject, ObservableObject {
                 succeeded: true,
                 lease: writeResult.lease
             ) == .becameReady {
-                signalPreparationReady(preparation, session: session)
+                if let preparation {
+                    signalPreparationReady(preparation, session: session)
+                }
             }
         }
 
@@ -607,7 +623,10 @@ class AudioRecorder: NSObject, ObservableObject {
         // delivery is intentionally not gated by this later state check: a
         // lease acquired before key-up still corresponds to audio that was
         // successfully written above and must reach the final commit.
-        if session.isActive {
+        if session.isActive,
+           session.accepts(engine: engine, generation: generation)
+        {
+            session.noteHealthyBuffer()
             let bands = frequencyAnalyzer.analyze(buffer: buffer)
             let level = calculateAudioLevel(from: buffer)
             DispatchQueue.main.async { [weak self, weak session] in
@@ -746,25 +765,118 @@ class AudioRecorder: NSObject, ObservableObject {
             return
         }
 
-        guard let session = activeCapture, session.engine.isRunning else {
-            if let session = activeCapture {
+        guard let session = activeCapture else { return }
+        guard session.engine.isRunning else {
+            attemptCaptureRecovery(session, reason: "audio engine stopped")
+            return
+        }
+
+        guard let lastAudioBufferAt else { return }
+        if Date().timeIntervalSince(lastAudioBufferAt) > Constants.recordingBufferStallThreshold {
+            attemptCaptureRecovery(session, reason: "audio buffers stalled")
+        }
+    }
+
+    private func attemptCaptureRecovery(
+        _ session: MacCaptureSession,
+        reason: String
+    ) {
+        precondition(Thread.isMainThread)
+        guard activeCapture === session, isRecording else { return }
+        guard let recoveryAttempt = session.beginRecovery(
+            maximumAttempts: Constants.captureRecoveryDelays.count
+        ) else {
+            if session.recoveryAttemptsExhausted(
+                maximumAttempts: Constants.captureRecoveryDelays.count
+            ) {
                 session.retire()
                 reportCaptureFailure(
-                    "The microphone stopped responding. Please record again.",
+                    "The microphone stopped responding. AIDictation tried to reconnect automatically. Please try again.",
                     session: session
                 )
             }
             return
         }
 
-        guard let lastAudioBufferAt else { return }
-        if Date().timeIntervalSince(lastAudioBufferAt) > Constants.recordingBufferStallThreshold {
-            session.retire()
-            reportCaptureFailure(
-                "The microphone stopped responding. Please record again.",
-                session: session
+        stopRecordingWatchdog()
+        let delay = Constants.captureRecoveryDelays[recoveryAttempt - 1]
+        DebugLog.warning(
+            "Recovering microphone capture attempt=\(recoveryAttempt) reason=\(reason)",
+            context: "AudioRecorder LOG"
+        )
+        SentryTelemetry.recordAudioEngineEvent("capture_recovery_started")
+
+        session.recoveryQueue.asyncAfter(deadline: .now() + delay) { [weak self, weak session] in
+            guard let self, let session else { return }
+            let result = self.rebuildCaptureEngine(session)
+            DispatchQueue.main.async { [weak self, weak session] in
+                guard let self, let session, self.activeCapture === session, self.isRecording else {
+                    session?.finishRecovery(engineStarted: false)
+                    return
+                }
+
+                session.finishRecovery(engineStarted: result == nil)
+                if let result {
+                    DebugLog.warning(
+                        "Microphone recovery attempt failed: \(result)",
+                        context: "AudioRecorder LOG"
+                    )
+                    self.attemptCaptureRecovery(session, reason: "recovery start failed")
+                    return
+                }
+
+                self.lastAudioBufferAt = Date()
+                self.startRecordingWatchdog()
+                SentryTelemetry.recordAudioEngineEvent("capture_recovery_engine_started")
+            }
+        }
+    }
+
+    /// Replaces only the failed CoreAudio graph. The session's open audio file,
+    /// durable recording identity, and realtime delivery owner survive.
+    private func rebuildCaptureEngine(_ session: MacCaptureSession) -> String? {
+        guard session.isActive else { return "recording is no longer active" }
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        guard inputFormat.channelCount > 0 else {
+            return "microphone format is unavailable"
+        }
+
+        guard let replacement = session.replaceEngine(engine) else {
+            return "recording is no longer active"
+        }
+        teardownCaptureEngine(replacement.oldEngine)
+
+        inputNode.installTap(onBus: 0, bufferSize: 2048, format: nil) {
+            [weak self, weak session, weak engine] buffer, _ in
+            guard let self, let session, let engine,
+                  session.accepts(engine: engine, generation: replacement.generation)
+            else { return }
+            self.processCaptureBuffer(
+                buffer,
+                session: session,
+                preparation: nil,
+                engine: engine,
+                generation: replacement.generation
             )
         }
+
+        do {
+            engine.prepare()
+            try engine.start()
+            return nil
+        } catch {
+            teardownCaptureEngine(engine)
+            return error.localizedDescription
+        }
+    }
+
+    private func teardownCaptureEngine(_ engine: AVAudioEngine) {
+        engine.inputNode.removeTap(onBus: 0)
+        if engine.isRunning { engine.stop() }
+        engine.reset()
     }
 
     private func reportCaptureFailure(_ message: String, session: MacCaptureSession) {
@@ -1132,6 +1244,10 @@ private final class MacCaptureFinalization: @unchecked Sendable {
 }
 
 private final class MacCaptureSession: @unchecked Sendable {
+    struct EngineReplacement {
+        let oldEngine: AVAudioEngine
+        let generation: UInt64
+    }
     enum WriteLease {
         case preparation
         case active
@@ -1153,7 +1269,6 @@ private final class MacCaptureSession: @unchecked Sendable {
     }
 
     let recordingID: UUID
-    let engine: AVAudioEngine
     let recordingURL: URL
     let outputFormat: AVAudioFormat
     let deviceResolution: AudioDeviceManager.CaptureDeviceResolution
@@ -1162,12 +1277,19 @@ private final class MacCaptureSession: @unchecked Sendable {
     private let condition = NSCondition()
     private let cleanupClaim = RecordingPreparationCleanupClaim()
     private var phase: Phase = .preparing
+    private var engineStorage: AVAudioEngine
+    private var engineGeneration: UInt64 = 1
+    private var recoveryPolicy = MacCaptureRecoveryPolicy()
     private var audioFile: AVAudioFile?
     private var activeWrites = 0
     private var engineStarted = false
     private var wroteBuffer = false
     private var failureMessage: String?
     private var failureDeliveryClaimed = false
+    let recoveryQueue = DispatchQueue(
+        label: "ai.writingmate.audio-capture-recovery.\(UUID().uuidString)",
+        qos: .userInitiated
+    )
 
     // Resampling to 16 kHz is now the normal path rather than the exception, so
     // the converter has to outlive a single buffer: rebuilding it per callback
@@ -1284,7 +1406,7 @@ private final class MacCaptureSession: @unchecked Sendable {
         closeProof: MacNativeRecorderCloseProof
     ) {
         self.recordingID = recordingID
-        self.engine = engine
+        engineStorage = engine
         self.audioFile = audioFile
         self.recordingURL = recordingURL
         self.outputFormat = outputFormat
@@ -1296,6 +1418,90 @@ private final class MacCaptureSession: @unchecked Sendable {
         condition.lock()
         defer { condition.unlock() }
         return phase == .active
+    }
+
+    var engine: AVAudioEngine {
+        condition.lock()
+        defer { condition.unlock() }
+        return engineStorage
+    }
+
+    var currentEngineGeneration: UInt64 {
+        condition.lock()
+        defer { condition.unlock() }
+        return engineGeneration
+    }
+
+    func owns(engine: AVAudioEngine) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return phase != .retired && engineStorage === engine
+    }
+
+    func accepts(engine: AVAudioEngine, generation: UInt64) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return phase != .retired
+            && engineStorage === engine
+            && engineGeneration == generation
+    }
+
+    func replaceEngine(_ engine: AVAudioEngine) -> EngineReplacement? {
+        condition.lock()
+        guard phase == .active else {
+            condition.unlock()
+            return nil
+        }
+        let oldEngine = engineStorage
+        engineGeneration &+= 1
+        engineStorage = engine
+        let replacement = EngineReplacement(
+            oldEngine: oldEngine,
+            generation: engineGeneration
+        )
+        condition.unlock()
+
+        converterLock.lock()
+        cachedConverter = nil
+        cachedConverterInputFormat = nil
+        converterLock.unlock()
+        realtimeConverterLock.lock()
+        cachedRealtimeConverter = nil
+        cachedRealtimeConverterInputFormat = nil
+        cachedRealtimeConverterOutputFormat = nil
+        realtimeConverterLock.unlock()
+        return replacement
+    }
+
+    func beginRecovery(maximumAttempts: Int) -> Int? {
+        condition.lock()
+        defer { condition.unlock() }
+        guard phase == .active,
+              let attempt = recoveryPolicy.begin(maximumAttempts: maximumAttempts)
+        else { return nil }
+        return attempt
+    }
+
+    func finishRecovery(engineStarted: Bool) {
+        condition.lock()
+        recoveryPolicy.finish()
+        if !engineStarted, phase == .active {
+            condition.broadcast()
+        }
+        condition.unlock()
+    }
+
+    func recoveryAttemptsExhausted(maximumAttempts: Int) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return phase == .active
+            && recoveryPolicy.isExhausted(maximumAttempts: maximumAttempts)
+    }
+
+    func noteHealthyBuffer() {
+        condition.lock()
+        recoveryPolicy.noteHealthyBuffer()
+        condition.unlock()
     }
 
     func markEngineStarted() -> Bool {
@@ -1396,6 +1602,7 @@ private final class MacCaptureSession: @unchecked Sendable {
         guard cleanupClaim.claim() else { return }
 
         retire()
+        let engine = self.engine
         engine.inputNode.removeTap(onBus: 0)
         if engine.isRunning {
             engine.stop()

--- a/Whishpermate/Whispermate/Services/AudioRecorder.swift
+++ b/Whishpermate/Whispermate/Services/AudioRecorder.swift
@@ -619,7 +619,12 @@ class AudioRecorder: NSObject, ObservableObject {
         }
 
         if let realtimeDeliveryLease {
-            if let chunk = realtimePCMChunk(from: buffer) {
+            if let realtimeOutputFormat,
+               let chunk = session.realtimePCMChunk(
+                   from: buffer,
+                   outputFormat: realtimeOutputFormat
+               )
+            {
                 realtimeDeliveryLease.deliver(chunk)
             } else {
                 realtimeDeliveryLease.failCoverage()
@@ -831,45 +836,6 @@ class AudioRecorder: NSObject, ObservableObject {
 
         guard sampleCount > 0 else { return nil }
         return sqrt(sumSquares / Float(sampleCount))
-    }
-
-    private func realtimePCMChunk(from buffer: AVAudioPCMBuffer) -> Data? {
-        guard let realtimeOutputFormat else { return nil }
-
-        let inputFormat = buffer.format
-        guard let converter = AVAudioConverter(from: inputFormat, to: realtimeOutputFormat) else {
-            return nil
-        }
-
-        let ratio = realtimeOutputFormat.sampleRate / inputFormat.sampleRate
-        let frameCapacity = AVAudioFrameCount(max(1, ceil(Double(buffer.frameLength) * ratio)))
-        guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: realtimeOutputFormat, frameCapacity: frameCapacity) else {
-            return nil
-        }
-
-        var conversionError: NSError?
-        var didProvideInput = false
-        converter.convert(to: convertedBuffer, error: &conversionError) { _, outStatus in
-            if didProvideInput {
-                outStatus.pointee = .noDataNow
-                return nil
-            }
-
-            didProvideInput = true
-            outStatus.pointee = .haveData
-            return buffer
-        }
-
-        if let conversionError {
-            DebugLog.info("Realtime audio conversion failed: \(conversionError)", context: "AudioRecorder")
-            return nil
-        }
-
-        guard let channelData = convertedBuffer.int16ChannelData else { return nil }
-        let byteCount = Int(convertedBuffer.frameLength) * MemoryLayout<Int16>.size
-        guard byteCount > 0 else { return nil }
-
-        return Data(bytes: channelData.pointee, count: byteCount)
     }
 
     func stopRecording(
@@ -1210,6 +1176,15 @@ private final class MacCaptureSession: @unchecked Sendable {
     private var cachedConverter: AVAudioConverter?
     private var cachedConverterInputFormat: AVAudioFormat?
 
+    // Realtime audio has its own 24 kHz PCM target. This converter must also
+    // outlive individual tap callbacks: rebuilding it for every 2,048-frame
+    // buffer repeatedly discards the resampler's priming/filter state and
+    // produces discontinuities in the bytes sent over the WebSocket.
+    private let realtimeConverterLock = NSLock()
+    private var cachedRealtimeConverter: AVAudioConverter?
+    private var cachedRealtimeConverterInputFormat: AVAudioFormat?
+    private var cachedRealtimeConverterOutputFormat: AVAudioFormat?
+
     /// Returns a converter from `inputFormat` to `outputFormat`, reusing the
     /// previous one whenever the device keeps handing us the same format.
     func converter(from inputFormat: AVAudioFormat) -> AVAudioConverter? {
@@ -1226,6 +1201,77 @@ private final class MacCaptureSession: @unchecked Sendable {
         cachedConverter = converter
         cachedConverterInputFormat = inputFormat
         return converter
+    }
+
+    func realtimePCMChunk(
+        from buffer: AVAudioPCMBuffer,
+        outputFormat: AVAudioFormat
+    ) -> Data? {
+        realtimeConverterLock.lock()
+        defer { realtimeConverterLock.unlock() }
+
+        let inputFormat = buffer.format
+        let converter: AVAudioConverter
+        if let cachedRealtimeConverter,
+           cachedRealtimeConverterInputFormat == inputFormat,
+           cachedRealtimeConverterOutputFormat == outputFormat
+        {
+            converter = cachedRealtimeConverter
+        } else {
+            guard let newConverter = AVAudioConverter(
+                from: inputFormat,
+                to: outputFormat
+            ) else { return nil }
+            cachedRealtimeConverter = newConverter
+            cachedRealtimeConverterInputFormat = inputFormat
+            cachedRealtimeConverterOutputFormat = outputFormat
+            converter = newConverter
+        }
+
+        let ratio = outputFormat.sampleRate / inputFormat.sampleRate
+        // Leave room for stateful resampler output that crosses a callback
+        // boundary instead of truncating it to this callback's ideal ratio.
+        let frameCapacity = AVAudioFrameCount(
+            max(1, ceil(Double(buffer.frameLength) * ratio) + 64)
+        )
+        guard let convertedBuffer = AVAudioPCMBuffer(
+            pcmFormat: outputFormat,
+            frameCapacity: frameCapacity
+        ) else { return nil }
+
+        var conversionError: NSError?
+        var didProvideInput = false
+        let status = converter.convert(
+            to: convertedBuffer,
+            error: &conversionError
+        ) { _, outStatus in
+            if didProvideInput {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            didProvideInput = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        if let conversionError {
+            DebugLog.info(
+                "Realtime audio conversion failed: \(conversionError)",
+                context: "AudioRecorder"
+            )
+            return nil
+        }
+        guard status != .error else { return nil }
+        return Self.int16PCMData(from: convertedBuffer)
+    }
+
+    private static func int16PCMData(
+        from buffer: AVAudioPCMBuffer
+    ) -> Data? {
+        guard let channelData = buffer.int16ChannelData else { return nil }
+        let byteCount = Int(buffer.frameLength) * MemoryLayout<Int16>.size
+        guard byteCount > 0 else { return nil }
+        return Data(bytes: channelData.pointee, count: byteCount)
     }
 
     init(

--- a/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
+++ b/Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift
@@ -484,6 +484,12 @@ nonisolated final class OpenAIRealtimeTranscriptionClient: @unchecked Sendable, 
     }
 
     private func commitAudioBufferIfNeeded(reason: String) {
+        // gpt-live-transcribe emits deltas while audio is appended. Committing
+        // every ~0.8 seconds incorrectly turns one dictation into dozens of
+        // tiny, independently finalized utterances. Keep the legacy cadence
+        // only for the older realtime-whisper contract; live transcription is
+        // committed once after the recorder's delivery queue drains.
+        guard transcriptionModel == Self.defaultTranscriptionModel else { return }
         guard uncommittedAudioByteCount >= Self.liveCommitByteThreshold else { return }
         commitAudioBuffer(reason: reason)
     }

--- a/Whishpermate/Whispermate/Services/OverlayWindowManager.swift
+++ b/Whishpermate/Whispermate/Services/OverlayWindowManager.swift
@@ -1,8 +1,38 @@
 import AppKit
+import ApplicationServices
 import SwiftUI
 import WhisperMateShared
 internal import Combine
 import AVFoundation
+
+enum OverlayPermissionIssue: Equatable {
+    case microphone
+    case accessibility
+
+    var message: String {
+        switch self {
+        case .microphone:
+            return "Microphone access is off"
+        case .accessibility:
+            return "Accessibility access is off"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .microphone:
+            return "mic.slash.fill"
+        case .accessibility:
+            return "hand.raised.fill"
+        }
+    }
+}
+
+enum OverlayPermissionCalloutMetrics {
+    static let width: CGFloat = 250
+    static let height: CGFloat = 36
+    static let spacing: CGFloat = 8
+}
 
 enum OverlayPosition: String, CaseIterable, Codable {
     case top = "Top"
@@ -98,6 +128,7 @@ class OverlayWindowManager: ObservableObject {
 
     @Published var isRecording = false
     @Published var isProcessing = false
+    @Published private(set) var permissionIssue: OverlayPermissionIssue?
 
     @Published var audioLevel: Float = 0.0 {
         didSet {
@@ -350,6 +381,98 @@ class OverlayWindowManager: ObservableObject {
         transition(to: .idle)
     }
 
+    /// Returns true when capture should remain idle while the user fixes a
+    /// missing system permission. The issue is rendered beside the overlay.
+    @discardableResult
+    func showMissingPermissionIfNeeded() -> Bool {
+        if AVCaptureDevice.authorizationStatus(for: .audio) != .authorized {
+            showPermissionIssue(.microphone)
+            return true
+        }
+
+        if !AXIsProcessTrusted() {
+            showPermissionIssue(.accessibility)
+            return true
+        }
+
+        clearPermissionIssue()
+        return false
+    }
+
+    func setUpPermission() {
+        guard let permissionIssue else { return }
+
+        switch permissionIssue {
+        case .microphone:
+            switch AVCaptureDevice.authorizationStatus(for: .audio) {
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                    DispatchQueue.main.async {
+                        guard let self else { return }
+                        if granted {
+                            self.initializeAudioObservers()
+                            self.refreshPermissionIssue()
+                        }
+                    }
+                }
+            case .denied, .restricted:
+                PrivacyPermissionFlowManager.shared.open(.microphone)
+            case .authorized:
+                initializeAudioObservers()
+                refreshPermissionIssue()
+            @unknown default:
+                PrivacyPermissionFlowManager.shared.open(.microphone)
+            }
+
+        case .accessibility:
+            PrivacyPermissionFlowManager.shared.open(
+                .accessibility,
+                promptForAccessibilityTrust: true,
+                permissionGranted: { AXIsProcessTrusted() }
+            )
+        }
+    }
+
+    private func showPermissionIssue(_ issue: OverlayPermissionIssue) {
+        guard permissionIssue != issue else {
+            ensureWindowExists()
+            overlayWindow?.orderFrontRegardless()
+            return
+        }
+
+        permissionIssue = issue
+        hoverCollapseResizeWorkItem?.cancel()
+        keepIdleVisibleAfterCollapse = true
+        ensureWindowExists()
+        positionStage()
+        overlayWindow?.orderFrontRegardless()
+    }
+
+    private func clearPermissionIssue() {
+        guard permissionIssue != nil else { return }
+        permissionIssue = nil
+        positionStage()
+        if overlayState == .idle, hideIdleState {
+            overlayWindow?.orderOut(nil)
+        }
+    }
+
+    private func refreshPermissionIssue() {
+        guard let permissionIssue else { return }
+
+        let isGranted: Bool
+        switch permissionIssue {
+        case .microphone:
+            isGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        case .accessibility:
+            isGranted = AXIsProcessTrusted()
+        }
+
+        if isGranted {
+            clearPermissionIssue()
+        }
+    }
+
     private func ensureWindowExists() {
         if overlayWindow == nil {
             DebugLog.info("ensureWindowExists: creating window", context: "OverlayWindowManager")
@@ -432,7 +555,7 @@ class OverlayWindowManager: ObservableObject {
         guard overlayState == .idle else { return }
         DebugLog.info("onCollapseAnimationComplete", context: "OverlayWindowManager")
         updateWindowSizeForState(.idle, animated: false, preserveAnchor: true)
-        let shouldHideIdle = hideIdleState && !keepIdleVisibleAfterCollapse
+        let shouldHideIdle = hideIdleState && permissionIssue == nil && !keepIdleVisibleAfterCollapse
         keepIdleVisibleAfterCollapse = false
         if shouldHideIdle {
             overlayWindow?.orderOut(nil)
@@ -478,13 +601,19 @@ class OverlayWindowManager: ObservableObject {
             DebugLog.warning("positionStage skipped: window or target screen missing", context: "OverlayWindowManager")
             return
         }
+        let stageWidth = permissionIssue == nil
+            ? Constants.stageWidth
+            : Constants.stageWidth + 2 * (OverlayPermissionCalloutMetrics.width + OverlayPermissionCalloutMetrics.spacing)
+        let stageHeight = permissionIssue == nil
+            ? Constants.stageHeight
+            : max(Constants.stageHeight, OverlayPermissionCalloutMetrics.height + (Constants.edgeMargin * 2))
         let (xPos, yPos) = calculatePosition(
             for: position,
             screenFrame: screen.visibleFrame,
-            windowWidth: Constants.stageWidth,
-            windowHeight: Constants.stageHeight
+            windowWidth: stageWidth,
+            windowHeight: stageHeight
         )
-        let newFrame = NSRect(x: xPos, y: yPos, width: Constants.stageWidth, height: Constants.stageHeight)
+        let newFrame = NSRect(x: xPos, y: yPos, width: stageWidth, height: stageHeight)
         guard window.frame != newFrame else { return }
         DebugLog.info(
             "positionStage screen=\(describeScreen(screen)) frame=\(formatRect(newFrame))",
@@ -644,6 +773,7 @@ class OverlayWindowManager: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             DebugLog.info("Frontmost app changed, repositioning overlay", context: "OverlayWindowManager")
+            self?.refreshPermissionIssue()
             self?.logWindowState("observer-activate-before")
             self?.repositionWindow()
             guard let self else { return }

--- a/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
+++ b/Whishpermate/Whispermate/Services/RealtimeTranscriptionFinishGate.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+/// Deterministic attempt policy for rebuilding a failed capture graph without
+/// ending the user's recording. Its owner supplies serialization.
+struct MacCaptureRecoveryPolicy {
+    private(set) var attemptCount = 0
+    private(set) var isRecovering = false
+
+    mutating func begin(maximumAttempts: Int) -> Int? {
+        guard !isRecovering, attemptCount < maximumAttempts else { return nil }
+        isRecovering = true
+        attemptCount += 1
+        return attemptCount
+    }
+
+    mutating func finish() {
+        isRecovering = false
+    }
+
+    mutating func noteHealthyBuffer() {
+        attemptCount = 0
+        isRecovering = false
+    }
+
+    func isExhausted(maximumAttempts: Int) -> Bool {
+        !isRecovering && attemptCount >= maximumAttempts
+    }
+}
+
 nonisolated protocol RealtimeTranscriptionFinalizing: AnyObject, Sendable {
     func requestFinish(timeout: TimeInterval)
     func awaitFinish() async -> String?

--- a/Whishpermate/Whispermate/Services/StatusBarManager.swift
+++ b/Whishpermate/Whispermate/Services/StatusBarManager.swift
@@ -375,11 +375,13 @@ class StatusBarManager: NSObject, NSMenuDelegate {
         let window = appWindow ?? findMainWindow()
 
         if let window = window {
-            if window.isVisible {
+            if window.isVisible, window.isKeyWindow, NSApplication.shared.isActive {
                 window.orderOut(nil)
             } else {
                 NSApplication.shared.activate(ignoringOtherApps: true)
+                window.setIsVisible(true)
                 window.makeKeyAndOrderFront(nil)
+                window.orderFrontRegardless()
             }
         } else {
             showMainSettingsWindow()

--- a/Whishpermate/Whispermate/Views/OnboardingView.swift
+++ b/Whishpermate/Whispermate/Views/OnboardingView.swift
@@ -50,11 +50,11 @@ struct OnboardingView: View {
         }
     }
 
-    // Gradient colors
+    // Keep the existing onboarding artwork, but use the exact same primary
+    // action color as Settings for every prominent button and selected control.
     private let gradientStart = Color(red: 1.0, green: 0.494, blue: 0.78) // #FF7EC7
     private let gradientEnd = Color(red: 1.0, green: 0.929, blue: 0.275) // #FFED46
-
-    private let accentColor = Color(red: 0.945, green: 0.431, blue: 0.0) // #F16E00
+    private let accentColor = Color.dsPrimary
     private var isAccountSignedIn: Bool {
         authManager.isAuthenticated && authManager.currentUser != nil
     }

--- a/Whishpermate/Whispermate/Views/RecordingOverlayView.swift
+++ b/Whishpermate/Whispermate/Views/RecordingOverlayView.swift
@@ -192,8 +192,24 @@ struct RecordingOverlayView: View {
 
     @ViewBuilder
     private func overlayContent(geometry _: GeometryProxy) -> some View {
-        // Horizontal layout for top/bottom positions
-        contentView
+        Group {
+            if let permissionIssue = manager.permissionIssue {
+                HStack(spacing: OverlayPermissionCalloutMetrics.spacing) {
+                    Color.clear
+                        .frame(
+                            width: OverlayPermissionCalloutMetrics.width,
+                            height: OverlayPermissionCalloutMetrics.height
+                        )
+                        .allowsHitTesting(false)
+
+                    contentView
+
+                    permissionCallout(permissionIssue)
+                }
+            } else {
+                contentView
+            }
+        }
         .padding(.top, idleHoverTopHitPadding)
         .fixedSize()
         .contentShape(Rectangle())
@@ -219,6 +235,45 @@ struct RecordingOverlayView: View {
                 collapseIdleHover()
             }
         }
+    }
+
+    private func permissionCallout(_ issue: OverlayPermissionIssue) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: issue.iconName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.orange)
+
+            Text(issue.message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(Color.white)
+                .lineLimit(1)
+
+            Spacer(minLength: 4)
+
+            Button("Set Up") {
+                updateHoverCursor(isActive: false)
+                manager.setUpPermission()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .tint(Color.orange)
+            .accessibilityLabel("Set up \(issue.message.lowercased())")
+        }
+        .padding(.horizontal, 10)
+        .frame(
+            width: OverlayPermissionCalloutMetrics.width,
+            height: OverlayPermissionCalloutMetrics.height
+        )
+        .background {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.black.opacity(0.86))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color.white.opacity(0.14), lineWidth: 0.75)
+                }
+        }
+        .shadow(color: .black.opacity(0.16), radius: 5, y: 2)
+        .transition(.opacity.combined(with: .move(edge: .trailing)))
     }
 
     // MARK: - Subviews

--- a/Whishpermate/Whispermate/WhispermateApp.swift
+++ b/Whishpermate/Whispermate/WhispermateApp.swift
@@ -222,10 +222,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             mainWindow?.orderOut(nil)
             return
         }
-        let state = AppState.shared
-        if state.recordingState != .idle || state.isProcessing {
-            mainWindow?.orderOut(nil)
-        }
+        // Activation can be the direct result of the user choosing Settings.
+        // Never hide an explicitly presented window merely because a recording
+        // is finishing in the background.
     }
 
     func applicationDockMenu(_: NSApplication) -> NSMenu? {
@@ -566,8 +565,20 @@ extension View {
 
 /// Global function to show main window - can be called from anywhere
 func showMainSettingsWindow(retryCount: Int = 0) {
+    precondition(Thread.isMainThread)
+    DebugLog.info(
+        "showMainSettingsWindow requested attempt=\(retryCount)",
+        context: "WindowManagement"
+    )
+
     // Don't show settings while onboarding is active
     if OnboardingManager.shared.showOnboarding {
+        DebugLog.info(
+            "Settings requested during onboarding; presenting onboarding",
+            context: "WindowManagement"
+        )
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        WindowBridge.openLegacyWindow(id: "onboarding")
         return
     }
 
@@ -596,21 +607,16 @@ func showMainSettingsWindow(retryCount: Int = 0) {
         return
     }
 
-    // Window doesn't exist yet — ask SwiftUI to create it, then retry
-    if retryCount < 3 {
-        if MainSettingsWindowOpenState.shouldRequestCreation() {
-            DebugLog.info("showMainSettingsWindow: window not found, requesting creation (attempt \(retryCount + 1))", context: "WindowManagement")
-            WindowBridge.openWindow?("main")
-        } else {
-            DebugLog.info("showMainSettingsWindow: creation already in progress (attempt \(retryCount + 1))", context: "WindowManagement")
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            showMainSettingsWindow(retryCount: retryCount + 1)
-        }
-    } else {
-        MainSettingsWindowOpenState.resolve()
-        DebugLog.info("showMainSettingsWindow: failed to find/create window after 3 attempts", context: "WindowManagement")
-    }
+    // SwiftUI's openWindow action is not guaranteed to have materialized its
+    // scene while a menu-bar-only app is inactive. Create the same hosted view
+    // synchronously through AppKit so a Settings request always has an actual
+    // window to raise.
+    MainSettingsWindowOpenState.resolve()
+    DebugLog.info(
+        "showMainSettingsWindow: creating synchronous AppKit fallback",
+        context: "WindowManagement"
+    )
+    WindowBridge.openLegacyWindow(id: "main")
 }
 
 /// Global function to show history window - can be called from anywhere

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,14 @@
         <description>Latest AIDictation releases.</description>
         <language>en</language>
         <item>
+            <title>0.0.112</title>
+            <pubDate>Thu, 27 Aug 2026 08:14:12 +0000</pubDate>
+            <sparkle:version>112</sparkle:version>
+            <sparkle:shortVersionString>0.0.112</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://github.com/writingmate/aidictation/releases/download/v0.0.112/AIDictation-v0.0.112.dmg" length="13220370" type="application/octet-stream"/>
+        </item>
+        <item>
             <title>0.0.110</title>
             <pubDate>Wed, 26 Aug 2026 05:15:59 +0000</pubDate>
             <sparkle:version>110</sparkle:version>

--- a/scripts/validate_macos_realtime_finalization.swift
+++ b/scripts/validate_macos_realtime_finalization.swift
@@ -148,6 +148,17 @@ private func waitForSignal(
 @main
 struct ValidateMacOSRealtimeFinalization {
     static func main() async throws {
+        var recovery = MacCaptureRecoveryPolicy()
+        precondition(recovery.begin(maximumAttempts: 2) == 1)
+        precondition(recovery.begin(maximumAttempts: 2) == nil)
+        recovery.finish()
+        precondition(recovery.begin(maximumAttempts: 2) == 2)
+        recovery.finish()
+        precondition(recovery.isExhausted(maximumAttempts: 2))
+        recovery.noteHealthyBuffer()
+        precondition(recovery.begin(maximumAttempts: 2) == 1)
+        recovery.finish()
+
         let queue = DispatchQueue(label: "realtime-finish-validator")
         let gate = RealtimeTranscriptionFinishGate(queue: queue)
 
@@ -511,6 +522,10 @@ struct ValidateMacOSRealtimeFinalization {
                 && retirePosition! < recorderDrainPosition!
         )
         precondition(recorderSource.contains("realtimeDeliveryLease.failCoverage()"))
+        precondition(recorderSource.contains("captureRecoveryDelays: [TimeInterval] = [0.15, 0.5]"))
+        precondition(recorderSource.contains("session.replaceEngine(engine)"))
+        precondition(recorderSource.contains("session.accepts(engine: engine, generation: replacement.generation)"))
+        precondition(recorderSource.contains("self.attemptCaptureRecovery(session, reason: \"recovery start failed\")"))
 
         print("macOS realtime finalization covers the durable stream, starts once, and fails closed")
     }


### PR DESCRIPTION
Ships authenticated realtime transcription, microphone self-recovery, reliable Settings foregrounding, aligned onboarding button colors, and the v0.0.112 Sparkle appcast entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790410827&installation_model_id=432087&pr_number=104&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F104&signature=318cec913871fd9ebd85897c9800479e0b9226f9f85bdc8f3928463401d935fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->