### PR TITLE
iOS 0.0.103: unblock store init when directory fsync fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## Unreleased
 
+- iOS store init no longer bricks recording when app-group directory fsync fails after mkdir; leftover quarantine is reset once on launch.
 - iOS no longer locks the app behind a failed saved-recordings check; the warning is dismissible and recording can continue.
 - Overlay no longer dies on built-in mic after the 0.0.116 capture pin.

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -1595,7 +1595,8 @@ struct ContentView: View {
         historyManager: HistoryManager
     ) async throws -> [UUID] {
         try await historyManager.reload()
-        _ = try await MobileAudioProcessingStore.shared.normalizeInterruptedAttempts()
+        _ = try await MobileAudioProcessingStore.shared
+            .normalizeInterruptedAttemptsRecoveringQuarantine()
         let snapshots = try await MobileAudioProcessingStore.shared.allSnapshots()
         let usageRecordingIDs = snapshots.compactMap { snapshot -> UUID? in
             guard snapshot.stage == .succeeded,

--- a/Whishpermate/WhisperMateShared/Services/MobileAudioLaunchRecoveryPolicy.swift
+++ b/Whishpermate/WhisperMateShared/Services/MobileAudioLaunchRecoveryPolicy.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Launch-recovery decisions for the mobile audio processing store.
+///
+/// Directory fsync after a successful mkdir is durability insurance only.
+/// iOS/APFS can fail that call even when the directory exists; store init
+/// must not fall into the unavailable stub for that. Quarantine reset is a
+/// separate last-resort path for a leftover `QUARANTINED` flag.
+public enum MobileAudioLaunchRecoveryPolicy {
+    public static var directoryCreationTreatsFsyncAsBestEffort: Bool {
+        #if os(iOS)
+            true
+        #else
+            false
+        #endif
+    }
+
+    public static func acceptDirectoryCreationFsync(
+        result: Int32,
+        bestEffort: Bool = directoryCreationTreatsFsyncAsBestEffort
+    ) -> Bool {
+        result == 0 || bestEffort
+    }
+}

--- a/Whishpermate/WhisperMateShared/Services/MobileAudioProcessingStore.swift
+++ b/Whishpermate/WhisperMateShared/Services/MobileAudioProcessingStore.swift
@@ -535,6 +535,8 @@ public actor MobileAudioProcessingStore {
                     trustedContainerDirectory: container
                 )
             } catch {
+                // Directory fsync after mkdir is best-effort on iOS. Only a missing
+                // app group or mkdir/open failure should land in this stub.
                 return MobileAudioProcessingStore(unavailable: ())
             }
         #else
@@ -1228,9 +1230,34 @@ public actor MobileAudioProcessingStore {
         }
     }
 
+    /// True when launch recovery should wipe the processing journal and retry.
+    /// Leftover `QUARANTINED` (and normalize blocked by that flag) is the only wipe.
+    /// A missing app-group / unavailable stub is not a history wipe.
+    public static func shouldForceResetQuarantine(_ error: Error) -> Bool {
+        (error as? StoreError) == .quarantined
+    }
+
+    /// Launch recovery: normalize interrupted attempts. If the store is quarantined,
+    /// clear the quarantine once and retry. History files are not touched.
+    @discardableResult
+    public func normalizeInterruptedAttemptsRecoveringQuarantine() throws -> [Snapshot] {
+        do {
+            return try normalizeInterruptedAttempts()
+        } catch {
+            guard Self.shouldForceResetQuarantine(error) else { throw error }
+            DebugLog.warning(
+                "Mobile audio store is quarantined; attempting one-time reset",
+                context: "MobileAudioProcessingStore"
+            )
+            try forceResetQuarantine()
+            return try normalizeInterruptedAttempts()
+        }
+    }
+
     /// Removes the quarantine flag and resets the store to allow recovery from a locked state.
     /// This is a last-resort recovery option that clears all pending attempts and quarantine state.
     /// Call this when the store is permanently locked and no other recovery is possible.
