### PR TITLE
iOS keyboard: keep second mic tap in-keyboard; no red transcription errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- iOS keyboard keeps Quick Dictation armed after the first session so later mic taps stay in-keyboard instead of opening the app again.
+- iOS keyboard no longer shows a red “couldn’t transcribe” error; failed transcriptions still save in the app and return to idle.
 - iOS store init no longer bricks recording when app-group directory fsync fails after mkdir; leftover quarantine is reset once on launch.
 - iOS no longer locks the app behind a failed saved-recordings check; the warning is dismissible and recording can continue.
 - Overlay no longer dies on built-in mic after the 0.0.116 capture pin.

--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -1116,13 +1116,14 @@ struct ContentView: View {
             keyboardIdentity: activeKeyboardDictationIdentity,
             keepAudioBridgeAliveAfterStop: activeKeyboardDictationIdentity != nil
         ) { recording in
-            if let activeKeyboardDictationIdentity {
+                if let activeKeyboardDictationIdentity {
                 DebugLog.info("completed keyboard attemptID=\(activeKeyboardDictationIdentity.attemptID) length=\(recording.transcription.count)", context: "KEYBOARD_DIAG")
                 self.activeKeyboardDictationIdentity = nil
                 self.showKeyboardReturnScreen = false
                 self.keyboardBridgeAliveUntil = nil
                 self.inlineRecording.setKeyboardAttemptIdentity(nil)
                 self.inlineRecording.stopListening()
+                self.rearmQuickDictationAfterKeyboardSession()
             }
             markRecordingAsNew(recording)
         }
@@ -1178,6 +1179,10 @@ struct ContentView: View {
         }
 
         activeKeyboardDictationIdentity = identity
+        // Real recording takes the audio session. Keep the published window so
+        // the next tap can re-arm without opening the app.
+        inlineRecording.audioRecorder.stopStandby(deactivateAudioSession: false)
+        refreshQuickDictationHeartbeat()
         keepKeyboardBridgeAlive()
         dismissAllSheetsForKeyboardDictation()
         showKeyboardReturnScreen = true
@@ -1276,6 +1281,7 @@ struct ContentView: View {
         else { return }
         _ = KeyboardDictationHandoff.cancelAttempt(identity: identity)
         cancelActiveKeyboardHostWork()
+        rearmQuickDictationAfterKeyboardSession()
     }
 
     /// Fails closed without touching the handoff journal. This is used when persistence itself
@@ -1296,11 +1302,18 @@ struct ContentView: View {
         }
     }
 
