### PR TITLE
Gate shortcut expansions on exact speech

### DIFF
--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -3043,6 +3043,11 @@ class AppState: ObservableObject {
             sttHintPrompt: sttHintPrompt,
             cleanupPromptComponents: cleanupComponents,
             baseCleanupPromptComponents: cleanupComponents,
+            shortcutExpansions: shortcutManager.shortcuts
+                .filter(\.isEnabled)
+                .map {
+                    .init(trigger: $0.voiceTrigger, expansion: $0.expansion)
+                },
             contextRules: contextRules,
             usesContextRules: usesContextRules,
             appContext: appContext,
@@ -3063,9 +3068,6 @@ class AppState: ObservableObject {
             promptComponents.append("Phrases: \(shortcutManager.transcriptionHints)")
         }
         if let instructions = dictionaryManager.formattingInstructions {
-            promptComponents.append(instructions)
-        }
-        if let instructions = shortcutManager.formattingInstructions {
             promptComponents.append(instructions)
         }
         return promptComponents
@@ -3380,7 +3382,7 @@ class AppState: ObservableObject {
         snapshot: MacTranscriptionAttemptSnapshot
     ) async throws -> String {
         let outputMode = snapshot.outputMode
-        let promptComponents = snapshot.cleanupPromptComponents
+        let promptComponents = snapshot.cleanupPromptComponents(for: rawText)
         let postProcessor = snapshot.postProcessingProvider
 
         if postProcessor == .aidictation,

--- a/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
+++ b/Whishpermate/Whispermate/Services/MacTranscriptionAttemptSnapshot.swift
@@ -6,6 +6,32 @@ import WhisperMateShared
 /// Every mutable preference needed by recognition and cleanup, captured before
 /// an attempt begins. Running attempts never consult the live manager objects.
 nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
+    struct ShortcutExpansion: Sendable {
+        let trigger: String
+        let expansion: String
+
+        func isSupported(in transcript: String) -> Bool {
+            let normalizedTrigger = trigger.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            guard !normalizedTrigger.isEmpty else { return false }
+            let escaped = NSRegularExpression.escapedPattern(
+                for: normalizedTrigger
+            )
+            guard let regex = try? NSRegularExpression(
+                pattern: "(?i)(?<![\\p{L}\\p{N}])\(escaped)(?![\\p{L}\\p{N}])"
+            ) else { return false }
+            return regex.firstMatch(
+                in: transcript,
+                range: NSRange(transcript.startIndex..., in: transcript)
+            ) != nil
+        }
+
+        var cleanupInstruction: String {
+            "Expand the exact spoken shortcut \"\(trigger)\" to \"\(expansion)\"."
+        }
+    }
+
     struct ContextRuleSnapshot: Sendable {
         let name: String
         let appBundleIDs: [String]
@@ -89,6 +115,7 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
     let sttHintPrompt: String
     let cleanupPromptComponents: [String]
     let baseCleanupPromptComponents: [String]
+    let shortcutExpansions: [ShortcutExpansion]
     let contextRules: [ContextRuleSnapshot]
     let usesContextRules: Bool
     let appContext: String?
@@ -157,6 +184,7 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
             sttHintPrompt: sttHintPrompt,
             cleanupPromptComponents: resolvedCleanupComponents,
             baseCleanupPromptComponents: baseCleanupPromptComponents,
+            shortcutExpansions: shortcutExpansions,
             contextRules: contextRules,
             usesContextRules: usesContextRules,
             appContext: appContext,
@@ -167,4 +195,9 @@ nonisolated struct MacTranscriptionAttemptSnapshot: @unchecked Sendable {
         )
     }
 
+    func cleanupPromptComponents(for rawTranscript: String) -> [String] {
+        cleanupPromptComponents + shortcutExpansions
+            .filter { $0.isSupported(in: rawTranscript) }
+            .map(\.cleanupInstruction)
+    }
 }

--- a/scripts/validate_macos_transcription_attempt_snapshot.swift
+++ b/scripts/validate_macos_transcription_attempt_snapshot.swift
@@ -73,6 +73,10 @@ private func capture(_ settings: MutableAttemptSettings) -> MacTranscriptionAtte
         sttHintPrompt: "Before hint",
         cleanupPromptComponents: settings.prompt,
         baseCleanupPromptComponents: settings.prompt,
+        shortcutExpansions: [
+            .init(trigger: "my calendly", expansion: "https://calendly.com/yourname"),
+            .init(trigger: "my email", expansion: "your.email@example.com"),
+        ],
         contextRules: [
             .init(
                 name: "Meetings",
@@ -130,6 +134,14 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
         precondition(snapshot.languageCode == "en")
         precondition(snapshot.vadThreshold == 0.31)
         precondition(snapshot.cleanupPromptComponents == ["Before vocabulary"])
+        precondition(
+            !snapshot.cleanupPromptComponents(for: "Discuss my calendars.")
+                .joined().contains("calendly.com")
+        )
+        precondition(
+            snapshot.cleanupPromptComponents(for: "Send my Calendly.")
+                .joined().contains("calendly.com")
+        )
         let contextualSnapshot = snapshot.withContext(
             appContext: "Captured app",
             screenContext: "Captured screen"

--- a/scripts/validate_transcription_prompt_routing.py
+++ b/scripts/validate_transcription_prompt_routing.py
@@ -165,6 +165,10 @@ require(
     "modern transcription requests lost literal keyword hints",
 )
 require(
+    "snapshot.cleanupPromptComponents(for: rawText)" in app_state_source,
+    "macOS cleanup does not gate shortcut expansions on the raw transcript",
+)
+require(
     "languageManager.apiLanguageCodes" in app_state_source,
     "modern transcription requests lost multiple language hints",
 )


### PR DESCRIPTION
Only shortcut expansions whose exact trigger appears in the durable raw transcript reach cleanup. This prevents fuzzy calendar/Calendly matches from exposing placeholder URLs to the LLM. Includes positive and negative regression coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790734862&installation_model_id=432087&pr_number=110&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F110&signature=94e97d72aaacabaa87ddfc506c3766fc44d8e61ca0c5fc685d6a1a32f6258837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->