### PR TITLE
Preserve blank lines between bullets after Mac cleanup

### DIFF
--- a/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
+++ b/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
@@ -45,12 +45,15 @@ struct TranscriptionOutputFilter {
             withTemplate: ""
         )
         result = result.replacingOccurrences(
-            of: #"\s+([,.;:!?])"#,
+            of: #"[ \t]+([,.;:!?])"#,
             with: "$1",
             options: .regularExpression
         )
+        // Collapse runs of spaces/tabs left by filler deletion. Do not use \s:
+        // Foundation \s includes newlines, which would turn blank lines between
+        // bullets and blocks into a single space after LLM cleanup.
         result = result.replacingOccurrences(
-            of: #"\s{2,}"#,
+            of: #"[ \t]{2,}"#,
             with: " ",
             options: .regularExpression
         )

--- a/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
+++ b/Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift
@@ -49,11 +49,13 @@ struct TranscriptionOutputFilter {
             with: "$1",
             options: .regularExpression
         )
-        // Collapse runs of spaces/tabs left by filler deletion. Do not use \s:
-        // Foundation \s includes newlines, which would turn blank lines between
-        // bullets and blocks into a single space after LLM cleanup.
+        // Collapse runs of spaces/tabs left by filler deletion, but only inside a
+        // line. Do not use \s: Foundation \s includes newlines, which would turn
+        // blank lines between bullets and blocks into a single space after LLM
+        // cleanup. Runs at line start are indentation (nested bullets, code) and
+        // must survive too.
         result = result.replacingOccurrences(
-            of: #"[ \t]{2,}"#,
+            of: #"(?<=\S)[ \t]{2,}"#,
             with: " ",
             options: .regularExpression
         )

