### PR TITLE
iOS: do not brick the app behind Saved recordings need attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- iOS no longer locks the app behind a failed saved-recordings check; the warning is dismissible and recording can continue.
 - Overlay no longer dies on built-in mic after the 0.0.116 capture pin.

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -1547,8 +1547,8 @@ struct ContentView: View {
     private func requireMobileAudioRecoveryReady() -> Bool {
         guard mobileAudioRecoveryReady else {
             historyActionMessage = "Saved recordings are still being checked. Try again in a moment."
-            // A previous pass may have failed or is still running; make sure another one is
-            // under way so the next tap can succeed.
+            // Only the in-flight first pass can still block. Kick it so the next
+            // tap proceeds after that pass finishes — success or failure.
             Task { @MainActor in await recoverMobileAudioProcessingIfNeeded() }
             return false
         }
@@ -1582,7 +1582,9 @@ struct ContentView: View {
             }
         }
 
-        mobileAudioRecoveryReady = succeeded
+        // A completed pass must never brick recording, history, or delete.
+        // Offline model download is a separate path and must not keep this false.
+        mobileAudioRecoveryReady = true
         if !succeeded {
             historyActionMessage = "Saved recordings need attention. Try again in a moment."
         }

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -934,7 +934,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateLiveActivity/WhisperMateLiveActivity.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateLiveActivity/Info.plist;
@@ -944,7 +944,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_LIVE_ACTIVITY_APPSTORE_PROFILE_NAME)";
@@ -979,7 +979,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;
@@ -1010,7 +1010,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;
@@ -1027,7 +1027,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = WhisperMateLiveActivity/WhisperMateLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateLiveActivity/Info.plist;
@@ -1037,7 +1037,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1281,7 +1281,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.shared;
@@ -1327,7 +1327,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.shared;
@@ -1357,7 +1357,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WhisperMateIOS/WhisperMateIOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1372,7 +1372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1395,7 +1395,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateIOS/WhisperMateIOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1410,7 +1410,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_APPSTORE_PROFILE_NAME)";
@@ -1432,7 +1432,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = WhisperMateKeyboard/WhisperMateKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateKeyboard/Info.plist;
@@ -1444,7 +1444,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1465,7 +1465,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateKeyboard/WhisperMateKeyboard.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 95;
+				CURRENT_PROJECT_VERSION = 96;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateKeyboard/Info.plist;
@@ -1477,7 +1477,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.101;
+				MARKETING_VERSION = 0.0.102;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_KEYBOARD_APPSTORE_PROFILE_NAME)";

--- a/scripts/validate_ios_audio_processing_recovery.swift
+++ b/scripts/validate_ios_audio_processing_recovery.swift
@@ -2341,6 +2341,23 @@ private func testIOSCallerRecoveryContracts() throws {
         "Keyboard recording can start before mobile audio recovery"
     )
     try require(
+        !content.contains("mobileAudioRecoveryReady = succeeded"),
+        "A failed launch recovery pass permanently bricks the app behind mobileAudioRecoveryReady"
+    )
+    guard let recoverStart = content.range(of: "private func recoverMobileAudioProcessingIfNeeded()"),
+          let recoverEnd = content.range(
+            of: "private static func performMobileAudioRecovery(",
+            range: recoverStart.upperBound ..< content.endIndex
+          )
+    else { throw ValidationFailure.failed("Mobile audio launch recovery function is missing") }
+    let recoverBody = String(content[recoverStart.lowerBound ..< recoverEnd.lowerBound])
+    try require(
+        recoverBody.contains("mobileAudioRecoveryReady = true")
+            && recoverBody.contains("if !succeeded")
+            && recoverBody.contains("Saved recordings need attention. Try again in a moment."),
+        "Failed mobile audio recovery must unblock the app and only show a dismissible warning"
+    )
+    try require(
         content.contains("private func reconcileActiveKeyboardAttemptIfNeeded()"),
         "Host does not reconcile a durable keyboard cancel after command expiry"
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A failed mobile audio recovery pass left `mobileAudioRecoveryReady == false` forever. Recording, open history, delete, and clear history all hit `requireMobileAudioRecoveryReady()` and showed a blocking **History** alert:

- "Saved recordings need attention. Try again in a moment."
- or "Saved recordings are still being checked…"

PR 103 added retry / clear-cache helpers, but a failed `MobileAudioProcessingStore` recovery / quarantine path still bricked the whole app until reinstall. Artem hit this on device; Jeremy Christensen is still locked on 0.0.100.

## Hotfix

After a recovery attempt **succeeds or fails**, set `mobileAudioRecoveryReady = true` so the user can dismiss the warning and record again.

- Useful recovery is unchanged (`normalizeInterruptedAttempts`, usage flush).
- Failure still shows the existing dismissible History alert with OK.
- Offline model download stays on its own path (Try Again / Use Cloud). A failed offline model no longer keeps this gate false.
- iOS marketing version **0.0.102**; app / keyboard / live activity `CURRENT_PROJECT_VERSION` 95 → 96.

Do not tag `ios-v0.0.102` here — Build tags after merge.

## Test

`scripts/validate_ios_audio_processing_recovery.swift` now asserts that a completed recovery pass assigns `mobileAudioRecoveryReady = true` (never `= succeeded`) and only shows the dismissible warning on failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0167a5ba-aec1-4cdf-b593-8735735a6117?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0167a5ba-aec1-4cdf-b593-8735735a6117&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791085696&installation_model_id=432087&pr_number=115&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F115&signature=674df4ce95b3eed51b415f01b147f8aadd45c43dd27eae6d45bff3ce39d6fac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->