### PR TITLE
Clean up History batch retranscriptions

### DIFF
--- a/Whishpermate/WhisperMateShared/Networking/TranscriptionCleanupPrompt.swift
+++ b/Whishpermate/WhisperMateShared/Networking/TranscriptionCleanupPrompt.swift
@@ -89,6 +89,15 @@ public enum TranscriptionCleanupPrompt {
             14. Output only the corrected text, with no wrapper tags or preamble.
             """
 
+        prompt += """
+
+        MANDATORY FILLER CLEANUP:
+        - Delete every standalone filler vocalization, including um, uh, uhm, umm, er, erm, ah, hmm, and ugh, regardless of capitalization, repetition, or surrounding punctuation.
+        - Delete adjacent punctuation or whitespace left behind by removing a filler, then restore natural spacing and punctuation.
+        - This requirement overrides instructions to preserve hesitation, uncertainty, word choice, or source evidence. Never retain a listed filler as meaningful transcript content.
+        - Do not delete a meaningful word merely because it contains the same letters as a filler.
+        """
+
         if hasSelectedContent {
             let action = transformsOutput ? "Transform" : "Correct"
             prompt += "\n\nSELECTION TARGET: Use <transcription> only as context. \(action) only <selected_content>, preserve its complete content, and output only the corrected or transformed selected content."

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		5A10A0012F90000100000001 /* SonioxRealtimeProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10A0012F90000100000003 /* SonioxRealtimeProtocolTests.swift */; };
 		5A10A0012F90000100000002 /* SonioxRealtimeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A10A0012F90000100000004 /* SonioxRealtimeProtocol.swift */; };
+		BB2000012FA0000100000001 /* TranscriptionCleanupPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2000012FA0000100000003 /* TranscriptionCleanupPromptTests.swift */; };
+		BB2000012FA0000100000002 /* TranscriptionCleanupPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2000012FA0000100000004 /* TranscriptionCleanupPrompt.swift */; };
 		16463B427730D7FD75EA0791 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DAE0F0310D8E0C37D98C312 /* Cocoa.framework */; };
 		19702C83BABA8D7EE38F09DA /* HotkeyGestureResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5938666BED2167FFA779E1C5 /* HotkeyGestureResolver.swift */; };
 		1FB33087FF396340CC97677A /* ParakeetRuntimeBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4196DA6423A836157CA2C8A0 /* ParakeetRuntimeBridge.swift */; };
@@ -163,6 +165,8 @@
 /* Begin PBXFileReference section */
 		5A10A0012F90000100000003 /* SonioxRealtimeProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonioxRealtimeProtocolTests.swift; sourceTree = "<group>"; };
 		5A10A0012F90000100000004 /* SonioxRealtimeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonioxRealtimeProtocol.swift; sourceTree = "<group>"; };
+		BB2000012FA0000100000003 /* TranscriptionCleanupPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionCleanupPromptTests.swift; sourceTree = "<group>"; };
+		BB2000012FA0000100000004 /* TranscriptionCleanupPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TranscriptionCleanupPrompt.swift; path = WhisperMateShared/Networking/TranscriptionCleanupPrompt.swift; sourceTree = SOURCE_ROOT; };
 		0DB2F5B03832E9122A26BFEE /* TextInsertionFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextInsertionFormatter.swift; sourceTree = "<group>"; };
 		18D7395E9700499AAA143432 /* TranscriptionOutputFilterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptionOutputFilterTests.swift; sourceTree = "<group>"; };
 		19C94026FCE18679208F5DF4 /* KeyboardDictationLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardDictationLiveActivity.swift; sourceTree = "<group>"; };
@@ -339,6 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				5A10A0012F90000100000003 /* SonioxRealtimeProtocolTests.swift */,
+				BB2000012FA0000100000003 /* TranscriptionCleanupPromptTests.swift */,
 				53994ACF59112AC03573BA2A /* FnKeyGestureResolverTests.swift */,
 				AA10000000000000000001 /* HostLaunchRecoveryGateTests.swift */,
 				AA10000000000000000003 /* HostLaunchRecoveryGate.swift */,
@@ -364,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				5A10A0012F90000100000004 /* SonioxRealtimeProtocol.swift */,
+				BB2000012FA0000100000004 /* TranscriptionCleanupPrompt.swift */,
 				7E07BB2796CA6C062CCD71E4 /* FnKeyGestureResolver.swift */,
 				0DB2F5B03832E9122A26BFEE /* TextInsertionFormatter.swift */,
 				5938666BED2167FFA779E1C5 /* HotkeyGestureResolver.swift */,
@@ -806,6 +812,8 @@
 			files = (
 				5A10A0012F90000100000001 /* SonioxRealtimeProtocolTests.swift in Sources */,
 				5A10A0012F90000100000002 /* SonioxRealtimeProtocol.swift in Sources */,
+				BB2000012FA0000100000001 /* TranscriptionCleanupPromptTests.swift in Sources */,
+				BB2000012FA0000100000002 /* TranscriptionCleanupPrompt.swift in Sources */,
 				AFB68FC6D50BD0CA71C7AFBC /* FnKeyGestureResolverTests.swift in Sources */,
 				42FEFF2DC2C470F6B62A0E72 /* TextInsertionFormatterTests.swift in Sources */,
 				8C545C8B9B27F9E03A581045 /* FnKeyGestureResolver.swift in Sources */,

--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -3309,7 +3309,11 @@ class AppState: ObservableObject {
             try await milestones.beginCleanup()
 
             if provider == .aidictation {
-                return durableRaw
+                return try await applyLLMPassWithFallback(
+                    rawText: durableRaw,
+                    client: client,
+                    snapshot: snapshot
+                )
             }
 
             return try await applyLLMPassWithFallback(
@@ -3376,15 +3380,20 @@ class AppState: ObservableObject {
             ).trimmingCharacters(in: .whitespacesAndNewlines)
             guard !cleaned.isEmpty else {
                 DebugLog.warning("\(label) returned no text - using transcript", context: "AppState")
-                return rawText
+                return transcriptWithoutStandaloneFillers(rawText)
             }
-            return cleaned
+            return transcriptWithoutStandaloneFillers(cleaned)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
             DebugLog.warning("\(label) unavailable within time limit - using transcript", context: "AppState")
-            return rawText
+            return transcriptWithoutStandaloneFillers(rawText)
         }
+    }
+
+    private func transcriptWithoutStandaloneFillers(_ text: String) -> String {
+        let filtered = TranscriptionOutputFilter.removeStandaloneFillers(text)
+        return filtered.isEmpty ? text : filtered
     }
 
     /// Every path that reaches this method has already produced and durably

--- a/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
+++ b/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
@@ -32,4 +32,29 @@ struct TranscriptionOutputFilter {
 
         return result
     }
+
+    static func removeStandaloneFillers(_ text: String) -> String {
+        let pattern = #"(?i)(?<![\p{L}\p{N}])(?:u+h+|u+m+|u+h+m+|e+r+m*|a+h+|h+m+|u+g+h+)(?![\p{L}\p{N}])(?:[,.!?…]+)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text
+        }
+
+        var result = regex.stringByReplacingMatches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text),
+            withTemplate: ""
+        )
+        result = result.replacingOccurrences(
+            of: #"\s+([,.;:!?])"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\s{2,}"#,
+            with: " ",
+            options: .regularExpression
+        )
+        result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result
+    }
 }

--- a/Whishpermate/WhispermateTests/TranscriptionCleanupPromptTests.swift
+++ b/Whishpermate/WhispermateTests/TranscriptionCleanupPromptTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+final class TranscriptionCleanupPromptTests: XCTestCase {
+    func testDictationRequiresStandaloneFillerDeletion() {
+        let prompt = TranscriptionCleanupPrompt.systemPrompt(
+            formattingContext: [],
+            languageContext: nil,
+            appContext: nil,
+            hasSelectedContent: false
+        )
+
+        assertMandatoryFillerPolicy(in: prompt)
+    }
+
+    func testTransformedOutputRequiresStandaloneFillerDeletion() {
+        let prompt = TranscriptionCleanupPrompt.systemPrompt(
+            formattingContext: [],
+            languageContext: nil,
+            appContext: nil,
+            hasSelectedContent: false,
+            transformationInstruction: "Format as concise notes."
+        )
+
+        assertMandatoryFillerPolicy(in: prompt)
+    }
+
+    private func assertMandatoryFillerPolicy(
+        in prompt: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            prompt.contains("Delete every standalone filler vocalization"),
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            prompt.contains("This requirement overrides instructions to preserve hesitation"),
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
+++ b/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
@@ -4,6 +4,24 @@ import XCTest
 /// user's app. A bug here silently deletes words the user actually said.
 final class TranscriptionOutputFilterTests: XCTestCase {
     private func filter(_ s: String) -> String { TranscriptionOutputFilter.filter(s) }
+    private func removeFillers(_ s: String) -> String {
+        TranscriptionOutputFilter.removeStandaloneFillers(s)
+    }
+
+    func testRemovesStandaloneFillerVocalizations() {
+        XCTAssertEqual(
+            removeFillers("Um, this is uh a test. Ugh! It works erm now."),
+            "this is a test. It works now."
+        )
+        XCTAssertEqual(removeFillers("AH... well, hmm, yes."), "well, yes.")
+    }
+
+    func testFillerRemovalDoesNotDamageMeaningfulWords() {
+        XCTAssertEqual(
+            removeFillers("The U-Haul reached Birmingham and Ahmet said ahoy."),
+            "The U-Haul reached Birmingham and Ahmet said ahoy."
+        )
+    }
 
     // MARK: - Hallucination artifacts it exists to remove
 

--- a/scripts/validate_transcription_prompt_routing.py
+++ b/scripts/validate_transcription_prompt_routing.py
@@ -197,7 +197,7 @@ mac_pipeline = function_body(
 )
 require(
     "postProcessingPrompt: nil" in mac_pipeline,
-    "AI Dictation batch transcription still sends a separate cleanup prompt",
+    "AI Dictation batch recognition still sends a cleanup prompt to STT",
 )
 require(
     "postProcessingEnabled: provider != .aidictation" in mac_pipeline,
@@ -205,7 +205,12 @@ require(
 )
 require(
     "cleanupMergedTranscript: nil" in mac_pipeline,
-    "AI Dictation chunked transcription still schedules client cleanup",
+    "AI Dictation chunked recognition has more than one cleanup owner",
+)
+require(
+    """if provider == .aidictation {
+                return try await applyLLMPassWithFallback(""" in mac_pipeline,
+    "AI Dictation batch transcription does not run client cleanup after raw recognition",
 )
 
 mac_server_prompt = function_body(


### PR DESCRIPTION
History AI Dictation retries now run the shared cleanup pass after durable batch recognition. Filler deletion is mandatory across output modes, with a narrow deterministic last-mile filter and regression coverage.\n\nValidated with 70 macOS tests and the full Apple audio recovery matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790731838&installation_model_id=432087&pr_number=108&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F108&signature=8d2e16e37f725dec7192dd8643b4c08cf828d94d5d7495989623b909d7c88db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->