-    private var shouldKeepKeyboardCommandPolling: Bool {
+    private var hasActiveKeyboardRecordingOrBridge: Bool {
         let hasActiveKeyboardRecording = activeKeyboardDictationIdentity != nil
             && (inlineRecording.state == .recording || inlineRecording.state == .paused || inlineRecording.state == .processing)
         let hasLiveKeyboardBridge = keyboardBridgeAliveUntil.map { $0 > Date() } ?? false
         return hasActiveKeyboardRecording || hasLiveKeyboardBridge
+    }
+
+    private var shouldKeepKeyboardCommandPolling: Bool {
+        KeyboardDictationHandoff.shouldKeepHostAlive(
+            hasActiveKeyboardWork: hasActiveKeyboardRecordingOrBridge,
+            availability: KeyboardDictationHandoff.loadQuickDictationAvailability()
+        )
     }
 
     private func startKeyboardCommandPolling() {
@@ -1317,31 +1330,30 @@ struct ContentView: View {
                 tearDownExpiredKeyboardBridge()
                 try? await Task.sleep(nanoseconds: 250_000_000)
 
-                // Check if we should keep polling
-                let isQuickDictationActive = inlineRecording.audioRecorder.isStandbyActive
-                let hasActiveKeyboardWork = shouldKeepKeyboardCommandPolling
+                let hasActiveKeyboardWork = hasActiveKeyboardRecordingOrBridge
+                let windowValid = KeyboardDictationHandoff.hasValidQuickDictationWindow()
 
-                if scenePhase != .active, !hasActiveKeyboardWork, !isQuickDictationActive {
-                    // App is in background, no active keyboard work, and no Quick Dictation standby
-                    // Stop polling and let iOS suspend the app
-                    DebugLog.info("stopping command polling (background, no standby)", context: "KEYBOARD_DIAG")
-                    clearQuickDictation()
-                    keyboardCommandPollTask = nil
-                    break
+                // A finished keyboard session tears down the recorder. Re-arm
+                // standby immediately so the next tap stays in-keyboard.
+                if inlineRecording.state == .idle, windowValid, !inlineRecording.audioRecorder.isStandbyActive {
+                    armQuickDictation()
                 }
 
-                // If Quick Dictation is active, check if it has expired
-                if isQuickDictationActive {
-                    if let availability = KeyboardDictationHandoff.loadQuickDictationAvailability(),
-                       availability.expiresAt <= Date() {
-                        // Quick Dictation window expired - stop standby
-                        DebugLog.info("Quick Dictation window expired; stopping standby", context: "KEYBOARD_DIAG")
-                        clearQuickDictation()
-                        if scenePhase != .active, !hasActiveKeyboardWork {
-                            keyboardCommandPollTask = nil
-                            break
-                        }
+                if let availability = KeyboardDictationHandoff.loadQuickDictationAvailability(),
+                   availability.expiresAt <= Date() {
+                    DebugLog.info("Quick Dictation window expired; stopping standby", context: "KEYBOARD_DIAG")
+                    clearQuickDictation()
+                    if scenePhase != .active, !hasActiveKeyboardWork {
+                        keyboardCommandPollTask = nil
+                        break
                     }
+                    continue
+                }
+
+                if scenePhase != .active, !hasActiveKeyboardWork, !windowValid {
+                    DebugLog.info("stopping command polling (background, no Quick Dictation window)", context: "KEYBOARD_DIAG")
+                    keyboardCommandPollTask = nil
+                    break
                 }
             }
         }
@@ -1349,23 +1361,57 @@ struct ContentView: View {
 
     /// Arms Quick Dictation with a 10-minute window using audio standby mode.
     /// The audio standby keeps iOS from suspending the app, enabling in-place dictation.
+    /// Re-arming after a session preserves the existing expiry so the window cannot
+    /// extend forever.
     private func armQuickDictation() {
+        guard inlineRecording.state == .idle else {
+            refreshQuickDictationHeartbeat()
+            return
+        }
         guard !inlineRecording.audioRecorder.isStandbyActive else {
-            // Already in standby - just refresh the availability
             refreshQuickDictationHeartbeat()
             return
         }
 
+        let existing = KeyboardDictationHandoff.loadQuickDictationAvailability()
+        let availability: KeyboardDictationHandoff.QuickDictationAvailability
+        if let existing, existing.expiresAt > Date() {
+            availability = existing.refreshingHeartbeat()
+        } else {
+            availability = KeyboardDictationHandoff.QuickDictationAvailability()
+        }
+
         do {
             try inlineRecording.audioRecorder.startStandby()
-            let availability = KeyboardDictationHandoff.QuickDictationAvailability()
             KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
             DebugLog.info("armed Quick Dictation with audio standby until \(availability.expiresAt)", context: "KEYBOARD_DIAG")
         } catch {
             DebugLog.info("failed to arm Quick Dictation: \(error)", context: "KEYBOARD_DIAG")
             // Fall back to non-standby mode - the heartbeat will expire quickly
-            let availability = KeyboardDictationHandoff.QuickDictationAvailability()
             KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
+        }
+    }
+
+    /// After a keyboard dictation returns to idle, keep (or immediately re-arm)
+    /// Quick Dictation so the next mic tap uses `.startViaReadyApp`.
+    private func rearmQuickDictationAfterKeyboardSession() {
+        switch KeyboardDictationHandoff.rearmDecisionAfterIdleSession(
+            current: KeyboardDictationHandoff.loadQuickDictationAvailability()
+        ) {
+        case .rearm(let availability):
+            KeyboardDictationHandoff.saveQuickDictationAvailability(availability)
+            DebugLog.info(
+                "re-armed Quick Dictation after keyboard session until \(availability.expiresAt)",
+                context: "KEYBOARD_DIAG"
+            )
+            KeyboardDictationHandoff.appendDiagnostic(
+                "re-armed Quick Dictation after keyboard session until \(availability.expiresAt)"
+            )
+            startKeyboardCommandPolling()
+            armQuickDictation()
+        case .clear:
+            DebugLog.info("Quick Dictation window expired after keyboard session; not re-arming", context: "KEYBOARD_DIAG")
+            clearQuickDictation()
         }
     }
 

--- a/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
+++ b/Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift
@@ -334,9 +334,15 @@ class KeyboardViewController: UIInputViewController {
 
     private func handlePrimaryAction() {
         let buttonState = primaryButtonState
+        let startPath = KeyboardDictationHandoff.idleStartPath()
         let quickDictationReady = KeyboardDictationHandoff.isQuickDictationReady()
-        DebugLog.info("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) quickDictationReady=\(quickDictationReady)", context: "KEYBOARD_DIAG")
-        KeyboardDictationHandoff.appendDiagnostic("primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) quickDictationReady=\(quickDictationReady)")
+        DebugLog.info(
+            "primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) startPath=\(startPath.rawValue) quickDictationReady=\(quickDictationReady)",
+            context: "KEYBOARD_DIAG"
+        )
+        KeyboardDictationHandoff.appendDiagnostic(
+            "primary button pressed state=\(keyboardState) buttonState=\(buttonState.rawValue) startPath=\(startPath.rawValue) quickDictationReady=\(quickDictationReady)"
+        )
         switch buttonState {
         case .startRequiresApp:
             startRecording(openAppIfNeeded: true)
@@ -354,7 +360,12 @@ class KeyboardViewController: UIInputViewController {
     private var primaryButtonState: PrimaryButtonState {
         switch keyboardState {
         case .idle:
-            return KeyboardDictationHandoff.isQuickDictationReady() ? .startViaReadyApp : .startRequiresApp
+            switch KeyboardDictationHandoff.idleStartPath() {
+            case .startViaReadyApp:
+                return .startViaReadyApp
+            case .startRequiresApp:
+                return .startRequiresApp
+            }
         case .recording, .paused:
             return .finishRecording
         case .processing:
@@ -371,7 +382,10 @@ class KeyboardViewController: UIInputViewController {
         do {
             identity = try KeyboardDictationHandoff.beginAttempt()
         } catch {
-            showIdleError("Couldn't save this recording. Try again.")
+            presentIdleOutcome(
+                .persistenceFailed,
+                userMessage: "Couldn't save this recording. Try again."
+            )
             return
         }
         guard KeyboardDictationHandoff.publish(command: .start, identity: identity) else {
@@ -379,7 +393,10 @@ class KeyboardViewController: UIInputViewController {
                 identity: identity,
                 reason: "Recording could not start."
             )
-            showIdleError("Recording couldn't start. Try again.")
+            presentIdleOutcome(
+                .startFailed,
+                userMessage: "Recording couldn't start. Try again."
+            )
             return
         }
 
@@ -428,6 +445,18 @@ class KeyboardViewController: UIInputViewController {
                       KeyboardDictationHandoff.snapshot(for: identity)?.phase == .preparing
                 else { return }
 
+                if !KeyboardDictationHandoff.shouldOpenAppAfterQuickDictationFallback() {
+                    DebugLog.info(
+                        "Quick Dictation fallback: host still ready; waiting sessionID=\(identity.sessionID)",
+                        context: "KEYBOARD_DIAG"
+                    )
+                    KeyboardDictationHandoff.appendDiagnostic(
+                        "Quick Dictation fallback: host still ready; waiting sessionID=\(identity.sessionID)"
+                    )
+                    self.startQuickDictationFallbackTimer(identity: identity)
+                    return
+                }
+
                 DebugLog.info("Quick Dictation fallback: app did not respond; opening app sessionID=\(identity.sessionID)", context: "KEYBOARD_DIAG")
                 KeyboardDictationHandoff.appendDiagnostic("Quick Dictation fallback: app did not respond; opening app sessionID=\(identity.sessionID)")
                 self.openAppForRecording(identity: identity)
@@ -446,6 +475,7 @@ class KeyboardViewController: UIInputViewController {
             failActiveAttempt(
                 identity: identity,
                 handoffReason: "The app could not be opened.",
+                failure: .openAppFailed,
                 userMessage: "Couldn't open AI Dictation. Try again."
             )
             return
@@ -461,6 +491,7 @@ class KeyboardViewController: UIInputViewController {
                 self.failActiveAttempt(
                     identity: identity,
                     handoffReason: "The app could not be opened.",
+                    failure: .openAppFailed,
                     userMessage: "Couldn't open AI Dictation. Try again."
                 )
                 return
@@ -565,6 +596,7 @@ class KeyboardViewController: UIInputViewController {
                 failActiveAttempt(
                     identity: identity,
                     handoffReason: "The recording could not be finished.",
+                    failure: .startFailed,
                     userMessage: "Couldn't finish recording. Try again."
                 )
             }
@@ -617,11 +649,13 @@ class KeyboardViewController: UIInputViewController {
         }
     }
 
-    private func showError(_ message: String) {
+    /// Operational status only. Never red — transcription failures must not
+    /// paint a scary error on the keyboard chrome.
+    private func showOperationalStatus(_ message: String) {
         let token = UUID()
         statusMessageToken = token
         statusLabel?.text = message
-        statusLabel?.textColor = UIColor.systemRed
+        statusLabel?.textColor = UIColor.secondaryLabel
         statusLabel?.isHidden = false
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
@@ -653,7 +687,10 @@ class KeyboardViewController: UIInputViewController {
         do {
             _ = try KeyboardDictationHandoff.expireStaleAttempt()
         } catch {
-            showIdleError("Couldn't restore this recording. Open AI Dictation to recover it.")
+            presentIdleOutcome(
+                .restoreFailed,
+                userMessage: "Couldn't restore this recording. Open AI Dictation to recover it."
+            )
             return
         }
         guard activeHandoffIdentity == nil,
@@ -691,11 +728,17 @@ class KeyboardViewController: UIInputViewController {
             _ = try KeyboardDictationHandoff.expireStaleAttempt()
             snapshot = try KeyboardDictationHandoff.loadSnapshot(for: identity)
         } catch {
-            showIdleError("Couldn't update this recording. Open AI Dictation to recover it.")
+            presentIdleOutcome(
+                .persistenceFailed,
+                userMessage: "Couldn't update this recording. Open AI Dictation to recover it."
+            )
             return
         }
         guard let snapshot else {
-            showIdleError("This recording is no longer active. Try again.")
+            presentIdleOutcome(
+                .startFailed,
+                userMessage: "This recording is no longer active. Try again."
+            )
             return
         }
 
@@ -746,20 +789,32 @@ class KeyboardViewController: UIInputViewController {
                     textDocumentProxy.insertText(textForInsertion(text))
                 }
             } catch {
-                showIdleError("Couldn't insert the transcript. It is saved in AI Dictation.")
+                presentIdleOutcome(
+                    .insertFailed,
+                    userMessage: "Couldn't insert the transcript. It is saved in AI Dictation."
+                )
                 return
             }
             finishAttempt()
 
         case .failed:
             stopHandoffDeadlineTimer()
-            showIdleError(snapshot.userMessage ?? "Transcription failed. Your recording is saved in the app.")
+            presentIdleOutcome(
+                .transcriptionFailed,
+                userMessage: snapshot.userMessage ?? "Transcription failed. Your recording is saved in the app."
+            )
 
         case .cancelled:
             stopHandoffDeadlineTimer()
-            showIdleError(snapshot.userMessage ?? "Recording cancelled.")
+            presentIdleOutcome(
+                .cancelled,
+                userMessage: snapshot.userMessage ?? "Recording cancelled."
+            )
         @unknown default:
-            showIdleError("This recording couldn't continue. Try again.")
+            presentIdleOutcome(
+                .startFailed,
+                userMessage: "This recording couldn't continue. Try again."
+            )
         }
     }
 
@@ -769,27 +824,34 @@ class KeyboardViewController: UIInputViewController {
             if reconcileTerminalAttemptIfAvailable(identity: identity) {
                 return
             }
-            showIdleError("Couldn't cancel this recording. Open AI Dictation to recover it.")
+            presentIdleOutcome(
+                .persistenceFailed,
+                userMessage: "Couldn't cancel this recording. Open AI Dictation to recover it."
+            )
             return
         }
         KeyboardDictationHandoff.appendDiagnostic(
             "keyboard cancelled sessionID=\(identity.sessionID) attemptID=\(identity.attemptID)"
         )
-        showIdleError("Recording cancelled.")
+        presentIdleOutcome(.cancelled, userMessage: "Recording cancelled.")
     }
 
     private func failActiveAttempt(
         identity: KeyboardDictationHandoff.AttemptIdentity,
         handoffReason: String,
+        failure: KeyboardDictationHandoff.KeyboardChromeFailure,
         userMessage: String
     ) {
         guard activeHandoffIdentity == identity || activeHandoffIdentity == nil else { return }
         if KeyboardDictationHandoff.cancelAttempt(identity: identity, reason: handoffReason) {
-            showIdleError(userMessage)
+            presentIdleOutcome(failure, userMessage: userMessage)
         } else if reconcileTerminalAttemptIfAvailable(identity: identity) {
             return
         } else {
-            showIdleError("Couldn't update this recording. Open AI Dictation to recover it.")
+            presentIdleOutcome(
+                .persistenceFailed,
+                userMessage: "Couldn't update this recording. Open AI Dictation to recover it."
+            )
         }
     }
 
@@ -811,18 +873,22 @@ class KeyboardViewController: UIInputViewController {
 
         let handoffReason: String
         let userMessage: String
+        let failure: KeyboardDictationHandoff.KeyboardChromeFailure
         switch snapshot.phase {
         case .preparing:
             handoffReason = "Recording did not start in time."
             userMessage = "Recording didn't start. Try again."
+            failure = .startFailed
         case .finalizing:
             handoffReason = "Recording did not finish in time."
             userMessage = snapshot.recordingID == nil
                 ? "Recording didn't finish. Try again."
                 : "Recording took too long to finish. Your audio is saved in the app."
+            failure = snapshot.recordingID == nil ? .startFailed : .transcriptionTimeout
         case .processing:
             handoffReason = "Transcription did not finish in time."
             userMessage = "Transcription took too long. Your recording is saved in the app."
+            failure = .transcriptionTimeout
         case .recording, .succeeded, .failed, .cancelled:
             return
         @unknown default:
@@ -835,6 +901,7 @@ class KeyboardViewController: UIInputViewController {
         failActiveAttempt(
             identity: snapshot.identity,
             handoffReason: handoffReason,
+            failure: failure,
             userMessage: userMessage
         )
     }
@@ -889,15 +956,18 @@ class KeyboardViewController: UIInputViewController {
         setHandoffPhase(nil, animated: true)
     }
 
-    private func showIdleError(_ message: String) {
-        activeHandoffIdentity = nil
-        stopStartFallbackTimer()
-        stopRecordingMeter()
-        stopHandoffDeadlineTimer()
-        displayedAudioLevel = 0
-        displayedFrequencyBands = Array(repeating: 0.0, count: 10)
-        setHandoffPhase(nil, animated: true)
-        showError(message)
+    private func presentIdleOutcome(
+        _ failure: KeyboardDictationHandoff.KeyboardChromeFailure,
+        userMessage: String
+    ) {
+        finishAttempt()
+        switch KeyboardDictationHandoff.chromePresentation(for: failure, userMessage: userMessage) {
+        case .silentIdle:
+            DebugLog.info("keyboard chrome silent failure=\(failure.rawValue)", context: "KEYBOARD_DIAG")
+            KeyboardDictationHandoff.appendDiagnostic("keyboard chrome silent failure=\(failure.rawValue)")
+        case .operational(let message):
+            showOperationalStatus(message)
+        }
     }
 
     private func textForInsertion(_ text: String) -> String {

--- a/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
+++ b/Whishpermate/WhisperMateShared/Services/AudioRecorder.swift
@@ -132,7 +132,12 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
         /// The audio engine runs with a tap but doesn't capture to disk.
         public func startStandby() throws {
             guard !isRecording else { return }
-            guard standbyEngine?.isRunning != true else { return }
+            if standbyEngine?.isRunning == true { return }
+            // A prior recording can leave a stopped engine behind. Replace it
+            // so Quick Dictation can re-arm after the session returns to idle.
+            if standbyEngine != nil {
+                stopStandby(deactivateAudioSession: false)
+            }
 
             DebugLog.info("Starting audio standby mode", context: "AudioRecorder")
 
@@ -313,6 +318,12 @@ public final class AudioRecorder: NSObject, ObservableObject, AVAudioRecorderDel
 
     private func startRecordingOnQueue(destinationURL: URL?, attemptID: UUID?) {
         DebugLog.info("startRecording called - isRecording before: \(isRecording)", context: "AudioRecorder LOG")
+
+        #if os(iOS)
+            // Tear down standby without deactivating the session so the real
+            // recorder can take over. Availability stays published by the host.
+            stopStandby(deactivateAudioSession: false)
+        #endif
 
         // Guard against multiple recording sessions
         if audioRecorder != nil || audioEngine != nil {

--- a/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
+++ b/Whishpermate/WhisperMateShared/Services/KeyboardDictationHandoff.swift
@@ -53,6 +53,37 @@ public enum KeyboardDictationHandoff {
         case cancel
     }
 
+    /// Idle mic-button path. Cold/expired/unavailable opens the app; a live
+    /// Quick Dictation window stays inside the keyboard.
+    public enum IdleStartPath: String, Equatable, Sendable {
+        case startRequiresApp
+        case startViaReadyApp
+    }
+
+    /// Host decision after a keyboard session returns to idle.
+    public enum QuickDictationRearmDecision: Equatable, Sendable {
+        case rearm(QuickDictationAvailability)
+        case clear
+    }
+
+    /// Keyboard chrome for a finished or failed attempt. Transcription failures
+    /// must return to idle silently — never a red "couldn't transcribe" banner.
+    public enum KeyboardChromeFailure: String, Equatable, Sendable {
+        case transcriptionFailed
+        case transcriptionTimeout
+        case insertFailed
+        case cancelled
+        case openAppFailed
+        case startFailed
+        case persistenceFailed
+        case restoreFailed
+    }
+
+    public enum KeyboardChromePresentation: Equatable, Sendable {
+        case silentIdle
+        case operational(String)
+    }
+
     public struct AttemptIdentity: Codable, Hashable, Sendable {
         public let sessionID: String
         public let attemptID: String
@@ -1094,6 +1125,64 @@ public enum KeyboardDictationHandoff {
             )
         }
         return ready
+    }
+
+    /// First tap (cold) opens the app. Every later tap while Quick Dictation is
+    /// still armed stays inside the keyboard.
+    public static func idleStartPath(now: Date = Date()) -> IdleStartPath {
+        isQuickDictationReady(now: now) ? .startViaReadyApp : .startRequiresApp
+    }
+
+    /// The 10-minute window is still open, even if the heartbeat is momentarily stale
+    /// or standby was torn down for a real recording.
+    public static func hasValidQuickDictationWindow(now: Date = Date()) -> Bool {
+        guard let availability = loadQuickDictationAvailability() else { return false }
+        return availability.expiresAt > now
+    }
+
+    /// Keep host polling/heartbeat alive while a keyboard attempt is running or
+    /// the Quick Dictation window is still valid. Do not treat "no active attempt"
+    /// as permission to drop standby.
+    public static func shouldKeepHostAlive(
+        hasActiveKeyboardWork: Bool,
+        availability: QuickDictationAvailability?,
+        now: Date = Date()
+    ) -> Bool {
+        if hasActiveKeyboardWork { return true }
+        return availability.map { $0.expiresAt > now } ?? false
+    }
+
+    /// After a completed keyboard session, preserve the existing window and
+    /// refresh the heartbeat so the next mic tap is `.startViaReadyApp`.
+    public static func rearmDecisionAfterIdleSession(
+        current: QuickDictationAvailability?,
+        now: Date = Date()
+    ) -> QuickDictationRearmDecision {
+        guard let current, current.expiresAt > now else {
+            return .clear
+        }
+        return .rearm(current.refreshingHeartbeat(at: now))
+    }
+
+    /// Open-app fallback is only for a truly cold/expired/unavailable host.
+    /// A live heartbeat means the app is still listening — keep waiting.
+    public static func shouldOpenAppAfterQuickDictationFallback(now: Date = Date()) -> Bool {
+        !isQuickDictationReady(now: now)
+    }
+
+    /// Transcription / insert / cancel outcomes stay silent on keyboard chrome.
+    /// Only operational "open the app" / persistence problems may show a
+    /// non-alarming status. Callers must never paint these as red errors.
+    public static func chromePresentation(
+        for failure: KeyboardChromeFailure,
+        userMessage: String
+    ) -> KeyboardChromePresentation {
+        switch failure {
+        case .transcriptionFailed, .transcriptionTimeout, .insertFailed, .cancelled:
+            return .silentIdle
+        case .openAppFailed, .startFailed, .persistenceFailed, .restoreFailed:
+            return .operational(userMessage)
+        }
     }
 
     // MARK: - Compatibility text bridge

--- a/scripts/validate_ios_audio_processing_recovery.swift
+++ b/scripts/validate_ios_audio_processing_recovery.swift
@@ -2041,6 +2041,7 @@ private func testDirectoryCreationSucceedsWhenParentFsyncFails() async throws {
     )
 }
 
+@MainActor
 private func testLaunchRecoveryForceResetsQuarantineAndKeepsHistory() async throws {
     let workspace = try makeRoot("quarantine-launch-reset")
     let historyRoot = workspace.appendingPathComponent("WhisperMate", isDirectory: true)

--- a/scripts/validate_keyboard_audio_recovery.swift
+++ b/scripts/validate_keyboard_audio_recovery.swift
@@ -871,6 +871,9 @@ private func run() throws {
     resetStore(generationSuite)
     setenv("AIDICTATION_KEYBOARD_HANDOFF_TEST_SUITE", suite, 1)
 
+    try validateQuickDictationSecondTapRearm(now: base)
+    try validateKeyboardChromePresentation()
+
     let contentURL = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
@@ -883,8 +886,186 @@ private func run() throws {
         failClosedCallCount >= 4,
         "host journal load/consume failures do not retire active native work"
     )
+    try expect(
+        contentSource.contains("rearmQuickDictationAfterKeyboardSession()"),
+        "host must re-arm Quick Dictation after a completed keyboard session"
+    )
+    try expect(
+        !contentSource.contains("stopping command polling (background, no standby)"),
+        "host must not drop Quick Dictation just because standby was torn down for recording"
+    )
+
+    let keyboardURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Whishpermate/WhisperMateKeyboard/KeyboardViewController.swift")
+    let keyboardSource = try String(contentsOf: keyboardURL, encoding: .utf8)
+    try expect(
+        !keyboardSource.contains("systemRed"),
+        "keyboard chrome must not paint transcription or idle errors in red"
+    )
+    try expect(
+        keyboardSource.contains("chromePresentation"),
+        "keyboard must classify idle outcomes through chromePresentation"
+    )
+    try expect(
+        keyboardSource.contains("idleStartPath()"),
+        "keyboard idle mic path must use the shared Quick Dictation start-path policy"
+    )
 
     print("Keyboard audio recovery validation passed")
+}
+
+/// After one completed keyboard session, availability stays armed (or is
+/// immediately re-armed) so the next idle mic tap is `.startViaReadyApp`.
+private func validateQuickDictationSecondTapRearm(now: Date) throws {
+    KeyboardDictationHandoff.clearQuickDictationAvailability()
+    try expectEqual(
+        KeyboardDictationHandoff.idleStartPath(now: now),
+        .startRequiresApp,
+        "cold start must open the containing app"
+    )
+    try expect(
+        !KeyboardDictationHandoff.isQuickDictationReady(now: now),
+        "cold start must not report Quick Dictation ready"
+    )
+
+    let firstArm = KeyboardDictationHandoff.QuickDictationAvailability(activatedAt: now)
+    KeyboardDictationHandoff.saveQuickDictationAvailability(firstArm)
+    try expect(
+        KeyboardDictationHandoff.isQuickDictationReady(now: now),
+        "first host arm must make Quick Dictation ready"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.idleStartPath(now: now),
+        .startViaReadyApp,
+        "armed Quick Dictation must stay in-keyboard"
+    )
+
+    // The bug: host cleared availability after the first session finished, so
+    // the second tap looked cold and opened the app again.
+    KeyboardDictationHandoff.clearQuickDictationAvailability()
+    try expectEqual(
+        KeyboardDictationHandoff.idleStartPath(now: now.addingTimeInterval(1)),
+        .startRequiresApp,
+        "clearing availability after a session forces another open-app dance"
+    )
+
+    KeyboardDictationHandoff.saveQuickDictationAvailability(firstArm)
+    let afterSession = now.addingTimeInterval(30)
+    switch KeyboardDictationHandoff.rearmDecisionAfterIdleSession(
+        current: KeyboardDictationHandoff.loadQuickDictationAvailability(),
+        now: afterSession
+    ) {
+    case .rearm(let refreshed):
+        try expectEqual(
+            refreshed.expiresAt,
+            firstArm.expiresAt,
+            "re-arm must preserve the original Quick Dictation window"
+        )
+        KeyboardDictationHandoff.saveQuickDictationAvailability(refreshed)
+    case .clear:
+        throw ValidationFailure.assertion("in-window session must re-arm, not clear")
+    }
+
+    try expect(
+        KeyboardDictationHandoff.isQuickDictationReady(now: afterSession),
+        "after one completed keyboard session, isQuickDictationReady must remain true"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.idleStartPath(now: afterSession),
+        .startViaReadyApp,
+        "second tap must use the in-keyboard start path"
+    )
+    try expect(
+        KeyboardDictationHandoff.shouldKeepHostAlive(
+            hasActiveKeyboardWork: false,
+            availability: KeyboardDictationHandoff.loadQuickDictationAvailability(),
+            now: afterSession
+        ),
+        "host must keep polling/heartbeat after the keyboard session returns to idle"
+    )
+    try expect(
+        !KeyboardDictationHandoff.shouldOpenAppAfterQuickDictationFallback(now: afterSession),
+        "fallback must not open the app while Quick Dictation is still ready"
+    )
+
+    let expiredAt = firstArm.expiresAt.addingTimeInterval(1)
+    try expectEqual(
+        KeyboardDictationHandoff.rearmDecisionAfterIdleSession(
+            current: KeyboardDictationHandoff.loadQuickDictationAvailability(),
+            now: expiredAt
+        ),
+        .clear,
+        "expired Quick Dictation window must not re-arm"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.idleStartPath(now: expiredAt),
+        .startRequiresApp,
+        "expired window is a cold start"
+    )
+
+    KeyboardDictationHandoff.saveQuickDictationAvailability(firstArm)
+    let staleHeartbeat = now.addingTimeInterval(
+        KeyboardDictationHandoff.QuickDictationAvailability.heartbeatMaximumAge + 1
+    )
+    try expect(
+        !KeyboardDictationHandoff.isQuickDictationReady(now: staleHeartbeat),
+        "stale heartbeat without re-arm is not ready"
+    )
+    try expect(
+        KeyboardDictationHandoff.shouldOpenAppAfterQuickDictationFallback(now: staleHeartbeat),
+        "stale heartbeat may open the app"
+    )
+    try expect(
+        KeyboardDictationHandoff.hasValidQuickDictationWindow(now: staleHeartbeat),
+        "stale heartbeat still has a valid window until expiry"
+    )
+
+    KeyboardDictationHandoff.clearQuickDictationAvailability()
+}
+
+private func validateKeyboardChromePresentation() throws {
+    try expectEqual(
+        KeyboardDictationHandoff.chromePresentation(
+            for: .transcriptionFailed,
+            userMessage: "Transcription failed. Your recording is saved in the app."
+        ),
+        .silentIdle,
+        "transcription failure must not show keyboard error chrome"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.chromePresentation(
+            for: .transcriptionTimeout,
+            userMessage: "Transcription took too long. Your recording is saved in the app."
+        ),
+        .silentIdle,
+        "transcription timeout must not show keyboard error chrome"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.chromePresentation(
+            for: .insertFailed,
+            userMessage: "Couldn't insert the transcript. It is saved in AI Dictation."
+        ),
+        .silentIdle,
+        "insert failure must not show a red couldn't-transcribe banner"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.chromePresentation(
+            for: .cancelled,
+            userMessage: "Recording cancelled."
+        ),
+        .silentIdle,
+        "cancel returns to idle without an error banner"
+    )
+    try expectEqual(
+        KeyboardDictationHandoff.chromePresentation(
+            for: .openAppFailed,
+            userMessage: "Couldn't open AI Dictation. Try again."
+        ),
+        .operational("Couldn't open AI Dictation. Try again."),
+        "deep-link failure may show a minimal operational status"
+    )
 }
 
 @main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes two iOS keyboard bugs Artem confirmed: the second mic tap was opening the containing app again, and transcription failures painted a red error on the keyboard chrome.

## Bug 1 — Second tap must stay in the keyboard

**Expected (Artem):**
- First tap (cold): OK to open the app once, swipe back, recording starts.
- Second tap and every later tap while the Quick Dictation window is alive: stay inside the keyboard. No open-app → swipe-back dance.

**What was broken:** after the first keyboard session finished, the host cleared standby (`clearQuickDictation` / `stopKeyboardCommandPolling`) and did not re-arm. The next tap saw `isQuickDictationReady() == false` and used `.startRequiresApp`. Scene-phase / “no standby” teardown made this worse after real recording tore down the standby engine.

**Fix:**
- After a completed or cancelled keyboard session, immediately re-arm Quick Dictation (same 10-minute window + heartbeat + audio standby) so the next idle path is `.startViaReadyApp`.
- Keep host polling/heartbeat alive for the rest of that window even when the user is back in the keyboard (app in background). Do not drop availability just because standby was torn down for a real recording.
- Preserve the original expiry on re-arm so the window cannot extend forever.
- Cold start is unchanged: no availability → open the app.
- The 8s in-keyboard fallback only opens the app if Quick Dictation is no longer ready (expired / stale heartbeat). A live heartbeat keeps waiting.
- Mac record path is untouched (iOS-only standby teardown; no wait-on-record delays).

## Bug 2 — No red “couldn’t transcribe” on the keyboard

Transcription / insert / cancel outcomes return to idle silently. Recordings are still saved in the host app.

Operational “couldn’t open the app” / persistence messages can still appear as brief secondary (non-red) status. `systemRed` is gone from keyboard chrome.

## Repro / test notes

1. Cold start: tap mic on the keyboard → app may open → swipe back → record.
2. Immediately tap mic again (and repeatedly within ~10 minutes): recording must start **in the keyboard** without opening the app UI.
3. Force a transcription failure: keyboard must return to idle with **no red error text**. Recording remains recoverable in the app.
4. After ~10 minutes or a force-quit: next tap is a cold start again.

**Validator:** `scripts/validate_keyboard_audio_recovery.swift` now covers:
- After one completed session, `isQuickDictationReady()` stays true (or is re-armed) and `idleStartPath` is `.startViaReadyApp`.
- Clearing availability after a session (the old bug) forces `.startRequiresApp`.
- Expired window does not re-arm.
- Transcription / timeout / insert chrome is `.silentIdle`; open-app failure may stay operational.
- Source checks that the host calls `rearmQuickDictationAfterKeyboardSession()` and the keyboard never uses `systemRed`.

Also marks the #116 quarantine-history validator `@MainActor` so Recovery contracts can compile (`HistoryManager` is MainActor-isolated). Store-init / quarantine behavior from #115/#116 is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f71b7ea8-d103-42ee-b97b-d7a9abc2d685?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f71b7ea8-d103-42ee-b97b-d7a9abc2d685&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791090598&installation_model_id=432087&pr_number=118&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F118&signature=75f7e4f5fc8a2ae74d50b2a57fc35ed54bdf4c0097a73c754aeba638f893d934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->