### PR TITLE
Mint Soniox client_secrets with the app API key when the user is logged out

### DIFF
--- a/Whishpermate/WhisperMateShared/Services/IOSRealtimeTranscriptionCoordinator.swift
+++ b/Whishpermate/WhisperMateShared/Services/IOSRealtimeTranscriptionCoordinator.swift
@@ -65,15 +65,9 @@ public final class IOSRealtimeTranscriptionCoordinator {
                 return
             }
 
-            // Writingmate realtime needs a signed-in first-party session. Without
-            // one the token fetch always fails; skip the doomed stream and let
-            // batch upload (free local quota) carry the recording.
-            if WritingmateRealtimeSessionSupport.isWritingmateSessionEndpoint(endpoint),
-               !AuthManager.shared.isAuthenticated {
-                DebugLog.info("Skipping realtime start: not signed in; using batch upload", context: "IOSRealtime")
-                return
-            }
-
+            // Writingmate realtime mints a client_secret with the signed-in
+            // user token when available, otherwise the bundled app API key
+            // already used for unsigned cloud transcription.
             let prompt = context.prompt
             let language = context.language
             let keywords = context.keywords
@@ -83,12 +77,14 @@ public final class IOSRealtimeTranscriptionCoordinator {
                 authorizationProvider: {
                     let token: String
                     if WritingmateRealtimeSessionSupport.isWritingmateSessionEndpoint(endpoint) {
-                        token = try await AuthManager.shared.accessToken()
-                    } else if !apiKey.isEmpty {
-                        token = apiKey
+                        token = try await WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey(
+                            fallbackAPIKey: apiKey
+                        )
+                    } else if let fallback = WritingmateRealtimeSessionSupport.usableClientSecretAPIKey(apiKey) {
+                        token = fallback
                     } else {
                         throw OpenAIRealtimeTranscriptionClientError.clientSecretRequestFailed(
-                            "Cloud transcription credentials are unavailable"
+                            WritingmateRealtimeSessionSupport.missingClientSecretCredentialsMessage
                         )
                     }
                     return try await WritingmateRealtimeClientSecretProvider.fetchAuthorization(

--- a/Whishpermate/WhisperMateShared/Services/WritingmateRealtimeSessionSupport.swift
+++ b/Whishpermate/WhisperMateShared/Services/WritingmateRealtimeSessionSupport.swift
@@ -79,4 +79,63 @@ public enum WritingmateRealtimeSessionSupport {
         }
         return model
     }
+
+    /// Bearer token for minting a Writingmate realtime `client_secret`.
+    /// Prefers a signed-in user access token; otherwise uses the bundled app
+    /// API key already used for unsigned cloud transcription.
+    public static func resolveClientSecretAPIKey(
+        fallbackAPIKey: String? = nil
+    ) async throws -> String {
+        if let userToken = await userAccessTokenIfAvailable() {
+            return userToken
+        }
+
+        if let fallback = usableClientSecretAPIKey(fallbackAPIKey) {
+            return fallback
+        }
+
+        if let keychainKey = usableClientSecretAPIKey(
+            KeychainHelper.get(key: TranscriptionProvider.custom.apiKeyName)
+        ) {
+            return keychainKey
+        }
+
+        if let bundledKey = usableClientSecretAPIKey(
+            SecretsLoader.transcriptionKey(for: .custom)
+        ) {
+            return bundledKey
+        }
+
+        throw OpenAIRealtimeTranscriptionClientError.clientSecretRequestFailed(
+            Self.missingClientSecretCredentialsMessage
+        )
+    }
+
+    public static let missingClientSecretCredentialsMessage =
+        "Cloud transcription credentials are unavailable"
+
+    public static func usableClientSecretAPIKey(_ key: String?) -> String? {
+        guard let key else { return nil }
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "not-needed" else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func userAccessTokenIfAvailable() async -> String? {
+        guard AuthManager.shared.isAuthenticated else {
+            return nil
+        }
+        do {
+            let token = try await AuthManager.shared.accessToken()
+            return usableClientSecretAPIKey(token)
+        } catch {
+            DebugLog.warning(
+                "User access token unavailable for realtime mint; using app key if configured",
+                context: "WritingmateRealtime"
+            )
+            return nil
+        }
+    }
 }

--- a/Whishpermate/Whispermate/Services/AppState.swift
+++ b/Whishpermate/Whispermate/Services/AppState.swift
@@ -2661,10 +2661,12 @@ class AppState: ObservableObject {
             }
             client = SonioxRealtimeTranscriptionClient(
                 authorizationProvider: {
-                    let accessToken = try await AuthManager.shared.accessToken()
+                    let apiKey = try await WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey(
+                        fallbackAPIKey: snapshot.transcriptionAPIKey
+                    )
                     return try await WritingmateRealtimeClientSecretProvider.fetchAuthorization(
                         endpoint: endpoint,
-                        apiKey: accessToken,
+                        apiKey: apiKey,
                         model: SonioxRealtimeProtocol.model,
                         prompt: realtimePrompt,
                         language: languageCode,
@@ -2731,12 +2733,16 @@ class AppState: ObservableObject {
                     authorizationProvider: {
                         let token: String
                         if Self.isWritingmateRealtimeSessionEndpoint(endpoint) {
-                            token = try await AuthManager.shared.accessToken()
-                        } else if let apiKey = snapshot.transcriptionAPIKey, !apiKey.isEmpty {
+                            token = try await WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey(
+                                fallbackAPIKey: snapshot.transcriptionAPIKey
+                            )
+                        } else if let apiKey = WritingmateRealtimeSessionSupport.usableClientSecretAPIKey(
+                            snapshot.transcriptionAPIKey
+                        ) {
                             token = apiKey
                         } else {
                             throw OpenAIRealtimeTranscriptionClientError.clientSecretRequestFailed(
-                                "Cloud transcription credentials are unavailable"
+                                WritingmateRealtimeSessionSupport.missingClientSecretCredentialsMessage
                             )
                         }
                         return try await WritingmateRealtimeClientSecretProvider.fetchAuthorization(

--- a/Whishpermate/Whispermate/Services/SonioxRealtimeTranscriptionClient.swift
+++ b/Whishpermate/Whispermate/Services/SonioxRealtimeTranscriptionClient.swift
@@ -64,8 +64,9 @@ nonisolated final class SonioxRealtimeTranscriptionClient: @unchecked Sendable, 
                 } catch is CancellationError {
                     return
                 } catch {
+                    let message = self.authorizationFailureMessage(for: error)
                     self.queue.async { [weak self] in
-                        self?.failOnQueue("Fast streaming could not start.")
+                        self?.failOnQueue(message)
                     }
                 }
             }
@@ -258,6 +259,16 @@ nonisolated final class SonioxRealtimeTranscriptionClient: @unchecked Sendable, 
         } catch {
             failOnQueue("Fast streaming could not read the transcript.")
         }
+    }
+
+    private func authorizationFailureMessage(for error: Error) -> String {
+        if let realtimeError = error as? OpenAIRealtimeTranscriptionClientError,
+           case .clientSecretRequestFailed(let detail) = realtimeError,
+           !detail.isEmpty
+        {
+            return detail
+        }
+        return "Fast streaming could not start."
     }
 
     private func failOnQueue(_ message: String) {

--- a/scripts/validate_ios_realtime_transcription.swift
+++ b/scripts/validate_ios_realtime_transcription.swift
@@ -8,6 +8,7 @@ struct ValidateIOSRealtimeTranscription {
         try validateSharedClientContract()
         try validateIOSRecorderStreaming()
         try validateIOSCloudFlowWiring()
+        try validateClientSecretAPIKeyFallback()
         print("iOS realtime transcription uses Writingmate client_secrets/WebSocket with batch fallback")
     }
 
@@ -74,13 +75,22 @@ struct ValidateIOSRealtimeTranscription {
         )
         precondition(support.contains("isWritingmateSessionEndpoint"))
         precondition(support.contains("/api/openai/v1/realtime/client_secrets"))
-        precondition(support.contains("AuthManager") == false)
+        precondition(support.contains("resolveClientSecretAPIKey"))
+        precondition(support.contains("usableClientSecretAPIKey"))
+        precondition(support.contains("AuthManager.shared.isAuthenticated"))
+        precondition(support.contains("AuthManager.shared.accessToken()"))
+        precondition(support.contains("SecretsLoader.transcriptionKey(for: .custom)"))
+        precondition(support.contains("missingClientSecretCredentialsMessage"))
+        precondition(support.contains("Cloud transcription credentials are unavailable"))
 
         let coordinator = try contents(
             "Whishpermate/WhisperMateShared/Services/IOSRealtimeTranscriptionCoordinator.swift"
         )
         precondition(coordinator.contains("WritingmateRealtimeClientSecretProvider.fetchAuthorization"))
-        precondition(coordinator.contains("AuthManager.shared.accessToken()"))
+        precondition(coordinator.contains("WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey"))
+        precondition(coordinator.contains("fallbackAPIKey: apiKey"))
+        precondition(!coordinator.contains("AuthManager.shared.accessToken()"))
+        precondition(!coordinator.contains("Skipping realtime start: not signed in"))
         precondition(coordinator.contains("OpenAIRealtimeTranscriptionClient"))
         precondition(coordinator.contains("prefersRealtimeRecognition"))
         precondition(coordinator.contains("CloudTranscriptionConsent.isGranted"))
@@ -159,6 +169,44 @@ struct ValidateIOSRealtimeTranscription {
         precondition(sheet.contains("shouldUseOnDeviceTranscription"))
         precondition(content.contains("SharedParakeetTranscriptionService"))
         precondition(sheet.contains("SharedParakeetTranscriptionService"))
+    }
+
+    private static func validateClientSecretAPIKeyFallback() throws {
+        precondition(usableClientSecretAPIKey("wm-app-key") == "wm-app-key")
+        precondition(usableClientSecretAPIKey("  wm-app-key  ") == "wm-app-key")
+        precondition(usableClientSecretAPIKey(nil) == nil)
+        precondition(usableClientSecretAPIKey("") == nil)
+        precondition(usableClientSecretAPIKey("   ") == nil)
+        precondition(usableClientSecretAPIKey("not-needed") == nil)
+
+        let appState = try contents("Whishpermate/Whispermate/Services/AppState.swift")
+        guard let sonioxStart = appState.range(of: "case .soniox:"),
+              let aidictationStart = appState.range(
+                of: "case .aidictation:",
+                range: sonioxStart.upperBound..<appState.endIndex
+              )
+        else {
+            throw ValidationFailure.failed("Could not isolate Mac Soniox realtime authorization")
+        }
+        let sonioxSource = String(appState[sonioxStart.lowerBound..<aidictationStart.lowerBound])
+        precondition(sonioxSource.contains("WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey"))
+        precondition(sonioxSource.contains("fallbackAPIKey: snapshot.transcriptionAPIKey"))
+        precondition(!sonioxSource.contains("AuthManager.shared.accessToken()"))
+
+        let sonioxClient = try contents(
+            "Whishpermate/Whispermate/Services/SonioxRealtimeTranscriptionClient.swift"
+        )
+        precondition(sonioxClient.contains("authorizationFailureMessage(for:"))
+        precondition(sonioxClient.contains("clientSecretRequestFailed"))
+    }
+
+    private static func usableClientSecretAPIKey(_ key: String?) -> String? {
+        guard let key else { return nil }
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "not-needed" else {
+            return nil
+        }
+        return trimmed
     }
 
     private static func endpoint(from transcriptionEndpoint: String) -> String? {

--- a/scripts/validate_macos_transcription_attempt_snapshot.swift
+++ b/scripts/validate_macos_transcription_attempt_snapshot.swift
@@ -244,6 +244,13 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
                 "Realtime attempt still reads mutable state: \(forbidden)"
             )
         }
+        precondition(
+            realtimeSource.contains("WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey")
+        )
+        precondition(
+            realtimeSource.contains("fallbackAPIKey: snapshot.transcriptionAPIKey")
+        )
+        precondition(!realtimeSource.contains("AuthManager.shared.accessToken()"))
         precondition(source.contains("if let realtimeResult"))
         precondition(!source.contains("usingBatchFallback"))
         precondition(!source.contains("groq/whisper-large-v3-turbo"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Soniox realtime must work without a user login. Writingmate will mint `client_secrets` using the AI Dictation app special API key; this client change sends that key on the mint path when there is no user access token.

## Problem

Mac `AppState` Soniox `authorizationProvider` and the iOS Writingmate realtime coordinator called only `AuthManager.accessToken()`. Logged-out sessions threw or skipped the stream, so realtime stayed empty and History showed **Realtime transcription did not complete.**

Unsigned batch cloud calls already use the bundled `CustomTranscriptionKey` from `SecretsLoader` (and an optional Keychain override). Realtime mint did not.

## Change

- Shared `WritingmateRealtimeSessionSupport.resolveClientSecretAPIKey`:
  1. signed-in user access token
  2. caller fallback (snapshot / request API key)
  3. Keychain custom transcription key
  4. bundled `SecretsLoader.transcriptionKey(for: .custom)` (`CustomTranscriptionKey`)
  5. clear error only if all of the above are missing (`Cloud transcription credentials are unavailable`)
- Mac Soniox and Writingmate `client_secrets` mint paths use that resolver
- iOS no longer skips realtime when the user is signed out
- Soniox client surfaces the credentials error instead of a generic start failure
- Validation scripts cover the fallback contract and Mac/iOS wiring

Backend must accept the app key on `/api/openai/v1/realtime/client_secrets` (separate PR on writingmate/chat). This PR does not invent a new anonymous auth scheme.

## Testing

- `scripts/validate_ios_realtime_transcription.swift`
- `scripts/validate_macos_transcription_attempt_snapshot.swift`
- `scripts/validate_macos_realtime_finalization.swift`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5858829-c1a6-4520-b019-5f6e78dc9d0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5858829-c1a6-4520-b019-5f6e78dc9d0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791138162&installation_model_id=432087&pr_number=122&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F122&signature=45279872305b035c55f7cf38e5db26f96c62e6368f1b050b931a3b255fcbc722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->