### PR TITLE
Realtime client_secrets derivation requires an absolute http(s) endpoint

### DIFF
--- a/Whishpermate/WhisperMateShared/Services/OpenAIRealtimeTranscriptionClient.swift
+++ b/Whishpermate/WhisperMateShared/Services/OpenAIRealtimeTranscriptionClient.swift
@@ -34,6 +34,11 @@ public struct WritingmateRealtimeClientSecretProvider {
         if scheme == "ws" || scheme == "wss" {
             return nil
         }
+        // Newer Foundation parses almost any string as a relative URL; only a
+        // real absolute http(s) endpoint can derive a client_secrets URL.
+        guard scheme == "http" || scheme == "https",
+              let host = components.host, !host.isEmpty
+        else { return nil }
 
         let path = components.path
 

--- a/scripts/validate_ios_realtime_transcription.swift
+++ b/scripts/validate_ios_realtime_transcription.swift
@@ -167,6 +167,11 @@ struct ValidateIOSRealtimeTranscription {
         if scheme == "ws" || scheme == "wss" {
             return nil
         }
+        // Newer Foundation parses almost any string as a relative URL; only a
+        // real absolute http(s) endpoint can derive a client_secrets URL.
+        guard scheme == "http" || scheme == "https",
+              let host = components.host, !host.isEmpty
+        else { return nil }
         let path = components.path
         if path.hasSuffix("/audio/transcriptions") {
             components.path = String(path.dropLast("/audio/transcriptions".count)) + "/realtime/client_secrets"


### PR DESCRIPTION
Foundation on macOS 26 parses "not a url" as a relative URL, so the
iOS realtime validator tripped on CI and blocked the ios-v0.0.106
upload. Require an http(s) scheme and host in both the client and the
validator's mirror.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092937&installation_model_id=432087&pr_number=120&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F120&signature=0771954ec665aa25ba19d5db63d8c95e40f6872f83db61f6f1637f721b3a8407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->