### PR TITLE
Fix built-in mic source-change crash by ignoring device changes during capture

### DIFF
--- a/Whishpermate/Whispermate/Services/AudioDeviceManager.swift
+++ b/Whishpermate/Whispermate/Services/AudioDeviceManager.swift
@@ -575,6 +575,11 @@ class AudioDeviceManager: ObservableObject {
             || shouldPreferExternalInputOverBuiltIn(availableDevices: availableDevices)
     }
 
+    /// Returns whether the device is a built-in microphone.
+    func isBuiltInDevice(_ device: AudioDevice) -> Bool {
+        isBuiltInInputDevice(device.id)
+    }
+
     private func isBuiltInInputDevice(_ deviceID: AudioDeviceID) -> Bool {
         if let transportType = getDeviceTransportType(deviceID: deviceID),
            transportType == kAudioDeviceTransportTypeBuiltIn

--- a/Whishpermate/Whispermate/Services/AudioRecorder.swift
+++ b/Whishpermate/Whispermate/Services/AudioRecorder.swift
@@ -131,22 +131,30 @@ class AudioRecorder: NSObject, ObservableObject {
         DebugLog.info("Audio input device changed", context: "AudioRecorder LOG")
         SentryTelemetry.recordAudioEngineEvent("input_device_changed")
 
-        let changedDeviceUID = notification.object as? String
-        if let pendingPreparation {
-            if !pendingPreparation.shouldInvalidate(forChangedDeviceUID: changedDeviceUID) {
-                return
-            }
-            invalidatePendingPreparation(
-                message: "The microphone changed before recording started. Please try again."
+        // Device is pinned for the duration of preparation and recording.
+        // Ignore device-change notifications to prevent source-change crashes
+        // that occur when Core Audio reconfigures mid-start. The selected
+        // device continues to be used; any format issues are caught by the
+        // normal preparation/watchdog paths without tearing down the session.
+        if pendingPreparation != nil {
+            DebugLog.info(
+                "Ignoring device change during preparation - device is pinned",
+                context: "AudioRecorder LOG"
             )
-        } else if isRecording, let session = activeCapture {
-            if changedDeviceUID == session.deviceResolution.device.uniqueID {
-                return
-            }
-            attemptCaptureRecovery(
-                session,
-                reason: "input device changed"
+            SentryTelemetry.recordAudioEngineEvent(
+                "device_change_ignored_preparation"
             )
+            return
+        }
+        if isRecording, activeCapture != nil {
+            DebugLog.info(
+                "Ignoring device change during recording - device is pinned",
+                context: "AudioRecorder LOG"
+            )
+            SentryTelemetry.recordAudioEngineEvent(
+                "device_change_ignored_recording"
+            )
+            return
         }
     }
 
@@ -162,16 +170,34 @@ class AudioRecorder: NSObject, ObservableObject {
         SentryTelemetry.recordAudioEngineEvent("configuration_changed")
 
         guard let changedEngine = notification.object as? AVAudioEngine else { return }
+
+        // Engine configuration changes are ignored during preparation and
+        // active recording. Reacting to them mid-start caused source-change
+        // crashes: Core Audio was reconfiguring the IO unit while we tried to
+        // tear down or rebuild the engine. The pinned device continues to be
+        // used; if the engine actually stops, the watchdog will catch it.
         if let pendingPreparation, pendingPreparation.owns(engine: changedEngine) {
-            invalidatePendingPreparation(
-                message: "The microphone changed before recording started. Please try again."
+            DebugLog.info(
+                "Ignoring engine configuration change during preparation - device is pinned",
+                context: "AudioRecorder LOG"
             )
-        } else if isRecording,
-                  let session = activeCapture,
-                  session.owns(engine: changedEngine),
-                  !changedEngine.isRunning
+            SentryTelemetry.recordAudioEngineEvent(
+                "config_change_ignored_preparation"
+            )
+            return
+        }
+        if isRecording,
+           let session = activeCapture,
+           session.owns(engine: changedEngine)
         {
-            attemptCaptureRecovery(session, reason: "audio configuration changed")
+            DebugLog.info(
+                "Ignoring engine configuration change during recording - device is pinned",
+                context: "AudioRecorder LOG"
+            )
+            SentryTelemetry.recordAudioEngineEvent(
+                "config_change_ignored_recording"
+            )
+            return
         }
     }
 

--- a/scripts/validate_macos_preparation_format_retry.swift
+++ b/scripts/validate_macos_preparation_format_retry.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+private enum ValidationFailure: Error, CustomStringConvertible {
+    case failed(String)
+
+    var description: String {
+        switch self {
+        case .failed(let message): message
+        }
+    }
+}
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    guard condition() else { throw ValidationFailure.failed(message) }
+}
+
+/// Validates that AudioRecorder.swift ignores device/configuration changes
+/// during preparation and recording to prevent source-change crashes.
+/// This contract ensures NO waits, delays, or retries on the recording
+/// start path while still protecting against mid-start reconfiguration.
+@main
+private struct SourceChangePinningValidator {
+    static func main() throws {
+        let workspaceRoot = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let audioRecorderPath = workspaceRoot
+            .appendingPathComponent("Whishpermate/Whispermate/Services/AudioRecorder.swift")
+        let recorderSource = try String(contentsOf: audioRecorderPath, encoding: .utf8)
+
+        // 1. Verify NO preparation format retry delays exist (removed)
+        try require(
+            !recorderSource.contains("preparationFormatRetryDelays"),
+            "AudioRecorder must NOT have preparationFormatRetryDelays - no waits on start path"
+        )
+
+        // 2. Verify NO prepareCaptureWithRetry method exists (removed)
+        try require(
+            !recorderSource.contains("prepareCaptureWithRetry"),
+            "AudioRecorder must NOT have prepareCaptureWithRetry - no retry waits on start"
+        )
+
+        // 3. Verify device change is IGNORED during preparation
+        try require(
+            recorderSource.contains("Ignoring device change during preparation"),
+            "handleAudioDeviceChanged must ignore changes during preparation"
+        )
+
+        // 4. Verify device change is IGNORED during recording
+        try require(
+            recorderSource.contains("Ignoring device change during recording"),
+            "handleAudioDeviceChanged must ignore changes during recording"
+        )
+
+        // 5. Verify engine config change is IGNORED during preparation
+        try require(
+            recorderSource.contains("Ignoring engine configuration change during preparation"),
+            "handleAudioEngineConfigurationChanged must ignore changes during preparation"
+        )
+
+        // 6. Verify engine config change is IGNORED during recording
+        try require(
+            recorderSource.contains("Ignoring engine configuration change during recording"),
+            "handleAudioEngineConfigurationChanged must ignore changes during recording"
+        )
+
+        // 7. Verify telemetry for ignored device changes
+        try require(
+            recorderSource.contains("device_change_ignored_preparation"),
+            "Must log device_change_ignored_preparation telemetry"
+        )
+        try require(
+            recorderSource.contains("device_change_ignored_recording"),
+            "Must log device_change_ignored_recording telemetry"
+        )
+
+        // 8. Verify telemetry for ignored config changes
+        try require(
+            recorderSource.contains("config_change_ignored_preparation"),
+            "Must log config_change_ignored_preparation telemetry"
+        )
+        try require(
+            recorderSource.contains("config_change_ignored_recording"),
+            "Must log config_change_ignored_recording telemetry"
+        )
+
+        // 9. Verify device is described as "pinned"
+        try require(
+            recorderSource.contains("device is pinned"),
+            "Log messages must indicate device is pinned for the session"
+        )
+
+        // 10. Verify NO invalidatePendingPreparation in handleAudioDeviceChanged
+        // (should not tear down preparation on device change)
+        let deviceChangedMethod = extractMethod(
+            named: "handleAudioDeviceChanged",
+            from: recorderSource
+        )
+        try require(
+            !deviceChangedMethod.contains("invalidatePendingPreparation"),
+            "handleAudioDeviceChanged must NOT call invalidatePendingPreparation"
+        )
+
+        // 11. Verify NO invalidatePendingPreparation in handleAudioEngineConfigurationChanged
+        let configChangedMethod = extractMethod(
+            named: "handleAudioEngineConfigurationChanged",
+            from: recorderSource
+        )
+        try require(
+            !configChangedMethod.contains("invalidatePendingPreparation"),
+            "handleAudioEngineConfigurationChanged must NOT call invalidatePendingPreparation"
+        )
+
+        // 12. Verify NO attemptCaptureRecovery in handleAudioDeviceChanged
+        try require(
+            !deviceChangedMethod.contains("attemptCaptureRecovery"),
+            "handleAudioDeviceChanged must NOT call attemptCaptureRecovery (no delayed recovery on device change)"
+        )
+
+        // 13. Verify NO attemptCaptureRecovery in handleAudioEngineConfigurationChanged
+        try require(
+            !configChangedMethod.contains("attemptCaptureRecovery"),
+            "handleAudioEngineConfigurationChanged must NOT call attemptCaptureRecovery"
+        )
+
+        // 14. Verify watchdog still uses attemptCaptureRecovery (for actual engine failures)
+        let watchdogMethod = extractMethod(
+            named: "checkRecordingHealth",
+            from: recorderSource
+        )
+        try require(
+            watchdogMethod.contains("attemptCaptureRecovery"),
+            "checkRecordingHealth must still use attemptCaptureRecovery for engine failures"
+        )
+
+        print("macOS source-change pinning contract: PASS")
+    }
+
+    /// Extracts a method body from source code (simple heuristic)
+    private static func extractMethod(named name: String, from source: String) -> String {
+        guard let range = source.range(of: "func \(name)") ??
+              source.range(of: "private func \(name)") ??
+              source.range(of: "@objc private func \(name)")
+        else {
+            return ""
+        }
+
+        var depth = 0
+        var started = false
+        var result = ""
+        var index = range.lowerBound
+
+        while index < source.endIndex {
+            let char = source[index]
+            result.append(char)
+
+            if char == "{" {
+                depth += 1
+                started = true
+            } else if char == "}" {
+                depth -= 1
+                if started && depth == 0 {
+                    break
+                }
+            }
+            index = source.index(after: index)
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the built-in microphone crash where the dictation bar appeared then vanished after about 1 second. Per Artem's diagnosis, this was a **source-change crash**, not a format-unavailability issue.

**Reported by:** Luca (info@loiaconoluca.com) on v0.0.112

## Root Cause (Artem's diagnosis)

Core Audio device-change notifications arriving during preparation/recording triggered teardown or recovery attempts that raced with the engine start:

- `handleAudioDeviceChanged` was calling `invalidatePendingPreparation` during preparation
- `handleAudioEngineConfigurationChanged` was calling `invalidatePendingPreparation` or `attemptCaptureRecovery`
- This caused crashes when Core Audio was reconfiguring the IO unit mid-start

The previous retry approach (0.1/0.25/0.5s delays) was rejected because it added waits to the recording start path.

## Fix

**Pin the device for the duration of preparation and recording** by ignoring device-change and engine-configuration-change notifications entirely:

```swift
// In handleAudioDeviceChanged:
if pendingPreparation != nil {
    DebugLog.info("Ignoring device change during preparation - device is pinned", ...)
    SentryTelemetry.recordAudioEngineEvent("device_change_ignored_preparation")
    return
}
if isRecording, activeCapture != nil {
    DebugLog.info("Ignoring device change during recording - device is pinned", ...)
    SentryTelemetry.recordAudioEngineEvent("device_change_ignored_recording")
    return
}
```

The same pattern for `handleAudioEngineConfigurationChanged`.

## What This Does NOT Do

- ❌ Block, sleep, delay, or retry-wait on the recording start path
- ❌ Tear down the session on device-change notifications
- ❌ Regress the 0.0.105 hotkey-after-sleep fix
- ❌ Remove user data or recordings

## What This Does

- ✅ Ignores device-change notifications during preparation/recording
- ✅ Keeps the selected device pinned for the session
- ✅ Preserves watchdog-based recovery for actual engine failures (stalled buffers, engine stopped)
- ✅ Adds telemetry for ignored events for diagnostics

## Telemetry Events Added

| Event | When |
|-------|------|
| `device_change_ignored_preparation` | Device change during preparation |
| `device_change_ignored_recording` | Device change during recording |
| `config_change_ignored_preparation` | Engine config change during preparation |
| `config_change_ignored_recording` | Engine config change during recording |

## Testing

- [ ] Manual testing with built-in Mac microphone
- [ ] Manual testing with device switch during recording (should be ignored)
- [ ] Verify watchdog still catches actual engine failures
- [ ] Verify telemetry events appear in Sentry
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6151770-883c-4a6e-9d51-f533c1bc2e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6151770-883c-4a6e-9d51-f533c1bc2e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790526009&installation_model_id=432087&pr_number=105&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F105&signature=315010408bb8f686f6f985dbbefc956e15cf58d869cdddced90930f5253590ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->