+    /// HistoryManager recordings (`history.json` / `Recordings/`) are not deleted.
     public func forceResetQuarantine() throws {
         let fm = FileManager.default
 
@@ -2830,7 +2857,13 @@ public actor MobileAudioProcessingStore {
     }
 
     @discardableResult
-    static func ensureDirectoryNoFollow(parent: URL, name: String) throws -> URL {
+    static func ensureDirectoryNoFollow(
+        parent: URL,
+        name: String,
+        parentDirectoryFsync: (@Sendable (Int32) -> Int32)? = nil,
+        treatDirectoryFsyncAsBestEffort: Bool = MobileAudioLaunchRecoveryPolicy
+            .directoryCreationTreatsFsyncAsBestEffort
+    ) throws -> URL {
         guard !name.isEmpty, name != ".", name != "..", !name.contains("/") else {
             throw StoreError.quarantined
         }
@@ -2861,7 +2894,16 @@ public actor MobileAudioProcessingStore {
             guard Darwin.fstat(childDescriptor, &status) == 0,
                   (status.st_mode & S_IFMT) == S_IFDIR
             else { throw StoreError.quarantined }
-            guard Darwin.fsync(parentDescriptor) == 0 else { throw StoreError.unavailable }
+            // mkdirat/openat already proved the directory exists. iOS/APFS directory
+            // fsync is unreliable and must not brick shared-store initialization.
+            let fsyncImpl = parentDirectoryFsync ?? { Darwin.fsync($0) }
+            let fsyncResult = fsyncImpl(parentDescriptor)
+            guard MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(
+                result: fsyncResult,
+                bestEffort: treatDirectoryFsyncAsBestEffort
+            ) else {
+                throw StoreError.unavailable
+            }
         #else
             try FileManager.default.createDirectory(
                 at: directory,

--- a/Whishpermate/Whispermate.xcodeproj/project.pbxproj
+++ b/Whishpermate/Whispermate.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		8F1AC4D7088B410D519BF10F /* MacAsyncDeadline.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12CA068C799386D2BF9EA4A /* MacAsyncDeadline.swift */; };
 		AA10000000000000000002 /* HostLaunchRecoveryGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000001 /* HostLaunchRecoveryGateTests.swift */; };
 		AA10000000000000000004 /* HostLaunchRecoveryGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000003 /* HostLaunchRecoveryGate.swift */; };
+		AA10000000000000000006 /* MobileAudioLaunchRecoveryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000005 /* MobileAudioLaunchRecoveryPolicyTests.swift */; };
+		AA10000000000000000008 /* MobileAudioLaunchRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000007 /* MobileAudioLaunchRecoveryPolicy.swift */; };
 		AFB68FC6D50BD0CA71C7AFBC /* FnKeyGestureResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53994ACF59112AC03573BA2A /* FnKeyGestureResolverTests.swift */; };
 		B2D5E0012F9BF00100000001 /* WhisperMateShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; };
 		B2D5E0022F9BF00100000002 /* WhisperMateShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1E7D2AD2EBA925200A07338 /* WhisperMateShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -174,6 +176,8 @@
 		53994ACF59112AC03573BA2A /* FnKeyGestureResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FnKeyGestureResolverTests.swift; sourceTree = "<group>"; };
 		AA10000000000000000001 /* HostLaunchRecoveryGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostLaunchRecoveryGateTests.swift; sourceTree = "<group>"; };
 		AA10000000000000000003 /* HostLaunchRecoveryGate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HostLaunchRecoveryGate.swift; path = WhisperMateShared/Services/HostLaunchRecoveryGate.swift; sourceTree = SOURCE_ROOT; };
+		AA10000000000000000005 /* MobileAudioLaunchRecoveryPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAudioLaunchRecoveryPolicyTests.swift; sourceTree = "<group>"; };
+		AA10000000000000000007 /* MobileAudioLaunchRecoveryPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MobileAudioLaunchRecoveryPolicy.swift; path = WhisperMateShared/Services/MobileAudioLaunchRecoveryPolicy.swift; sourceTree = SOURCE_ROOT; };
 		56334D9AC285442AC331E6B8 /* TextInsertionFormatterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextInsertionFormatterTests.swift; sourceTree = "<group>"; };
 		5938666BED2167FFA779E1C5 /* HotkeyGestureResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyGestureResolver.swift; sourceTree = "<group>"; };
 		5D82849D268DF9E045FAFE3E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -347,6 +351,8 @@
 				53994ACF59112AC03573BA2A /* FnKeyGestureResolverTests.swift */,
 				AA10000000000000000001 /* HostLaunchRecoveryGateTests.swift */,
 				AA10000000000000000003 /* HostLaunchRecoveryGate.swift */,
