### PR TITLE
iOS: stream live realtime partials while recording

### DIFF
--- a/Whishpermate/WhisperMateIOS/ContentView.swift
+++ b/Whishpermate/WhisperMateIOS/ContentView.swift
@@ -2478,11 +2478,13 @@ private final class InlineRecordingCoordinator: ObservableObject {
     @Published var frequencyBands: [Float] = Array(repeating: 0.0, count: 10)
     @Published var errorMessage: String?
     @Published var completionText: String?
+    @Published var liveTranscript: String = ""
 
     private let audioRecorderSlot = IOSRetirableResourceSlot(factory: AudioRecorder.init)
     /// Public accessor for the audio recorder, needed for Quick Dictation standby mode.
     var audioRecorder: AudioRecorder { audioRecorderSlot.current }
     private let realtimeTranscription = IOSRealtimeTranscriptionCoordinator()
+    private var realtimeCancellables = Set<AnyCancellable>()
     private let processingStore = MobileAudioProcessingStore.shared
     private let recordingStatus = RecordingNowPlayingStatus()
     private let subscriptionManager = SubscriptionManager.shared
@@ -2533,6 +2535,12 @@ private final class InlineRecordingCoordinator: ObservableObject {
 
     init() {
         bindAudioRecorder(audioRecorder)
+        realtimeTranscription.$partialTranscript
+            .sink { [weak self] text in
+                guard let self, self.liveTranscript != text else { return }
+                self.liveTranscript = text
+            }
+            .store(in: &realtimeCancellables)
     }
 
     private func bindAudioRecorder(_ recorder: AudioRecorder) {
@@ -2746,6 +2754,7 @@ private final class InlineRecordingCoordinator: ObservableObject {
             audioLevel = 0
             frequencyBands = Array(repeating: 0.0, count: 10)
             completionText = nil
+            liveTranscript = ""
             errorMessage = nil
             return
         }
@@ -3822,6 +3831,7 @@ private final class InlineRecordingCoordinator: ObservableObject {
         audioLevel = 0
         frequencyBands = Array(repeating: 0.0, count: 10)
         completionText = nil
+        liveTranscript = ""
     }
 
     private func showError(_ message: String) {
@@ -3833,6 +3843,7 @@ private final class InlineRecordingCoordinator: ObservableObject {
             state = .idle
             errorMessage = message
             completionText = nil
+            liveTranscript = ""
             stopRequestedWhilePreparing = false
             recordingStartTime = nil
             activeTranscriptionRequest = nil
@@ -3913,6 +3924,17 @@ private struct InlineRecordingPanel: View {
     private var activeContent: some View {
         GeometryReader { proxy in
             ZStack {
+                if !recorder.liveTranscript.isEmpty {
+                    AIDictationLiveTranscriptCaption(
+                        text: recorder.liveTranscript
+                    )
+                    .padding(.horizontal, 28)
+                    .position(
+                        x: proxy.size.width / 2,
+                        y: max(86, proxy.size.height * 0.28)
+                    )
+                }
+
                 AIDictationActiveRecordingVisual(
                     state: recorder.visualState,
                     audioLevel: recorder.audioLevel,

--- a/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
+++ b/Whishpermate/WhisperMateIOS/RecordingSheetView.swift
@@ -38,7 +38,7 @@ struct RecordingSheetView: View {
     @State private var cancelledPendingAttemptID: UUID?
 
     private let processingStore = MobileAudioProcessingStore.shared
-    @State private var realtimeTranscription = IOSRealtimeTranscriptionCoordinator()
+    @StateObject private var realtimeTranscription = IOSRealtimeTranscriptionCoordinator()
     private var audioRecorder: AudioRecorder { audioRecorderSlot.current }
 
     private var selectedPreset: ContextRule? {
@@ -199,6 +199,20 @@ struct RecordingSheetView: View {
                 .padding(.top, 18)
                 .padding(.horizontal, 56)
                 .zIndex(3)
+            }
+
+            if shouldShowLiveTranscript {
+                VStack {
+                    Spacer()
+                        .frame(height: 118)
+                    AIDictationLiveTranscriptCaption(
+                        text: realtimeTranscription.partialTranscript
+                    )
+                    .padding(.horizontal, 28)
+                    Spacer()
+                }
+                .allowsHitTesting(false)
+                .zIndex(2)
             }
 
             Button(action: handleCancel) {
@@ -577,6 +591,15 @@ struct RecordingSheetView: View {
             return selectedOutputMode == .meetings ? "Speaker detection ready" : "Offline mode ready"
         case .downloading, .initializing, .error, .transcribing:
             return nil
+        }
+    }
+
+    private var shouldShowLiveTranscript: Bool {
+        switch sheetState {
+        case .recording, .paused, .processing:
+            return !realtimeTranscription.partialTranscript.isEmpty
+        case .idle, .viewing:
+            return false
         }
     }
 

--- a/Whishpermate/WhisperMateShared/AIDictationRecordingSurface.swift
+++ b/Whishpermate/WhisperMateShared/AIDictationRecordingSurface.swift
@@ -187,3 +187,37 @@ public struct AIDictationRecordingSurface: View {
         .accessibilityLabel(state == .paused ? "Resume recording" : "Pause recording")
     }
 }
+
+/// Live cloud-dictation caption that grows as partial transcripts arrive.
+public struct AIDictationLiveTranscriptCaption: View {
+    public let text: String
+    public let color: Color
+
+    public init(text: String, color: Color = .white) {
+        self.text = text
+        self.color = color
+    }
+
+    public var body: some View {
+        Group {
+            if !text.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView(showsIndicators: false) {
+                        Text(text)
+                            .font(.system(size: 17, weight: .regular))
+                            .foregroundStyle(color)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: .infinity)
+                            .id("liveTranscriptTail")
+                    }
+                    .frame(maxHeight: 96)
+                    .onChange(of: text) { _ in
+                        proxy.scrollTo("liveTranscriptTail", anchor: .bottom)
+                    }
+                }
+                .accessibilityLabel(text)
+                .accessibilityAddTraits(.updatesFrequently)
+            }
+        }
+    }
+}

--- a/Whishpermate/WhisperMateShared/Services/IOSRealtimeTranscriptionCoordinator.swift
+++ b/Whishpermate/WhisperMateShared/Services/IOSRealtimeTranscriptionCoordinator.swift
@@ -1,14 +1,26 @@
 import Foundation
+public import Combine
 
 /// Owns one iOS cloud-mode realtime stream: client_secrets, WebSocket, and
 /// PCM delivery into the shared recorder. Batch upload remains the fallback
 /// when this session is missing or returns an empty transcript.
 @MainActor
-public final class IOSRealtimeTranscriptionCoordinator {
+public final class IOSRealtimeTranscriptionCoordinator: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published public private(set) var partialTranscript: String = ""
+
+    // MARK: - Private Properties
+
     private var client: (any RealtimeTranscriptionStreaming)?
     private var finishRequest: RealtimeTranscriptionFinishRequest?
+    private var streamSessionID = UUID()
+
+    // MARK: - Initialization
 
     public init() {}
+
+    // MARK: - Public API
 
     public var isActive: Bool {
         client != nil || finishRequest != nil
@@ -36,6 +48,9 @@ public final class IOSRealtimeTranscriptionCoordinator {
             overrideModel: context.customRealtimeModel
         )
         let overrideEndpoint = context.customRealtimeEndpoint
+        let sessionID = UUID()
+        streamSessionID = sessionID
+        let onPartialTranscript = makePartialTranscriptHandler(sessionID: sessionID)
         let client: OpenAIRealtimeTranscriptionClient
 
         if let webSocketURL = WritingmateRealtimeSessionSupport.webSocketURL(
@@ -51,7 +66,7 @@ public final class IOSRealtimeTranscriptionCoordinator {
                 keywords: context.keywords,
                 languages: context.languages,
                 prompt: context.prompt,
-                onPartialTranscript: { _ in },
+                onPartialTranscript: onPartialTranscript,
                 onError: { message in
                     DebugLog.warning(message, context: "IOSRealtime")
                 }
@@ -106,7 +121,7 @@ public final class IOSRealtimeTranscriptionCoordinator {
                 language: language,
                 keywords: keywords,
                 languages: languages,
-                onPartialTranscript: { _ in },
+                onPartialTranscript: onPartialTranscript,
                 onError: { message in
                     DebugLog.warning(message, context: "IOSRealtime")
                 }
@@ -142,6 +157,7 @@ public final class IOSRealtimeTranscriptionCoordinator {
     }
 
     public func cancel(recorder: AudioRecorder?) {
+        invalidateStreamSession()
         recorder?.realtimeAudioChunkHandler = nil
         recorder?.detachRealtimeAudioChunkHandlerAndDrain { _ in }
         finishRequest?.close()
@@ -168,6 +184,31 @@ public final class IOSRealtimeTranscriptionCoordinator {
         finishRequest?.close()
         finishRequest = nil
         client = nil
+    }
+
+    // MARK: - Private Methods
+
+    private func makePartialTranscriptHandler(
+        sessionID: UUID
+    ) -> @MainActor (String) -> Void {
+        { [weak self] partial in
+            self?.handlePartialTranscript(partial, sessionID: sessionID)
+        }
+    }
+
+    private func handlePartialTranscript(_ partial: String, sessionID: UUID) {
+        guard streamSessionID == sessionID, isActive else { return }
+        let text = partial.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        partialTranscript = text
+        DebugLog.info("Realtime transcription partial length=\(text.count)", context: "IOSRealtime")
+    }
+
+    private func invalidateStreamSession() {
+        streamSessionID = UUID()
+        if !partialTranscript.isEmpty {
+            partialTranscript = ""
+        }
     }
 
     private func takeFinishRequest(

--- a/Whishpermate/Whispermate/Services/MacAudioProcessingStore.swift
+++ b/Whishpermate/Whispermate/Services/MacAudioProcessingStore.swift
@@ -2339,7 +2339,11 @@ actor MacAudioProcessingStore {
         operation: @escaping @Sendable () throws -> Void
     ) async throws {
         let gate = MacAudioDeadlineGate<Void>()
-        let timeout = max(0, deadline.timeIntervalSinceNow + 0.05)
+        // Keep the watchdog behind the lock-wait deadline. A loaded worker
+        // queue can miss a 50ms slack and report persistenceTimedOut for a
+        // held flock, which poisons a healthy store. persistenceBusy is the
+        // correct lock-wait outcome.
+        let timeout = max(0.2, deadline.timeIntervalSinceNow + 0.2)
         let maximumSeconds = Double(UInt64.max) / 1_000_000_000
         let timeoutNanoseconds = UInt64(min(timeout, maximumSeconds) * 1_000_000_000)
 

--- a/scripts/validate_ios_realtime_transcription.swift
+++ b/scripts/validate_ios_realtime_transcription.swift
@@ -33,11 +33,21 @@ struct ValidateIOSRealtimeTranscription {
                 "Derived \(derived ?? "nil") from \(input), expected \(expected)"
             )
         }
-        precondition(endpoint(from: "not a url") == nil)
+        // Darwin URLComponents accepts many non-URLs, including "not a url".
+        // Reject websocket schemes here and source-check the parse-failure path.
+        precondition(
+            endpoint(from: "wss://example.com/v1/audio/transcriptions") == nil,
+            "WebSocket transcription endpoints must not mint a client_secrets URL"
+        )
+        precondition(
+            endpoint(from: "ws://example.com/v1/audio/transcriptions") == nil,
+            "WebSocket transcription endpoints must not mint a client_secrets URL"
+        )
 
         let provider = try contents(
             "Whishpermate/WhisperMateShared/Services/OpenAIRealtimeTranscriptionClient.swift"
         )
+        precondition(provider.contains("guard var components = URLComponents(string: transcriptionEndpoint) else { return nil }"))
         precondition(provider.contains("if scheme == \"ws\" || scheme == \"wss\""))
         precondition(provider.contains("return nil"))
     }
@@ -90,6 +100,13 @@ struct ValidateIOSRealtimeTranscription {
         precondition(coordinator.contains("request?.requestFinish"))
         precondition(coordinator.contains("request?.close()"))
         precondition(coordinator.contains("armDrainDeadline"))
+        precondition(
+            !coordinator.contains("onPartialTranscript: { _ in }"),
+            "iOS must not discard realtime partial transcripts"
+        )
+        precondition(coordinator.contains("handlePartialTranscript("))
+        precondition(coordinator.contains("@Published public private(set) var partialTranscript"))
+        precondition(coordinator.contains("onPartialTranscript: onPartialTranscript"))
     }
 
     private static func validateIOSRecorderStreaming() throws {
@@ -159,6 +176,12 @@ struct ValidateIOSRealtimeTranscription {
         precondition(sheet.contains("shouldUseOnDeviceTranscription"))
         precondition(content.contains("SharedParakeetTranscriptionService"))
         precondition(sheet.contains("SharedParakeetTranscriptionService"))
+        precondition(sheet.contains("realtimeTranscription.partialTranscript"))
+        precondition(sheet.contains("AIDictationLiveTranscriptCaption"))
+        precondition(content.contains("@Published var liveTranscript"))
+        precondition(content.contains("realtimeTranscription.$partialTranscript"))
+        precondition(content.contains("AIDictationLiveTranscriptCaption"))
+        precondition(content.contains("text: recorder.liveTranscript"))
     }
 
     private static func endpoint(from transcriptionEndpoint: String) -> String? {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#119 shipped iOS cloud realtime on the shared `OpenAIRealtimeTranscriptionClient`, but `IOSRealtimeTranscriptionCoordinator` still discarded every partial (`onPartialTranscript: { _ in }`). That is the gap Artem called out: iOS only showed a final result after stop.

This wires the same client’s partials into the iOS recording UI.

## What changed

- The coordinator publishes `partialTranscript` as deltas arrive (trim, ignore empty, ignore stale sessions)
- Recording sheet and inline recording panel show that growing text while recording / paused / finishing
- Same shared OpenAI realtime client — no second protocol
- Writingmate signed-in skip and batch fallback from 0.0.106 are unchanged

## Tests

`scripts/validate_ios_realtime_transcription.swift` now fails if partials are discarded again, and checks sheet + inline UI wiring. The Darwin `URLComponents("not a url")` runtime assertion is replaced with `ws`/`wss` rejection.

CI: macOS journal persistence keeps the lock-wait `persistenceBusy` path ahead of the `persistenceTimedOut` watchdog, so a held flock on a loaded runner does not poison a healthy store.

## Out of scope

- Offline / Parakeet
- Meetings / diarization (still batch)
- Keyboard-extension caption (no handoff field for live text; host inline panel shows it)

Replaces the live-partials work that was still sitting on closed #117 after #119 shipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-272bebea-7d82-47a9-876d-50b4539f37b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-272bebea-7d82-47a9-876d-50b4539f37b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791093029&installation_model_id=432087&pr_number=121&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F121&signature=0de325e67c6f6ae53f0e685efde2b0d85732fefdac307b41192f6d179a089b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->