--- a/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
+++ b/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
@@ -63,8 +63,35 @@ final class TranscriptionOutputFilterTests: XCTestCase {
         XCTAssertEqual(removeFillers("hello\t\tworld"), "hello world")
         XCTAssertEqual(
             removeFillers("hello  \n\n  world"),
-            "hello \n\n world"
+            "hello \n\n  world"
         )
+    }
+
+    func testFillerRemovalPreservesNestedBulletIndentation() {
+        let dictated = """
+        - Parent item
+          - Nested um child
+            - Deeper child
+        """
+        let expected = """
+        - Parent item
+          - Nested child
+            - Deeper child
+        """
+        XCTAssertEqual(removeFillers(dictated), expected)
+        XCTAssertEqual(liveCleanupOutput(dictated), expected)
+    }
+
+    func testFillerRemovalPreservesIndentedBlocks() {
+        let dictated = """
+        1. First step
+
+            indented block line
+
+        2. Second step
+        """
+        XCTAssertEqual(removeFillers(dictated), dictated)
+        XCTAssertEqual(liveCleanupOutput(dictated), dictated)
     }
 
     func testFillerRemovalKeepsBlankLinesAfterDeletingFillers() {

--- a/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
+++ b/Whishpermate/WhispermateTests/TranscriptionOutputFilterTests.swift
@@ -8,6 +8,14 @@ final class TranscriptionOutputFilterTests: XCTestCase {
         TranscriptionOutputFilter.removeStandaloneFillers(s)
     }
 
+    /// Mirrors `AppState.cleanupWithRawFallback` after a successful LLM pass:
+    /// trim, then `transcriptWithoutStandaloneFillers`.
+    private func liveCleanupOutput(_ s: String) -> String {
+        let cleaned = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = TranscriptionOutputFilter.removeStandaloneFillers(cleaned)
+        return filtered.isEmpty ? cleaned : filtered
+    }
+
     func testRemovesStandaloneFillerVocalizations() {
         XCTAssertEqual(
             removeFillers("Um, this is uh a test. Ugh! It works erm now."),
@@ -21,6 +29,57 @@ final class TranscriptionOutputFilterTests: XCTestCase {
             removeFillers("The U-Haul reached Birmingham and Ahmet said ahoy."),
             "The U-Haul reached Birmingham and Ahmet said ahoy."
         )
+    }
+
+    func testFillerRemovalPreservesBlankLinesBetweenBullets() {
+        let dictated = """
+        - First item
+
+        - Second item
+
+        - Third item
+        """
+        XCTAssertEqual(removeFillers(dictated), dictated)
+        XCTAssertEqual(
+            liveCleanupOutput(dictated),
+            dictated
+        )
+    }
+
+    func testFillerRemovalPreservesBlankLinesBetweenBlocks() {
+        let dictated = """
+        First paragraph.
+
+        Second paragraph.
+
+        Third paragraph.
+        """
+        XCTAssertEqual(removeFillers(dictated), dictated)
+        XCTAssertEqual(liveCleanupOutput(dictated), dictated)
+    }
+
+    func testFillerRemovalCollapsesHorizontalWhitespaceWithoutTouchingNewlines() {
+        XCTAssertEqual(removeFillers("hello    world"), "hello world")
+        XCTAssertEqual(removeFillers("hello\t\tworld"), "hello world")
+        XCTAssertEqual(
+            removeFillers("hello  \n\n  world"),
+            "hello \n\n world"
+        )
+    }
+
+    func testFillerRemovalKeepsBlankLinesAfterDeletingFillers() {
+        let dictated = """
+        - First um item
+
+        - Second uh item
+        """
+        let expected = """
+        - First item
+
+        - Second item
+        """
+        XCTAssertEqual(removeFillers(dictated), expected)
+        XCTAssertEqual(liveCleanupOutput(dictated), expected)
     }
 
     // MARK: - Hallucination artifacts it exists to remove
@@ -37,6 +96,8 @@ final class TranscriptionOutputFilterTests: XCTestCase {
     }
 
     func testCollapsesWhitespaceAndTrims() {
+        // `.filter` is not the production post-cleanup path. It still collapses
+        // every run of Foundation \s, including newlines.
         XCTAssertEqual(filter("  hello    world  "), "hello world")
         XCTAssertEqual(filter("hello\n\n\nworld"), "hello world")
     }

--- a/scripts/validate_macos_transcription_attempt_snapshot.swift
+++ b/scripts/validate_macos_transcription_attempt_snapshot.swift
@@ -298,6 +298,45 @@ struct ValidateMacOSTranscriptionAttemptSnapshot {
             cleanupSource.contains("rules: promptComponents"),
             "Two-stage cleanup lost personal vocabulary, phrases, replacements, or rules"
         )
+        guard let liveOutputStart = source.range(of: "    private func cleanupWithRawFallback("),
+              let liveOutputEnd = source.range(
+                of: "    private func applyLLMPass(",
+                range: liveOutputStart.upperBound..<source.endIndex
+              )
+        else {
+            preconditionFailure("Could not isolate live cleanup output path")
+        }
+        let liveOutputSource = String(source[liveOutputStart.lowerBound..<liveOutputEnd.lowerBound])
+        precondition(
+            liveOutputSource.contains("return transcriptWithoutStandaloneFillers(cleaned)"),
+            "Successful LLM cleanup no longer runs the live filler output filter"
+        )
+        precondition(
+            liveOutputSource.contains("return transcriptWithoutStandaloneFillers(rawText)"),
+            "Cleanup fallback no longer runs the live filler output filter"
+        )
+        precondition(
+            liveOutputSource.contains("TranscriptionOutputFilter.removeStandaloneFillers(text)"),
+            "Live cleanup output path lost removeStandaloneFillers"
+        )
+        precondition(
+            !liveOutputSource.contains("TranscriptionOutputFilter.filter"),
+            "Live cleanup output still passes through destructive .filter whitespace collapsing"
+        )
+        let filterPath = "Whishpermate/Whispermate/Services/TranscriptionOutputFilter.swift"
+        let filterSource = try String(contentsOfFile: filterPath, encoding: .utf8)
+        guard let fillerStart = filterSource.range(of: "static func removeStandaloneFillers(") else {
+            preconditionFailure("Could not isolate removeStandaloneFillers")
+        }
+        let fillerSource = String(filterSource[fillerStart.lowerBound...])
+        precondition(
+            !fillerSource.contains(#"\s{2,}"#),
+            "removeStandaloneFillers still collapses Foundation \\s, including newlines between bullets"
+        )
+        precondition(
+            fillerSource.contains(#"[ \t]{2,}"#),
+            "removeStandaloneFillers no longer collapses leftover spaces and tabs after filler deletion"
+        )
         let cleanupFailureChecks = source.components(
             separatedBy: "managedCleanupFailed = !cleanup.completed"
         ).count - 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Customer impact

Walter Mazzola (Mac AI Dictation 0.0.120+) reports that custom formatting is still broken: **blank lines between bullets and block paragraphs disappear after dictation/cleanup**. LLM cleanup can emit the requested layout, then Mac post-processing collapses it before paste.

This is independent of #126, which only added a sentence-type rule to the shared cleanup prompt. Prompt rules are unchanged here.

## Root cause

After LLM cleanup, Mac always runs:

`AppState.cleanupWithRawFallback` → `transcriptWithoutStandaloneFillers` → `TranscriptionOutputFilter.removeStandaloneFillers`

That last step used `replacingOccurrences` of `#"\s{2,}"#` with a single space. Foundation `\s` includes newlines, so `\n\n` became a space and blank lines between bullets died. The same run also flattened leading indentation on nested bullets and indented blocks.

`TranscriptionOutputFilter.filter` still has the same `\s{2,}` collapse (`testCollapsesWhitespaceAndTrims`), but `.filter` is **not** the production post-cleanup path. The live path is `removeStandaloneFillers`.

## What changed

- `removeStandaloneFillers` now collapses runs of spaces and tabs only when they follow a non-whitespace character (`(?<=\S)[ \t]{2,}`). Leftover filler gaps inside a line still flatten; newlines between bullets/blocks and leading indentation on nested bullets survive.
- The punctuation-hug replacement next to that step was tightened the same way (`[ \t]+` instead of `\s+`) so it cannot eat a blank line before `,.;:!?`.
- Regression tests cover blank lines between bullets and blocks, nested bullet indentation, indented blocks, and filler deletion inside bullets, both through `removeStandaloneFillers` and a helper that mirrors the live `cleanupWithRawFallback` output path.
- The macOS attempt-snapshot validator now locks that live path to `removeStandaloneFillers` (not `.filter`) and rejects a regression to `\s{2,}`.

Cleanup prompt rules are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98eb7d36-1896-4638-a040-f5edd82796a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98eb7d36-1896-4638-a040-f5edd82796a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/writingmate/codesmith/aidictation/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791475163&installation_model_id=432087&pr_number=127&repository=writingmate%2Faidictation&return_to=https%3A%2F%2Fgithub.com%2Fwritingmate%2Faidictation%2Fpull%2F127&signature=669faa13fb21a58fbd5719d6b16079b94d9bd6d1b482235b02f6e7a60400f7f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->