+				AA10000000000000000005 /* MobileAudioLaunchRecoveryPolicyTests.swift */,
+				AA10000000000000000007 /* MobileAudioLaunchRecoveryPolicy.swift */,
 				56334D9AC285442AC331E6B8 /* TextInsertionFormatterTests.swift */,
 				EBE389747A89826966B083FB /* HotkeyGestureResolverTests.swift */,
 				18D7395E9700499AAA143432 /* TranscriptionOutputFilterTests.swift */,
@@ -826,6 +832,8 @@
 				8F1AC4D7088B410D519BF10F /* MacAsyncDeadline.swift in Sources */,
 				AA10000000000000000002 /* HostLaunchRecoveryGateTests.swift in Sources */,
 				AA10000000000000000004 /* HostLaunchRecoveryGate.swift in Sources */,
+				AA10000000000000000006 /* MobileAudioLaunchRecoveryPolicyTests.swift in Sources */,
+				AA10000000000000000008 /* MobileAudioLaunchRecoveryPolicy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -934,7 +942,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateLiveActivity/WhisperMateLiveActivity.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateLiveActivity/Info.plist;
@@ -944,7 +952,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_LIVE_ACTIVITY_APPSTORE_PROFILE_NAME)";
@@ -979,7 +987,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;
@@ -1010,7 +1018,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.whispermate.parakeet-runtime";
 				PRODUCT_NAME = ParakeetRuntime;
 				SKIP_INSTALL = YES;
@@ -1027,7 +1035,7 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = WhisperMateLiveActivity/WhisperMateLiveActivity.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateLiveActivity/Info.plist;
@@ -1037,7 +1045,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.liveactivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1281,7 +1289,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.shared;
@@ -1327,7 +1335,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.shared;
@@ -1357,7 +1365,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = WhisperMateIOS/WhisperMateIOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1372,7 +1380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1395,7 +1403,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateIOS/WhisperMateIOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -1410,7 +1418,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_APPSTORE_PROFILE_NAME)";
@@ -1432,7 +1440,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = WhisperMateKeyboard/WhisperMateKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateKeyboard/Info.plist;
@@ -1444,7 +1452,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1465,7 +1473,7 @@
 				CODE_SIGN_ENTITLEMENTS = WhisperMateKeyboard/WhisperMateKeyboard.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 96;
+				CURRENT_PROJECT_VERSION = 97;
 				DEVELOPMENT_TEAM = G7DJ6P37KU;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = WhisperMateKeyboard/Info.plist;
@@ -1477,7 +1485,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.0.102;
+				MARKETING_VERSION = 0.0.103;
 				PRODUCT_BUNDLE_IDENTIFIER = com.whispermate.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "$(IOS_KEYBOARD_APPSTORE_PROFILE_NAME)";

--- a/Whishpermate/WhispermateTests/MobileAudioLaunchRecoveryPolicyTests.swift
+++ b/Whishpermate/WhispermateTests/MobileAudioLaunchRecoveryPolicyTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+/// Covers the launch-recovery policy that decides whether a failed directory
+/// fsync after mkdir can brick iOS recording. Artsiom's 0.0.102 device never
+/// created WhisperMate/MobileAudioProcessing because parent fsync threw.
+final class MobileAudioLaunchRecoveryPolicyTests: XCTestCase {
+    func testSuccessfulDirectoryFsyncIsAlwaysAccepted() {
+        XCTAssertTrue(
+            MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(
+                result: 0,
+                bestEffort: false
+            )
+        )
+        XCTAssertTrue(
+            MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(
+                result: 0,
+                bestEffort: true
+            )
+        )
+    }
+
+    func testIOSBestEffortAcceptsFailedDirectoryFsync() {
+        XCTAssertTrue(
+            MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(
+                result: -1,
+                bestEffort: true
+            )
+        )
+    }
+
+    func testRequiredDirectoryFsyncStillFailsClosed() {
+        XCTAssertFalse(
+            MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(
+                result: -1,
+                bestEffort: false
+            )
+        )
+    }
+
+    func testProductionDefaultMatchesPlatform() {
+        #if os(iOS)
+            XCTAssertTrue(MobileAudioLaunchRecoveryPolicy.directoryCreationTreatsFsyncAsBestEffort)
+            XCTAssertTrue(MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: -1))
+        #else
+            XCTAssertFalse(MobileAudioLaunchRecoveryPolicy.directoryCreationTreatsFsyncAsBestEffort)
+            XCTAssertFalse(MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: -1))
+        #endif
+    }
+}

--- a/scripts/validate_apple_audio_recovery.sh
+++ b/scripts/validate_apple_audio_recovery.sh
@@ -82,6 +82,7 @@ swiftc -parse-as-library -module-cache-path "$module_cache" \
   Whishpermate/WhisperMateShared/Models/TranscriptionOptions.swift \
   Whishpermate/WhisperMateShared/Models/Recording.swift \
   Whishpermate/WhisperMateShared/Services/DebugLog.swift \
+  Whishpermate/WhisperMateShared/Services/MobileAudioLaunchRecoveryPolicy.swift \
   Whishpermate/WhisperMateShared/Services/MobileAudioProcessingStore.swift \
   Whishpermate/WhisperMateShared/Services/IOSAudioProcessingDeadline.swift \
   Whishpermate/WhisperMateShared/Storage/HistoryManager.swift \

--- a/scripts/validate_ios_audio_processing_recovery.swift
+++ b/scripts/validate_ios_audio_processing_recovery.swift
@@ -1987,6 +1987,123 @@ private func testLegacyHistoryDeletionIntentSurvivesCrash() async throws {
     )
 }
 
+private func testDirectoryCreationSucceedsWhenParentFsyncFails() async throws {
+    try require(
+        MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: 0, bestEffort: false),
+        "Successful directory fsync must always be accepted"
+    )
+    try require(
+        MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: -1, bestEffort: true),
+        "iOS store init must accept a failed parent-directory fsync after mkdir"
+    )
+    try require(
+        !MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: -1, bestEffort: false),
+        "Non-iOS directory-creation fsync failure must remain visible"
+    )
+    #if os(iOS)
+        try require(
+            MobileAudioLaunchRecoveryPolicy.directoryCreationTreatsFsyncAsBestEffort
+                && MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(result: -1),
+            "iOS production store init still treats directory fsync as required"
+        )
+    #endif
+
+    let parent = try makeRoot("dir-fsync-best-effort")
+    let whisperMate = try MobileAudioProcessingStore.ensureDirectoryNoFollow(
+        parent: parent,
+        name: "WhisperMate",
+        parentDirectoryFsync: { _ in -1 },
+        treatDirectoryFsyncAsBestEffort: true
+    )
+    let processing = try MobileAudioProcessingStore.ensureDirectoryNoFollow(
+        parent: whisperMate,
+        name: "MobileAudioProcessing",
+        parentDirectoryFsync: { _ in -1 },
+        treatDirectoryFsyncAsBestEffort: true
+    )
+    var isDirectory: ObjCBool = false
+    try require(
+        FileManager.default.fileExists(atPath: whisperMate.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+            && FileManager.default.fileExists(atPath: processing.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue,
+        "App-group WhisperMate/MobileAudioProcessing directories were not created when fsync failed"
+    )
+
+    let store = MobileAudioProcessingStore(rootDirectory: processing)
+    let lease = try await store.beginNewAttempt(
+        recordingID: UUID(),
+        deadlineAt: Date().addingTimeInterval(30)
+    )
+    try require(
+        FileManager.default.fileExists(atPath: lease.sourceURL.deletingLastPathComponent().path),
+        "A store rooted in the fsync-failed mkdir path cannot start a recording"
+    )
+}
+
+private func testLaunchRecoveryForceResetsQuarantineAndKeepsHistory() async throws {
+    let workspace = try makeRoot("quarantine-launch-reset")
+    let historyRoot = workspace.appendingPathComponent("WhisperMate", isDirectory: true)
+    let storeRoot = historyRoot.appendingPathComponent("MobileAudioProcessing", isDirectory: true)
+    try FileManager.default.createDirectory(at: storeRoot, withIntermediateDirectories: true)
+
+    let history = HistoryManager(rootDirectory: historyRoot)
+    try await history.reload()
+    let kept = Recording(transcription: "history must survive quarantine reset")
+    try await history.upsertRecording(kept)
+    try await history.reload()
+    try require(
+        history.recordings.contains(where: { $0.id == kept.id }),
+        "History fixture was not persisted before quarantine"
+    )
+
+    let store = MobileAudioProcessingStore(rootDirectory: storeRoot)
+    let lease = try await store.beginNewAttempt(
+        recordingID: UUID(),
+        deadlineAt: Date().addingTimeInterval(30)
+    )
+    try Data("source marker".utf8).write(to: lease.sourceURL, options: .atomic)
+    let quarantineURL = storeRoot.appendingPathComponent("QUARANTINED")
+    try Data("leftover".utf8).write(to: quarantineURL, options: .atomic)
+
+    try require(
+        MobileAudioProcessingStore.shouldForceResetQuarantine(
+            MobileAudioProcessingStore.StoreError.quarantined
+        )
+            && !MobileAudioProcessingStore.shouldForceResetQuarantine(
+                MobileAudioProcessingStore.StoreError.unavailable
+            ),
+        "Launch recovery must reset only a quarantined store, not an unavailable stub"
+    )
+    try await requireThrows(.quarantined) {
+        _ = try await store.normalizeInterruptedAttempts()
+    }
+    try require(
+        FileManager.default.fileExists(atPath: quarantineURL.path),
+        "Leftover QUARANTINED flag was cleared by normalize without an explicit reset"
+    )
+
+    _ = try await store.normalizeInterruptedAttemptsRecoveringQuarantine()
+    try require(
+        !FileManager.default.fileExists(atPath: quarantineURL.path),
+        "Launch recovery did not clear the leftover QUARANTINED flag"
+    )
+    try await history.reload()
+    try require(
+        history.recordings.contains(where: { $0.id == kept.id && $0.transcription == kept.transcription }),
+        "forceResetQuarantine deleted HistoryManager recordings"
+    )
+
+    let next = try await store.beginNewAttempt(
+        recordingID: UUID(),
+        deadlineAt: Date().addingTimeInterval(30)
+    )
+    try require(
+        next.recordingID != lease.recordingID,
+        "Store was not writable after quarantine launch recovery"
+    )
+}
+
 private func testCorruptionQuarantinesWithoutOverwrite() async throws {
     let root = try makeRoot("corrupt")
     let store = MobileAudioProcessingStore(rootDirectory: root)
@@ -2357,6 +2474,18 @@ private func testIOSCallerRecoveryContracts() throws {
             && recoverBody.contains("Saved recordings need attention. Try again in a moment."),
         "Failed mobile audio recovery must unblock the app and only show a dismissible warning"
     )
+    guard let performStart = content.range(of: "private static func performMobileAudioRecovery("),
+          let performEnd = content.range(
+            of: "return usageRecordingIDs",
+            range: performStart.upperBound ..< content.endIndex
+          )
+    else { throw ValidationFailure.failed("performMobileAudioRecovery body is missing") }
+    let performBody = String(content[performStart.lowerBound ..< performEnd.upperBound])
+    try require(
+        performBody.contains("normalizeInterruptedAttemptsRecoveringQuarantine()")
+            && !performBody.contains("normalizeInterruptedAttempts()\n"),
+        "Launch recovery still calls normalize without a one-time quarantine reset"
+    )
     try require(
         content.contains("private func reconcileActiveKeyboardAttemptIfNeeded()"),
         "Host does not reconcile a durable keyboard cancel after command expiry"
@@ -2462,6 +2591,33 @@ private func testIOSCallerRecoveryContracts() throws {
             && storeSource.contains("MobileAudioProcessingStore(unavailable: ())")
             && !storeSource.contains("defaultRootDirectory()"),
         "Production mobile audio store still falls back outside the App Group"
+    )
+    try require(
+        storeSource.contains("parentDirectoryFsync")
+            && storeSource.contains("treatDirectoryFsyncAsBestEffort")
+            && storeSource.contains("MobileAudioLaunchRecoveryPolicy.acceptDirectoryCreationFsync(")
+            && !storeSource.contains(
+                "guard Darwin.fsync(parentDescriptor) == 0 else { throw StoreError.unavailable }"
+            ),
+        "Store init directory creation still throws when parent fsync fails on iOS"
+    )
+    let policySource = try String(
+        contentsOf: repositoryRoot.appendingPathComponent(
+            "Whishpermate/WhisperMateShared/Services/MobileAudioLaunchRecoveryPolicy.swift"
+        ),
+        encoding: .utf8
+    )
+    try require(
+        policySource.contains("os(iOS)")
+            && policySource.contains("directoryCreationTreatsFsyncAsBestEffort")
+            && policySource.contains("result == 0 || bestEffort"),
+        "iOS directory-creation fsync policy is no longer best-effort"
+    )
+    try require(
+        storeSource.contains("normalizeInterruptedAttemptsRecoveringQuarantine()")
+            && storeSource.contains("shouldForceResetQuarantine(")
+            && storeSource.contains("forceResetQuarantine()"),
+        "Quarantined launch recovery has no one-time force reset"
     )
     try require(
         storeSource.contains("public final class ChunkWorkspace")
@@ -2572,6 +2728,10 @@ private struct IOSAudioRecoveryValidator {
             try await testUsageClaimIsAtMostOnceAcrossRestartDeleteAndClear()
             print("testLegacyHistoryDeletionIntentSurvivesCrash")
             try await testLegacyHistoryDeletionIntentSurvivesCrash()
+            print("testDirectoryCreationSucceedsWhenParentFsyncFails")
+            try await testDirectoryCreationSucceedsWhenParentFsyncFails()
+            print("testLaunchRecoveryForceResetsQuarantineAndKeepsHistory")
+            try await testLaunchRecoveryForceResetsQuarantineAndKeepsHistory()
             print("testCorruptionQuarantinesWithoutOverwrite")
             try await testCorruptionQuarantinesWithoutOverwrite()
             print("testHistoryDoesNotResurrectEvictedStoreAttempts")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why 0.0.102 was not enough

PR #115 (`0.0.102` / build 96) only set `mobileAudioRecoveryReady = true` after launch recovery and showed a dismissible History alert on failure. That unblocked the UI gate, but it did **not** make `MobileAudioProcessingStore` writable.

On Artsiom’s iPhone the app group `group.com.whispermate.shared` was accessible, but `WhisperMate/` and `MobileAudioProcessing/` were never created. Shared init therefore fell into the permanent `unavailable: ()` stub. Every Record tap then mapped `StoreError.unavailable` to:

> Recordings are temporarily unavailable. Please restart the app and try again.

Launch recovery also failed (`normalizeInterruptedAttempts()` needs a writable store), which produced:

> Saved recordings need attention. Try again in a moment.

The likely throw site is `ensureDirectoryNoFollow`: after `mkdirat`/`openat` succeed it required `fsync(parentDescriptor) == 0`. Directory fsync is not reliable on iOS/APFS and can fail even when the directory exists. That exception bricked the process for its whole lifetime.

## This change

1. **Primary:** parent-directory `fsync` after a successful mkdir is best-effort on iOS. Store init no longer falls into the unavailable stub for that. Injectable `parentDirectoryFsync` hook covers the regression (mkdir still succeeds when fsync returns `-1`).
2. **Secondary:** if launch recovery still sees a leftover `QUARANTINED` file, `normalizeInterruptedAttemptsRecoveringQuarantine()` calls `forceResetQuarantine()` once and retries. That clears processing attempts/metadata only — `HistoryManager` `history.json` / `Recordings/` stay intact. A successful reset is silent (no History alert). Record is not gated forever.
3. Normal corruption quarantine still throws `.quarantined` from `normalizeInterruptedAttempts()`; only launch recovery resets once.
4. iOS marketing version **0.0.103**, build **97**.

Mac/Windows recording paths are unchanged except for the shared mkdir helper used by iOS History/store init.

## Tests

- `MobileAudioLaunchRecoveryPolicyTests` (HostLaunchRecoveryGate style)
- Validator: mkdir path succeeds when injected parent fsync fails
- Validator: leftover `QUARANTINED` → one-time force reset → normalize/start works and History rows remain
- Source contracts that ContentView uses the recovering normalize path and no longer hard-throws on parent-directory fsync

After merge we can tag `ios-v0.0.103`. Device install is separate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e5ef7a-487d-4017-bd7f-53d5e5b98528?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e5ef7a-487d-4017-bd7f-53d5e5b98528&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791089833&installation_model_id=432087&pr_number=116&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F116&signature=d6c96a8ed7a25dd5e042024b9cb90fea676fffde16969b76ff06a0251687c0b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->