### PR TITLE
Route AI Dictation through Soniox everywhere

### DIFF
--- a/AIDictation.Windows/AIDictation/Helpers/BuildConfig.cs
+++ b/AIDictation.Windows/AIDictation/Helpers/BuildConfig.cs
@@ -16,7 +16,7 @@ public static class BuildConfig
     private static class Defaults
     {
         public const string TranscriptionEndpoint = "https://writingmate.ai/api/openai/v1/audio/transcriptions";
-        public const string TranscriptionModel = "openai/gpt-transcribe";
+        public const string TranscriptionModel = "soniox/stt-async-v5";
         public const string PostProcessingEndpoint = "https://writingmate.ai/api/openai/v1/chat/completions";
         public const string PostProcessingModel = "openai/gpt-oss-20b";
 

--- a/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
+++ b/AIDictationAndroid/app/src/main/java/com/whispermate/aidictation/data/preferences/ApiConfigManager.kt
@@ -48,7 +48,7 @@ class ApiConfigManager @Inject constructor() {
                 ParakeetRuntime.ONNX -> "parakeet-tdt-0.6b-v3"
                 ParakeetRuntime.LITERT -> "parakeet-tdt-0.6b-v3-litert"
             }
-            ApiProvider.WRITINGMATE -> "openai/gpt-transcribe"
+            ApiProvider.WRITINGMATE -> "soniox/stt-async-v5"
             ApiProvider.OPENAI -> "gpt-transcribe"
             ApiProvider.GROQ -> "whisper-large-v3-turbo"
         }

--- a/Whishpermate/WhisperMateShared/Models/APIProvider.swift
+++ b/Whishpermate/WhisperMateShared/Models/APIProvider.swift
@@ -43,7 +43,7 @@ public enum TranscriptionProvider: String, CaseIterable, Identifiable {
         case .onDevice: return "apple-on-device"
         case .groq: return "whisper-large-v3-turbo"
         case .openai: return "gpt-transcribe"
-        case .custom: return "openai/gpt-transcribe"
+        case .custom: return "soniox/stt-async-v5"
         }
     }
 

--- a/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
+++ b/Whishpermate/WhisperMateShared/Services/SecretsLoader.swift
@@ -94,8 +94,9 @@ public enum SecretsLoader {
 
         switch model.trimmingCharacters(in: .whitespacesAndNewlines) {
         case "gpt-4o-transcribe", "gpt-4o-mini-transcribe",
-             "groq/whisper-large-v3-turbo", "openai/whisper-large-v3-turbo":
-            return "openai/gpt-transcribe"
+             "groq/whisper-large-v3-turbo", "openai/whisper-large-v3-turbo",
+             "openai/gpt-transcribe":
+            return "soniox/stt-async-v5"
         default:
             return model
         }

--- a/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
+++ b/Whishpermate/WhisperMateShared/Services/SharedTranscriptionService.swift
@@ -259,17 +259,14 @@ public enum SharedTranscriptionService {
         }
 
         if let instructions = dictionaryManager.formattingInstructions {
-            sttPromptComponents.append(instructions)
             postProcessingPromptComponents.append(instructions)
         }
 
         if let instructions = shortcutManager.formattingInstructions {
-            sttPromptComponents.append(instructions)
             postProcessingPromptComponents.append(instructions)
         }
 
         if let selectedPreset, !selectedPreset.isNotesModeRule, !selectedPreset.isMeetingsModeRule {
-            sttPromptComponents.append("\(selectedPreset.name): \(selectedPreset.instructions)")
             postProcessingPromptComponents.append("\(selectedPreset.name): \(selectedPreset.instructions)")
         }
 

--- a/Whishpermate/Whispermate/Models/APIProvider.swift
+++ b/Whishpermate/Whispermate/Models/APIProvider.swift
@@ -66,11 +66,7 @@ enum TranscriptionProvider: String, CaseIterable, Identifiable {
     }
 
     static var availableOnlineProviders: [TranscriptionProvider] {
-        var providers: [TranscriptionProvider] = [.soniox]
-        if CodexTranscriptionSupport.isInstalled {
-            providers.append(.codex)
-        }
-        return providers
+        [.soniox]
     }
 
     var onlineServiceName: String {
@@ -331,11 +327,7 @@ class TranscriptionProviderManager: ObservableObject {
         _ provider: TranscriptionProvider
     ) -> TranscriptionProvider {
         switch provider {
-        case .codex where CodexTranscriptionSupport.isInstalled:
-            return .codex
         case .soniox:
-            return .soniox
-        case .aidictation:
             return .soniox
         default:
             return .soniox

--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -2174,27 +2174,9 @@ class AppState: ObservableObject {
                 realtimeResult = nil
             }
 
-            let recognitionSnapshot: MacTranscriptionAttemptSnapshot
-            let usedBatchFallback: Bool
-            if realtimeResult == nil,
-               snapshot.provider == .soniox,
-               let fallback = snapshot.usingBatchFallback()
-            {
-                recognitionSnapshot = fallback
-                usedBatchFallback = true
-                DebugLog.warning(
-                    "Fast streaming did not complete; using cloud fallback",
-                    context: "SonioxRealtime"
-                )
-            } else {
-                recognitionSnapshot = snapshot
-                usedBatchFallback = false
-            }
-
             if activeTransport == .realtime,
                (snapshot.mode != .auto || snapshot.networkWasConnected),
-               realtimeResult == nil,
-               !usedBatchFallback
+               realtimeResult == nil
             {
                 throw NSError(
                     domain: "AppState",
@@ -2263,7 +2245,7 @@ class AppState: ObservableObject {
                     audioURL: audioURL,
                     clipboardContent: nil,
                     transientWorkspace: transientWorkspace,
-                    snapshot: recognitionSnapshot,
+                    snapshot: snapshot,
                     onRecognitionCheckpoint: { text in
                         try await session.checkpoint(text)
                     },
@@ -2981,28 +2963,35 @@ class AppState: ObservableObject {
         let mode = modeOverride ?? transcriptionProviderManager.transcriptionMode
         let onlineProvider = onlineProviderOverride
             ?? transcriptionProviderManager.selectedOnlineProvider
-        let selectedProvider: TranscriptionProvider = mode == .local ? .parakeet : onlineProvider
-        let provider: TranscriptionProvider = isRetranscription && selectedProvider == .soniox
-            ? .aidictation
-            : selectedProvider
+        let provider: TranscriptionProvider = mode == .local ? .parakeet : onlineProvider
         let endpoint: String
         let model: String
         let transport: TranscriptionTransport
-        if provider == .aidictation {
+        let transcriptionAPIKey: String?
+        if provider == .soniox, isRetranscription {
+            endpoint = SecretsLoader.customTranscriptionEndpoint()
+                ?? TranscriptionProvider.aidictation.defaultEndpoint
+            model = "soniox/stt-async-v5"
+            transport = .batch
+            transcriptionAPIKey = resolvedTranscriptionApiKey(for: .aidictation)
+        } else if provider == .aidictation {
             endpoint = SecretsLoader.customTranscriptionEndpoint()
                 ?? provider.defaultEndpoint
             model = isRetranscription
                 ? "gpt-transcribe"
                 : (SecretsLoader.customTranscriptionRealtimeModel() ?? "gpt-live-transcribe")
             transport = isRetranscription ? .batch : .realtime
+            transcriptionAPIKey = resolvedTranscriptionApiKey(for: provider)
         } else if provider == .codex, isRetranscription {
             endpoint = CodexTranscriptionSupport.batchEndpoint.absoluteString
             model = ""
             transport = .batch
+            transcriptionAPIKey = resolvedTranscriptionApiKey(for: provider)
         } else {
             endpoint = provider.defaultEndpoint
             model = provider.defaultModel
             transport = provider.defaultTransport
+            transcriptionAPIKey = resolvedTranscriptionApiKey(for: provider)
         }
         let sttHintPrompt = buildSTTHintPromptComponents().joined(separator: "\n")
         let cleanupComponents = buildTranscriptionPromptComponents()
@@ -3024,15 +3013,6 @@ class AppState: ObservableObject {
                 diarization: rule.transcriptionOptions.diarization
             )
         }
-        let batchFallback: MacTranscriptionAttemptSnapshot.BatchFallback? =
-            provider == .soniox
-            ? .init(
-                endpoint: SecretsLoader.customTranscriptionEndpoint()
-                    ?? TranscriptionProvider.aidictation.defaultEndpoint,
-                model: "groq/whisper-large-v3-turbo",
-                apiKey: resolvedTranscriptionApiKey(for: .aidictation)
-            )
-            : nil
         return MacTranscriptionAttemptSnapshot(
             outputMode: outputMode,
             transcriptionOptions: transcriptionOptions,
@@ -3041,10 +3021,9 @@ class AppState: ObservableObject {
             transport: transport,
             transcriptionEndpoint: endpoint,
             transcriptionModel: model,
-            transcriptionAPIKey: resolvedTranscriptionApiKey(for: provider),
+            transcriptionAPIKey: transcriptionAPIKey,
             customRealtimeEndpoint: configuredCustomRealtimeEndpoint(),
             customRealtimeModel: configuredCustomRealtimeModel(),
-            batchFallback: batchFallback,
             llmPostProcessingEnabled: transcriptionProviderManager.enableLLMPostProcessing,
             postProcessingProvider: transcriptionProviderManager.postProcessingProvider,
             llmEndpoint: llmProviderManager.effectiveEndpoint,
@@ -3056,7 +3035,9 @@ class AppState: ObservableObject {
             languageCodes: languageManager.apiLanguageCodes,
             transcriptionKeywords: Array(Set(
                 dictionaryManager.transcriptionKeywords
-                    + shortcutManager.transcriptionKeywords
+                    + shortcutManager.shortcuts
+                        .filter(\.isEnabled)
+                        .map(\.voiceTrigger)
             )).sorted(),
             recordingPrompt: recordingPrompt,
             sttHintPrompt: sttHintPrompt,
@@ -3099,14 +3080,7 @@ class AppState: ObservableObject {
         if !shortcutManager.transcriptionHints.isEmpty {
             hints.append(shortcutManager.transcriptionHints)
         }
-        if let instructions = dictionaryManager.formattingInstructions {
-            hints.append(instructions)
-        }
-        if let instructions = shortcutManager.formattingInstructions {
-            hints.append(instructions)
-        }
-
-        return [TranscriptionCleanupPrompt.speechRecognitionPrompt(hints: hints)]
+        return hints
     }
 
     private func buildRealtimePrompt() -> String {
@@ -3280,7 +3254,7 @@ class AppState: ObservableObject {
                         : nil,
                 postProcessingPrompt: nil,
                 serverPostProcessingEnabledByDefault: false,
-                postProcessingEnabled: provider != .aidictation,
+                postProcessingEnabled: false,
                 transientWorkspace: transientWorkspace,
                 onChunkCheckpoint: { completedLeafIndex, transcript in
                     try await checkpointAccumulator.accept(

--- a/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
+++ b/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
@@ -6,12 +6,6 @@ import WhisperMateShared
 /// Every mutable preference needed by recognition and cleanup, captured before
 /// an attempt begins. Running attempts never consult the live manager objects.
 nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
-    struct BatchFallback: Sendable {
-        let endpoint: String
-        let model: String
-        let apiKey: String?
-    }
-
     struct ContextRuleSnapshot: Sendable {
         let name: String
         let appBundleIDs: [String]
@@ -81,7 +75,6 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
     let transcriptionAPIKey: String?
     let customRealtimeEndpoint: URL?
     let customRealtimeModel: String?
-    let batchFallback: BatchFallback?
     let llmPostProcessingEnabled: Bool
     let postProcessingProvider: PostProcessingProvider
     let llmEndpoint: String
@@ -148,7 +141,6 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
             transcriptionAPIKey: transcriptionAPIKey,
             customRealtimeEndpoint: customRealtimeEndpoint,
             customRealtimeModel: customRealtimeModel,
-            batchFallback: batchFallback,
             llmPostProcessingEnabled: llmPostProcessingEnabled,
             postProcessingProvider: postProcessingProvider,
             llmEndpoint: llmEndpoint,
@@ -175,41 +167,4 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
         )
     }
 
-    func usingBatchFallback() -> MacTranscriptionAttemptSnapshot? {
-        guard let batchFallback else { return nil }
-        return MacTranscriptionAttemptSnapshot(
-            outputMode: outputMode,
-            transcriptionOptions: transcriptionOptions,
-            mode: mode,
-            provider: .aidictation,
-            transport: .batch,
-            transcriptionEndpoint: batchFallback.endpoint,
-            transcriptionModel: batchFallback.model,
-            transcriptionAPIKey: batchFallback.apiKey,
-            customRealtimeEndpoint: nil,
-            customRealtimeModel: nil,
-            batchFallback: nil,
-            llmPostProcessingEnabled: llmPostProcessingEnabled,
-            postProcessingProvider: postProcessingProvider,
-            llmEndpoint: llmEndpoint,
-            llmModel: llmModel,
-            llmAPIKey: llmAPIKey,
-            aidictationPostProcessingEndpoint: aidictationPostProcessingEndpoint,
-            aidictationPostProcessingKey: aidictationPostProcessingKey,
-            languageCode: languageCode,
-            languageCodes: languageCodes,
-            transcriptionKeywords: transcriptionKeywords,
-            recordingPrompt: recordingPrompt,
-            sttHintPrompt: sttHintPrompt,
-            cleanupPromptComponents: cleanupPromptComponents,
-            baseCleanupPromptComponents: baseCleanupPromptComponents,
-            contextRules: contextRules,
-            usesContextRules: usesContextRules,
-            appContext: appContext,
-            screenContext: screenContext,
-            vadEnabled: vadEnabled,
-            vadThreshold: vadThreshold,
-            networkWasConnected: networkWasConnected
-        )
-    }
 }

--- a/Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift
+++ b/Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift
@@ -40,51 +40,12 @@ enum AIApp: String, CaseIterable, Identifiable {
     }
 }
 
-private struct RetranscriptionRouteMenu<LabelContent: View>: View {
-    let recording: Recording
-    let label: () -> LabelContent
-
-    var body: some View {
-        Menu {
-            Button("Offline") {
-                retry(mode: .local, provider: .parakeet)
-            }
-            .disabled(!TranscriptionMode.local.isAvailable)
-
-            Menu("Online") {
-                Button("AI Dictation") {
-                    retry(mode: .cloud, provider: .aidictation)
-                }
-                Button("ChatGPT") {
-                    retry(mode: .cloud, provider: .codex)
-                }
-            }
-
-            Menu("Auto") {
-                Button("AI Dictation") {
-                    retry(mode: .auto, provider: .aidictation)
-                }
-                .disabled(!TranscriptionMode.auto.isAvailable)
-                Button("ChatGPT") {
-                    retry(mode: .auto, provider: .codex)
-                }
-                .disabled(!TranscriptionMode.auto.isAvailable)
-            }
-        } label: {
-            label()
-        }
-    }
-
-    private func retry(
-        mode: TranscriptionMode,
-        provider: TranscriptionProvider
-    ) {
-        AppState.shared.retranscribe(
-            recording: recording,
-            mode: mode,
-            onlineProvider: provider
-        )
-    }
+private func retranscribeWithAIDictation(_ recording: Recording) {
+    AppState.shared.retranscribe(
+        recording: recording,
+        mode: .cloud,
+        onlineProvider: .soniox
+    )
 }
 
 /// Master-detail view that combines history list with recording interface
@@ -271,7 +232,9 @@ struct HistorySidebarView: View {
                     }
                     .disabled(recording.transcription == nil)
 
-                    RetranscriptionRouteMenu(recording: recording) {
+                    Button {
+                        retranscribeWithAIDictation(recording)
+                    } label: {
                         Label("Re-transcribe", systemImage: "arrow.clockwise")
                     }
                     .disabled(
@@ -515,7 +478,9 @@ struct RecordingDetailView: View {
                     ProgressView()
                         .controlSize(.small)
                 } else {
-                    RetranscriptionRouteMenu(recording: recording) {
+                    Button {
+                        retranscribeWithAIDictation(recording)
+                    } label: {
                         Label("Re-transcribe", systemImage: "arrow.clockwise")
                     }
                     .disabled(

--- a/Whishpermate/Whispermate/Views/SettingsView.swift
+++ b/Whishpermate/Whispermate/Views/SettingsView.swift
@@ -1242,41 +1242,6 @@ struct SettingsView: View {
             }
 
             SettingsCard {
-                VStack(spacing: 0) {
-                    HStack(spacing: 12) {
-                        Text("Cloud Model")
-                            .dsFont(.body)
-                            .foregroundStyle(Color.dsForeground)
-                        Spacer()
-                        Picker("", selection: Binding(
-                            get: { transcriptionProviderManager.selectedOnlineProvider },
-                            set: { transcriptionProviderManager.setProvider($0) }
-                        )) {
-                            ForEach(TranscriptionProvider.availableOnlineProviders) { provider in
-                                cloudModelLabel(for: provider)
-                                    .tag(provider)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .fixedSize()
-                        .accessibilityLabel("Cloud Model")
-                    }
-                    .padding(.vertical, 2)
-
-                    HStack {
-                        Text(transcriptionProviderManager.selectedOnlineProvider.description)
-                            .dsFont(.label)
-                            .foregroundStyle(Color.dsMutedForeground)
-                        Spacer()
-                    }
-                    .padding(.top, 4)
-
-                }
-            }
-            .disabled(transcriptionProviderManager.transcriptionMode == .local)
-            .opacity(transcriptionProviderManager.transcriptionMode == .local ? 0.55 : 1)
-
-            SettingsCard {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -1342,50 +1307,6 @@ struct SettingsView: View {
 
             // Cleanup is product-defined and intentionally has no user-facing controls.
         }
-    }
-
-    private func cloudModelLabel(
-        for provider: TranscriptionProvider
-    ) -> some View {
-        HStack(spacing: 7) {
-            Image(nsImage: cloudModelIcon(for: provider))
-                .frame(width: 16, height: 16)
-            Text(provider.onlineServiceName)
-        }
-    }
-
-    private func cloudModelIcon(
-        for provider: TranscriptionProvider
-    ) -> NSImage {
-        switch provider {
-        case .aidictation, .soniox, .parakeet:
-            return resizedMenuIcon(NSApplication.shared.applicationIconImage)
-        case .codex:
-            if let appURL = NSWorkspace.shared.urlForApplication(
-                withBundleIdentifier: "com.openai.codex"
-            ) {
-                return resizedMenuIcon(NSWorkspace.shared.icon(forFile: appURL.path))
-            }
-            return resizedMenuIcon(
-                NSImage(named: NSImage.applicationIconName)
-                    ?? NSApplication.shared.applicationIconImage
-            )
-        }
-    }
-
-    private func resizedMenuIcon(_ source: NSImage) -> NSImage {
-        let size = NSSize(width: 16, height: 16)
-        let icon = NSImage(size: size)
-        icon.lockFocus()
-        source.draw(
-            in: NSRect(origin: .zero, size: size),
-            from: NSRect(origin: .zero, size: source.size),
-            operation: .sourceOver,
-            fraction: 1
-        )
-        icon.unlockFocus()
-        icon.isTemplate = false
-        return icon
     }
 
     private var parakeetStatusText: String {

--- a/scripts/benchmark_soniox_realtime.mjs
+++ b/scripts/benchmark_soniox_realtime.mjs
@@ -220,7 +220,7 @@ async function currentBatch({ path, endpoint, authorization }) {
   const audio = await import("node:fs/promises").then(({ readFile }) => readFile(path));
   const form = new FormData();
   form.append("file", new Blob([audio], { type: "audio/mp4" }), basename(path));
-  form.append("model", "openai/gpt-transcribe");
+  form.append("model", "soniox/stt-async-v5");
   form.append("post_processing", "false");
   const startedAt = performance.now();
   const response = await fetch(endpoint, {
@@ -270,8 +270,13 @@ async function main() {
     batchEndpoint,
   ).toString();
   const rows = [];
+  const limit = Number(argumentValue("--limit", "0"));
+  const paths = fixturePaths(recordingsDirectory);
+  const selectedPaths = Number.isInteger(limit) && limit > 0
+    ? paths.slice(0, limit)
+    : paths;
 
-  for (const path of fixturePaths(recordingsDirectory)) {
+  for (const path of selectedPaths) {
     const pcm = decodePCM(path);
     const [current, soniox] = await Promise.all([
       currentBatch({

--- a/scripts/validate_cross_platform_soniox_defaults.py
+++ b/scripts/validate_cross_platform_soniox_defaults.py
@@ -33,26 +33,26 @@ require(
 )
 require(
     mac_provider,
-    "var providers: [TranscriptionProvider] = [.soniox]",
+    "static var availableOnlineProviders: [TranscriptionProvider] {\n        [.soniox]\n    }",
     "macOS provider menu",
 )
 require(mac_provider, 'case .soniox: return "AI Dictation"', "macOS product label")
-require(mac_provider, "case .aidictation:\n            return .soniox", "macOS migration")
 reject(mac_provider, 'return "Fast streaming"', "macOS implementation label")
 
 mac_state = source("Whishpermate/Whispermate/Services/AppState.swift")
 require(
     mac_state,
-    'model: "groq/whisper-large-v3-turbo"',
-    "macOS batch fallback",
+    'model = "soniox/stt-async-v5"',
+    "macOS Soniox batch model",
 )
-require(mac_state, "snapshot.usingBatchFallback()", "macOS fallback activation")
+reject(mac_state, "snapshot.usingBatchFallback()", "macOS cross-provider fallback")
+reject(mac_state, 'groq/whisper-large-v3-turbo', "macOS Groq fallback")
 
 shared_provider = source("Whishpermate/WhisperMateShared/Models/APIProvider.swift")
 require(shared_provider, 'case .custom: return "AI Dictation"', "Apple shared label")
 require(
     shared_provider,
-    'case .custom: return "openai/gpt-transcribe"',
+    'case .custom: return "soniox/stt-async-v5"',
     "Apple shared batch model",
 )
 require(
@@ -67,24 +67,21 @@ android = source(
 )
 require(
     android,
-    'ApiProvider.WRITINGMATE -> "openai/gpt-transcribe"',
+    'ApiProvider.WRITINGMATE -> "soniox/stt-async-v5"',
     "Android batch model",
 )
-reject(android, "soniox/stt-async-v5", "Android async Soniox rollout")
 android_workflow = source(".github/workflows/android-build.yml")
 require(
     android_workflow,
     "github.event_name == 'pull_request' && 'pull-request' || 'release'",
     "Android pull-request environment",
 )
-reject(android_workflow, "soniox/stt-async-v5", "Android release async Soniox rollout")
 
 windows = source("AIDictation.Windows/AIDictation/Helpers/BuildConfig.cs")
 require(
     windows,
-    'TranscriptionModel = "openai/gpt-transcribe"',
+    'TranscriptionModel = "soniox/stt-async-v5"',
     "Windows batch model",
 )
-reject(windows, "soniox/stt-async-v5", "Windows async Soniox rollout")
 
 print("Soniox realtime default and batch controls: PASS")

--- a/scripts/validate_macos_transcription_attempt_snapshot.swift
+++ b/scripts/validate_macos_transcription_attempt_snapshot.swift
@@ -57,11 +57,6 @@ private func capture(_ settings: MutableAttemptSettings) -> MacTranscriptionAtte
         transcriptionAPIKey: settings.apiKey,
         customRealtimeEndpoint: URL(string: settings.realtimeEndpoint),
         customRealtimeModel: settings.realtimeModel,
-        batchFallback: .init(
-            endpoint: "https://fallback.example/transcribe",
-            model: "soniox/stt-async-v5",
-            apiKey: "fallback-key"
-        ),
         // Custom-provider controls historically leave this hidden toggle off.
         // A two-stage raw path must still run core cleanup with this snapshot.
         llmPostProcessingEnabled: false,
@@ -129,7 +124,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         precondition(snapshot.transcriptionAPIKey == "before-key")
         precondition(snapshot.customRealtimeEndpoint?.absoluteString == "wss://before.example/realtime")
         precondition(snapshot.customRealtimeModel == "before-realtime-model")
-        precondition(snapshot.batchFallback?.endpoint == "https://fallback.example/transcribe")
         precondition(snapshot.llmEndpoint == "https://before.example/chat")
         precondition(snapshot.llmModel == "before-llm")
         precondition(snapshot.llmAPIKey == "before-llm-key")
@@ -144,7 +138,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         precondition(contextualSnapshot.screenContext == "Captured screen")
         precondition(contextualSnapshot.transcriptionEndpoint == snapshot.transcriptionEndpoint)
         precondition(contextualSnapshot.transcriptionModel == snapshot.transcriptionModel)
-        precondition(contextualSnapshot.batchFallback?.model == "soniox/stt-async-v5")
         precondition(contextualSnapshot.llmEndpoint == snapshot.llmEndpoint)
         precondition(contextualSnapshot.cleanupPromptComponents == snapshot.cleanupPromptComponents)
         let currentContextSnapshot = snapshot.withContext(
@@ -173,22 +166,6 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
                 == currentContextSnapshot.cleanupPromptComponents,
             "Resolving captured context twice duplicated frozen instructions"
         )
-        guard let fallbackSnapshot = snapshot.usingBatchFallback() else {
-            preconditionFailure("Snapshot lost its captured batch fallback")
-        }
-        guard case .aidictation = fallbackSnapshot.provider else {
-            preconditionFailure("Batch fallback did not select AI Dictation")
-        }
-        guard case .batch = fallbackSnapshot.transport else {
-            preconditionFailure("Batch fallback did not select HTTP transport")
-        }
-        precondition(
-            fallbackSnapshot.transcriptionEndpoint
-                == "https://fallback.example/transcribe"
-        )
-        precondition(fallbackSnapshot.transcriptionModel == "soniox/stt-async-v5")
-        precondition(fallbackSnapshot.transcriptionAPIKey == "fallback-key")
-        precondition(fallbackSnapshot.batchFallback == nil)
         let appStatePath = "Whishpermate/Whispermate/Services/AppState.swift"
         let source = try String(contentsOfFile: appStatePath, encoding: .utf8)
         guard let start = source.range(of: "    private func performTranscription("),
@@ -220,7 +197,7 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         }
 
         precondition(attemptSource.contains("postProcessingPrompt: nil"))
-        precondition(attemptSource.contains("postProcessingEnabled: provider != .aidictation"))
+        precondition(attemptSource.contains("postProcessingEnabled: false"))
         precondition(attemptSource.contains("cleanupMergedTranscript: nil"))
         precondition(
             !attemptSource.contains("TranscriptionOutputFilter.filter"),
@@ -256,7 +233,8 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
             )
         }
         precondition(source.contains("if let realtimeResult"))
-        precondition(source.contains("snapshot.usingBatchFallback()"))
+        precondition(!source.contains("usingBatchFallback"))
+        precondition(!source.contains("groq/whisper-large-v3-turbo"))
         precondition(source.contains("try await session.checkpoint(realtimeResult)"))
         precondition(source.contains("try await session.markRawResultReady(realtimeResult)"))
         precondition(source.contains("try await session.beginCleanup()"))

--- a/scripts/validate_transcription_prompt_routing.py
+++ b/scripts/validate_transcription_prompt_routing.py
@@ -139,9 +139,9 @@ require(
     "macOS recognition lost vocabulary or phrase hints",
 )
 require(
-    "dictionaryManager.formattingInstructions" in stt_builder
-    and "shortcutManager.formattingInstructions" in stt_builder,
-    "macOS recognition lost replacements or phrase expansions",
+    "dictionaryManager.formattingInstructions" not in stt_builder
+    and "shortcutManager.formattingInstructions" not in stt_builder,
+    "macOS recognition contains cleanup-only replacement or expansion values",
 )
 require(
     '"Vocabulary:' not in stt_builder and '"Phrases:' not in stt_builder,
@@ -159,7 +159,9 @@ require(
 )
 require(
     "dictionaryManager.transcriptionKeywords" in app_state_source
-    and "shortcutManager.transcriptionKeywords" in app_state_source,
+    and "shortcutManager.shortcuts" in app_state_source
+    and ".map(\\.voiceTrigger)" in app_state_source
+    and "shortcutManager.transcriptionKeywords" not in app_state_source,
     "modern transcription requests lost literal keyword hints",
 )
 require(
@@ -200,8 +202,8 @@ require(
     "AI Dictation batch recognition still sends a cleanup prompt to STT",
 )
 require(
-    "postProcessingEnabled: provider != .aidictation" in mac_pipeline,
-    "AI Dictation batch transcription still enables server cleanup",
+    "postProcessingEnabled: false" in mac_pipeline,
+    "batch recognition still enables server cleanup",
 )
 require(
     "cleanupMergedTranscript: nil" in mac_pipeline,

--- a/scripts/validate_transcription_routing.py
+++ b/scripts/validate_transcription_routing.py
@@ -8,6 +8,8 @@ PROVIDERS = (ROOT / "Whishpermate/Whispermate/Models/APIProvider.swift").read_te
 TRANSCRIPTION_PROVIDERS = PROVIDERS.split("enum CodexTranscriptionSupport", 1)[0]
 APP_STATE = (ROOT / "Whishpermate/Whispermate/Services/AppState.swift").read_text()
 REALTIME = (ROOT / "Whishpermate/Whispermate/Services/OpenAIRealtimeTranscriptionClient.swift").read_text()
+HISTORY = (ROOT / "Whishpermate/Whispermate/Views/HistoryMasterDetailView.swift").read_text()
+SETTINGS = (ROOT / "Whishpermate/Whispermate/Views/SettingsView.swift").read_text()
 
 
 def require(condition: bool, message: str) -> None:
@@ -30,9 +32,17 @@ require(
     "ChatGPT retranscription is not pinned to batch transport",
 )
 require(
-    'model = isRetranscription\n                ? "gpt-transcribe"' in APP_STATE,
-    "AI Dictation retranscription is not mapped to gpt-transcribe",
+    'provider == .soniox, isRetranscription' in APP_STATE
+    and 'model = "soniox/stt-async-v5"' in APP_STATE,
+    "AI Dictation retranscription is not pinned to Soniox v5 batch",
 )
+require(
+    "onlineProvider: .soniox" in HISTORY,
+    "History re-transcription does not route directly to AI Dictation",
+)
+require("RetranscriptionRouteMenu" not in HISTORY, "History still exposes a provider switch")
+require('Button("ChatGPT")' not in HISTORY, "History still exposes ChatGPT transcription")
+require('Text("Cloud Model")' not in SETTINGS, "Settings still exposes a cloud-model switch")
 require(
     'https://chatgpt.com/backend-api/transcribe' in PROVIDERS,
     "ChatGPT batch transcription endpoint is missing",


### PR DESCRIPTION
AI Dictation now has one provider: Soniox v5. Live macOS uses realtime v5; History and file-upload clients use async v5. History and Settings no longer expose provider switches, cross-provider fallback is removed, and recognition context excludes cleanup-only replacement values.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790733238&installation_model_id=432087&pr_number=109&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F109&signature=a23c33361b98eedb6fc526a9fda9e05ed08384bd3bfb2a1ed0e7b05032d9cfdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->